### PR TITLE
fix: disable update_sensors dispatcher to stop duplicate entity errors

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -689,7 +689,11 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         if not self.api.connected():
             raise UpdateFailed("Mikrotik Disconnected")
 
-        async_dispatcher_send(self.hass, "update_sensors", self)
+        # Disabled: causes duplicate entity registration errors on every update cycle.
+        # _check_entity_exists() does not properly guard against re-adding existing
+        # entities. New device discovery will be addressed in a future release with
+        # a proper guard that only fires when new UIDs appear in ds.
+        # async_dispatcher_send(self.hass, "update_sensors", self)
         return self.ds
 
     # ---------------------------

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.7"
+    "version": "2.3.8"
 }


### PR DESCRIPTION
## Summary
- The `update_sensors` dispatcher re-enabled in v2.3.6 fires `_run_entity_setup_loop` every 30s
- `_check_entity_exists()` does not properly guard against re-adding existing entities
- Causes thousands of "does not generate unique IDs" errors in the HA log
- **Impact:** Log spam only — entities function correctly
- **Fix:** Disable dispatcher until a proper new-UID-only guard is implemented
- Bumps version to v2.3.8

## Remediation for users on v2.3.6 or v2.3.7
1. Update to v2.3.8 via HACS
2. Restart Home Assistant
3. Log errors will stop immediately

## Test Plan
- [ ] CI passes
- [ ] Deploy to HA — verify no more "unique IDs" errors in log
- [ ] Existing entities continue to update normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)