### PR TITLE
chore: bump version to 2.3.6

### DIFF
--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.4"
+    "version": "2.3.6"
 }


### PR DESCRIPTION
## Summary
- Bump manifest.json version to 2.3.6 for release

🤖 Generated with [Claude Code](https://claude.com/claude-code)