### PR TITLE
fix: replace deprecated pytz and utcfromtimestamp with stdlib equivalents

### DIFF
--- a/custom_components/mikrotik_router/apiparser.py
+++ b/custom_components/mikrotik_router/apiparser.py
@@ -1,9 +1,8 @@
 """API parser for JSON APIs."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import getLogger
 
-from pytz import utc
 from voluptuous import Optional
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -18,7 +17,7 @@ _LOGGER = getLogger(__name__)
 # ---------------------------
 def utc_from_timestamp(timestamp: float) -> datetime:
     """Return a UTC time from a timestamp."""
-    return utc.localize(datetime.utcfromtimestamp(timestamp))
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc)
 
 
 # ---------------------------

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -6,9 +6,7 @@ import asyncio
 import ipaddress
 import logging
 import re
-import pytz
-
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
 from ipaddress import ip_address, IPv4Network
 from mac_vendor_lookup import AsyncMacLookup
@@ -85,7 +83,7 @@ def is_valid_ip(address):
 
 def utc_from_timestamp(timestamp: float) -> datetime:
     """Return a UTC time from a timestamp."""
-    return pytz.utc.localize(datetime.utcfromtimestamp(timestamp))
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc)
 
 
 def as_local(dattim: datetime) -> datetime:
@@ -93,7 +91,7 @@ def as_local(dattim: datetime) -> datetime:
     if dattim.tzinfo == DEFAULT_TIME_ZONE:
         return dattim
     if dattim.tzinfo is None:
-        dattim = pytz.utc.localize(dattim)
+        dattim = dattim.replace(tzinfo=timezone.utc)
 
     return dattim.astimezone(DEFAULT_TIME_ZONE)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -647,15 +647,18 @@ def test_utc_from_timestamp_apiparser_matches_coordinator():
     assert apiparser_utc_from_timestamp(ts) == utc_from_timestamp(ts)
 
 
-def test_as_local_attaches_utc_to_naive_datetime():
-    """as_local attaches UTC tzinfo when datetime has no tzinfo."""
+def test_as_local_returns_naive_datetime_unchanged_when_no_tz_configured():
+    """as_local returns naive datetime unchanged when DEFAULT_TIME_ZONE is None."""
     naive = datetime(2024, 1, 15, 12, 0, 0)
     result = as_local(naive)
-    assert result.tzinfo is not None
+    assert result == naive
 
 
-def test_as_local_leaves_aware_datetime_unchanged_tzinfo():
-    """as_local does not strip tzinfo from an already-aware datetime."""
-    aware = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
-    result = as_local(aware)
+def test_as_local_attaches_utc_to_naive_datetime_when_tz_configured(monkeypatch):
+    """as_local attaches UTC tzinfo to naive datetime when DEFAULT_TIME_ZONE is set."""
+    import custom_components.mikrotik_router.coordinator as coord_module
+
+    monkeypatch.setattr(coord_module, "DEFAULT_TIME_ZONE", timezone.utc)
+    naive = datetime(2024, 1, 15, 12, 0, 0)
+    result = as_local(naive)
     assert result.tzinfo is not None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,11 +1,19 @@
 """Unit tests for Mikrotik Router coordinator and apiparser logic."""
 
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.mikrotik_router.apiparser import parse_api
-from custom_components.mikrotik_router.coordinator import MikrotikCoordinator
+from custom_components.mikrotik_router.apiparser import (
+    parse_api,
+    utc_from_timestamp as apiparser_utc_from_timestamp,
+)
+from custom_components.mikrotik_router.coordinator import (
+    MikrotikCoordinator,
+    as_local,
+    utc_from_timestamp,
+)
 from custom_components.mikrotik_router.const import (
     CONF_SENSOR_POE,
     CONF_SENSOR_PORT_TRAFFIC,
@@ -619,3 +627,35 @@ async def test_mac_lookup_cancelled_error_propagates():
 
     with pytest.raises(asyncio.CancelledError):
         await coordinator.async_process_host()
+
+
+# ---------------------------------------------------------------------------
+# utc_from_timestamp and as_local tests
+# ---------------------------------------------------------------------------
+
+
+def test_utc_from_timestamp_returns_utc_aware_datetime():
+    """utc_from_timestamp produces a UTC-aware datetime from a Unix timestamp."""
+    result = utc_from_timestamp(0)
+    assert result == datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    assert result.tzinfo is timezone.utc
+
+
+def test_utc_from_timestamp_apiparser_matches_coordinator():
+    """Both apiparser and coordinator produce identical results."""
+    ts = 1_700_000_000.0
+    assert apiparser_utc_from_timestamp(ts) == utc_from_timestamp(ts)
+
+
+def test_as_local_attaches_utc_to_naive_datetime():
+    """as_local attaches UTC tzinfo when datetime has no tzinfo."""
+    naive = datetime(2024, 1, 15, 12, 0, 0)
+    result = as_local(naive)
+    assert result.tzinfo is not None
+
+
+def test_as_local_leaves_aware_datetime_unchanged_tzinfo():
+    """as_local does not strip tzinfo from an already-aware datetime."""
+    aware = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+    result = as_local(aware)
+    assert result.tzinfo is not None


### PR DESCRIPTION
## Summary
- Replace `pytz` with stdlib `datetime.timezone.utc` in `apiparser.py` and `coordinator.py` — pytz is deprecated in Python 3.9+
- Replace `datetime.utcfromtimestamp()` with `datetime.fromtimestamp(ts, tz=timezone.utc)` — deprecated in Python 3.12+
- Remove pytz import from both files entirely

## SonarCloud
Fixes reliability impact issues S6890 and S6903. The 3 remaining reliability issues (`async` functions without `await` in `__init__.py` and `diagnostics.py`) are HA framework entry points marked Won't Fix.

## Test Plan
- [ ] CI tests pass
- [ ] SonarCloud reliability issues resolved