### PR TITLE
fix: move ARP failed-status filtering to async_process_host (#17)

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1883,15 +1883,6 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             ensure_vals=[{"name": "bridge", "default": ""}],
         )
 
-        # Remove ARP entries with failed status — device is not reachable
-        to_remove = [
-            uid
-            for uid, vals in self.ds["arp"].items()
-            if vals.get("status") == "failed"
-        ]
-        for uid in to_remove:
-            self.ds["arp"].pop(uid)
-
         for uid, vals in self.ds["arp"].items():
             if vals["interface"] in self.ds["bridge"] and uid in self.ds["bridge_host"]:
                 self.ds["arp"][uid]["bridge"] = vals["interface"]
@@ -2207,9 +2198,14 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 self.ds["host"][uid][key] = vals[key]
 
         # Add hosts from ARP
+        # Only count non-failed ARP entries as detected — failed entries
+        # indicate the device is unreachable (#17).  We keep failed entries
+        # in ds["arp"] so that bridge-interface lookups still work for the
+        # tracker coordinator's ping logic.
         arp_detected = {}
         for uid, vals in self.ds["arp"].items():
-            arp_detected[uid] = True
+            if vals.get("status") != "failed":
+                arp_detected[uid] = True
             if uid not in self.ds["host"]:
                 self.ds["host"][uid] = {"source": "arp"}
             elif self.ds["host"][uid]["source"] != "arp":

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -577,6 +577,107 @@ async def test_wireless_host_not_counted_as_wired():
     assert coordinator.ds["resource"]["clients_wireless"] == 1
 
 
+@pytest.mark.asyncio
+async def test_arp_failed_status_not_detected_but_host_created():
+    """ARP entry with status 'failed' is NOT counted in arp_detected (#17).
+
+    The host entry IS still created (so it appears in the UI as 'away'),
+    but it is not marked available.  The failed entry stays in ds['arp']
+    so the tracker coordinator can still look up bridge interfaces.
+    """
+    mac = "AA:BB:CC:DD:EE:F1"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac: {
+                "mac-address": mac,
+                "address": "192.168.1.50",
+                "interface": "ether1",
+                "status": "failed",
+                "bridge": "bridge",
+            }
+        }
+    )
+
+    await coordinator.async_process_host()
+
+    # Host entry created (visible in UI) but marked unavailable
+    assert mac in coordinator.ds["host"]
+    assert coordinator.ds["host"][mac]["available"] is False
+
+    # Failed entry kept in ds["arp"] for bridge lookups
+    assert mac in coordinator.ds["arp"]
+    assert coordinator.ds["arp"][mac]["bridge"] == "bridge"
+
+
+@pytest.mark.asyncio
+async def test_arp_reachable_status_detected():
+    """ARP entry with non-failed status is counted as detected and available."""
+    mac = "AA:BB:CC:DD:EE:F2"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac: {
+                "mac-address": mac,
+                "address": "192.168.1.51",
+                "interface": "ether1",
+                "status": "reachable",
+            }
+        }
+    )
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["host"][mac]["available"] is True
+    assert coordinator.ds["host"][mac]["last-seen"] is not False
+
+
+@pytest.mark.asyncio
+async def test_arp_empty_status_detected():
+    """ARP entry with empty/missing status (static entry) is detected and available."""
+    mac = "AA:BB:CC:DD:EE:F3"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac: {
+                "mac-address": mac,
+                "address": "192.168.1.52",
+                "interface": "ether1",
+                "status": "",
+            }
+        }
+    )
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["host"][mac]["available"] is True
+
+
+@pytest.mark.asyncio
+async def test_mixed_arp_statuses_only_failed_excluded():
+    """Only 'failed' ARP entries are excluded from detection; others are detected."""
+    mac_ok = "AA:BB:CC:DD:EE:A1"
+    mac_failed = "AA:BB:CC:DD:EE:A2"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac_ok: {
+                "mac-address": mac_ok,
+                "address": "192.168.1.60",
+                "interface": "ether1",
+                "status": "stale",
+            },
+            mac_failed: {
+                "mac-address": mac_failed,
+                "address": "192.168.1.61",
+                "interface": "ether1",
+                "status": "failed",
+            },
+        }
+    )
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["host"][mac_ok]["available"] is True
+    assert coordinator.ds["host"][mac_failed]["available"] is False
+
+
 # ---------------------------------------------------------------------------
 # Group E: bug-fix regression tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The original fix removed failed ARP entries in get_arp(), which also
removed bridge-interface data needed by the tracker coordinator for
ping lookups.  Without correct bridge info, pings were sent on the
wrong interface and failed, leaving all wired devices marked "away".

Move the filtering to async_process_host() where arp_detected is
built: failed entries are excluded from detection (so they don't
falsely appear "home") but remain in ds["arp"] so the tracker can
still resolve bridge interfaces for its ping logic.

Fixes #17

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01XKKiBxRSBc9aEkZmpxk3ij