### PR TITLE
fix: move ARP failed-status filtering to async_process_host (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,30 +15,43 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
-## What's New — v2.3.5
+## What's New — v2.3.6
 
-The [v2.3.5](https://github.com/jnctech/homeassistant-mikrotik_router/releases/tag/v2.3.5) release is a Python compatibility patch.
+The [v2.3.6](https://github.com/jnctech/homeassistant-mikrotik_router/releases/tag/v2.3.6) release fixes critical bugs and aligns with HA best practices.
 
-### Bug fixes in v2.3.5
+### Critical fixes in v2.3.6
+
+| Fix | Detail |
+|-----|--------|
+| **Options flow crash on HA 2025.12+** | Config panel now works on modern HA versions ([upstream #470](https://github.com/tomaae/homeassistant-mikrotik_router/issues/470), [#471](https://github.com/tomaae/homeassistant-mikrotik_router/issues/471)) |
+| **Deadlock in `run_script()`** | Lock was never released when script not found — permanently froze the integration |
+| **Blocking I/O on event loop** | Switch toggles, button presses, firmware updates no longer freeze the HA UI |
+| **False "home" device tracking** | ARP entries with `status: failed` no longer cause devices to show as home ([#17](https://github.com/jnctech/homeassistant-mikrotik_router/issues/17)) |
+| **New devices not appearing** | Dispatcher signal re-enabled so new network devices register as HA entities without restart |
+| **Deprecated `DeviceInfo` params** | Updated to current HA API (`name`, `manufacturer`, `model`) |
+
+### Previous releases
+
+<details>
+<summary>v2.3.5 — Python compatibility</summary>
 
 | Fix | Detail |
 |-----|--------|
 | **Python 3.12 compatibility** | Replaced deprecated `datetime.utcfromtimestamp()` with `datetime.fromtimestamp(ts, tz=UTC)` |
 | **Removed `pytz` dependency** | Replaced with stdlib `datetime.timezone.utc` — no behavioural change |
 
----
+</details>
 
-## v2.3.4 — Reliability Patch
-
-The [v2.3.4](https://github.com/jnctech/homeassistant-mikrotik_router/releases/tag/v2.3.4) release is a reliability patch.
-
-### Bug fixes in v2.3.4
+<details>
+<summary>v2.3.4 — Reliability patch</summary>
 
 | Fix | Detail |
 |-----|--------|
 | **Crash on empty accounting query** | No longer crashes when `/ip/accounting` returns no data |
 | **Firmware version parse** | Handles RouterOS versions without a minor segment |
 | **Host manufacturer lookup** | Exception during MAC OUI lookup no longer propagates |
+
+</details>
 
 ---
 

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1883,15 +1883,6 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             ensure_vals=[{"name": "bridge", "default": ""}],
         )
 
-        # Remove ARP entries with failed status — device is not reachable
-        to_remove = [
-            uid
-            for uid, vals in self.ds["arp"].items()
-            if vals.get("status") == "failed"
-        ]
-        for uid in to_remove:
-            self.ds["arp"].pop(uid)
-
         for uid, vals in self.ds["arp"].items():
             if vals["interface"] in self.ds["bridge"] and uid in self.ds["bridge_host"]:
                 self.ds["arp"][uid]["bridge"] = vals["interface"]
@@ -2207,9 +2198,14 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 self.ds["host"][uid][key] = vals[key]
 
         # Add hosts from ARP
+        # Only count non-failed ARP entries as detected — failed entries
+        # indicate the device is unreachable (#17).  We keep failed entries
+        # in ds["arp"] so that bridge-interface lookups still work for the
+        # tracker coordinator's ping logic.
         arp_detected = {}
         for uid, vals in self.ds["arp"].items():
-            arp_detected[uid] = True
+            if vals.get("status") != "failed":
+                arp_detected[uid] = True
             if uid not in self.ds["host"]:
                 self.ds["host"][uid] = {"source": "arp"}
             elif self.ds["host"][uid]["source"] != "arp":

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -577,6 +577,107 @@ async def test_wireless_host_not_counted_as_wired():
     assert coordinator.ds["resource"]["clients_wireless"] == 1
 
 
+@pytest.mark.asyncio
+async def test_arp_failed_status_not_detected_but_host_created():
+    """ARP entry with status 'failed' is NOT counted in arp_detected (#17).
+
+    The host entry IS still created (so it appears in the UI as 'away'),
+    but it is not marked available.  The failed entry stays in ds['arp']
+    so the tracker coordinator can still look up bridge interfaces.
+    """
+    mac = "AA:BB:CC:DD:EE:F1"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac: {
+                "mac-address": mac,
+                "address": "192.168.1.50",
+                "interface": "ether1",
+                "status": "failed",
+                "bridge": "bridge",
+            }
+        }
+    )
+
+    await coordinator.async_process_host()
+
+    # Host entry created (visible in UI) but marked unavailable
+    assert mac in coordinator.ds["host"]
+    assert coordinator.ds["host"][mac]["available"] is False
+
+    # Failed entry kept in ds["arp"] for bridge lookups
+    assert mac in coordinator.ds["arp"]
+    assert coordinator.ds["arp"][mac]["bridge"] == "bridge"
+
+
+@pytest.mark.asyncio
+async def test_arp_reachable_status_detected():
+    """ARP entry with non-failed status is counted as detected and available."""
+    mac = "AA:BB:CC:DD:EE:F2"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac: {
+                "mac-address": mac,
+                "address": "192.168.1.51",
+                "interface": "ether1",
+                "status": "reachable",
+            }
+        }
+    )
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["host"][mac]["available"] is True
+    assert coordinator.ds["host"][mac]["last-seen"] is not False
+
+
+@pytest.mark.asyncio
+async def test_arp_empty_status_detected():
+    """ARP entry with empty/missing status (static entry) is detected and available."""
+    mac = "AA:BB:CC:DD:EE:F3"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac: {
+                "mac-address": mac,
+                "address": "192.168.1.52",
+                "interface": "ether1",
+                "status": "",
+            }
+        }
+    )
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["host"][mac]["available"] is True
+
+
+@pytest.mark.asyncio
+async def test_mixed_arp_statuses_only_failed_excluded():
+    """Only 'failed' ARP entries are excluded from detection; others are detected."""
+    mac_ok = "AA:BB:CC:DD:EE:A1"
+    mac_failed = "AA:BB:CC:DD:EE:A2"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac_ok: {
+                "mac-address": mac_ok,
+                "address": "192.168.1.60",
+                "interface": "ether1",
+                "status": "stale",
+            },
+            mac_failed: {
+                "mac-address": mac_failed,
+                "address": "192.168.1.61",
+                "interface": "ether1",
+                "status": "failed",
+            },
+        }
+    )
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["host"][mac_ok]["available"] is True
+    assert coordinator.ds["host"][mac_failed]["available"] is False
+
+
 # ---------------------------------------------------------------------------
 # Group E: bug-fix regression tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The v2.3.6 fix removed failed ARP entries in `get_arp()`, which also removed bridge-interface data needed by the tracker coordinator for ping lookups
- Without correct bridge info, pings were sent on the wrong interface and failed, leaving all wired devices marked "away"
- Moves the filtering to `async_process_host()` where `arp_detected` is built: failed entries are excluded from detection (so they don't falsely appear "home") but remain in `ds["arp"]` so the tracker can still resolve bridge interfaces

## Test Plan
- [x] 4 new regression tests covering failed, reachable, empty, and mixed ARP statuses
- [ ] CI passes
- [ ] Deploy to HA and verify wired devices show correct home/away status

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)