### PR TITLE
test: Phase 4 entity-level integration tests (80 new, 441 total)

### DIFF
--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,42 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260321-phase4-integration-tests — Entity-level integration tests for all platform types
+
+**Date:** 2026-03-21
+**Branch:** `feature/phase4-integration-tests`
+**PR:** #31 (targeting dev)
+**Status:** In Review
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `tests/conftest.py` | Added `make_mock_coordinator()`, `make_mock_entity_description()`, `patch_coordinator_entity_init()` shared helpers |
+| `tests/test_init.py` | New: 4 tests for `async_migrate_entry` (v1→v2, noop, data preservation) and `async_remove_config_entry_device` |
+| `tests/test_entity.py` | Extended: 15 new tests for `MikrotikEntity` class (init, custom_name, unique_id, device_info, extra_state_attributes, `_handle_coordinator_update`) |
+| `tests/test_sensor.py` | New: 7 tests for `MikrotikSensor` (native_value, native_unit_of_measurement, ClientTrafficSensor.custom_name) |
+| `tests/test_binary_sensor.py` | New: 10 tests for binary sensor is_on, icon branches, PPP disabled guard, PortBinarySensor 3-state icon |
+| `tests/test_switch.py` | New: 19 tests for 5 switch classes — turn_on/off, write access guard, CAPsMAN guard, PoE side-effects, NAT/Queue UID lookup, Kidcontrol resume/pause |
+| `tests/test_button.py` | New: 3 tests for Button no-op, ScriptButton run_script, ApiEntryNotFound handling |
+| `tests/test_device_tracker.py` | New: 12 tests for is_connected (tracking disabled, wireless, capsman, ARP timeout), state, extra_state_attributes |
+| `tests/test_update.py` | Extended: 8 new tests for RouterOS/RouterBOARD install (with/without backup), version properties |
+| `docs/ISSUES.md` | Updated ISS-260320-test-coverage with Phase 4 completion |
+
+### Why
+
+ISS-260320-test-coverage Phase 4: entity-level tests cover all 6 platform entity types and the MikrotikEntity base class. Previous phases covered helpers and coordinator data methods but the actual entity behaviour (properties, actions, state) was untested. 80 new tests bring total to 441.
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint | 0 errors | ✅ |
+| Ruff format | 0 reformats needed | ✅ |
+| Tests | 441 passed, 5 skipped | ✅ |
+
+---
+
 ## CR-260321-complexity-reduction — Cognitive complexity reduction across coordinator, entity, apiparser
 
 **Date:** 2026-03-21

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -14,22 +14,22 @@
 **Type:** Testing
 **Priority:** High
 **Created:** 2026-03-20
-**Status:** 🟡 Backlog — Phase 1-3 done (PR #29 merged), Phase 4 pending
+**Status:** 🟡 Backlog — Phase 1-4 done, Phase 5 (full HA integration tests) pending
 
 **Done:**
 - ✅ Phase 1: `helper.py` (13 tests), `apiparser.py` (52 tests), `mikrotikapi.py` (30 tests), `coordinator.py` basics (12 tests) — PR #29
 - ✅ Phase 2: coordinator data methods — get_system_resource, get_firmware_update, get_nat/mangle/filter, get_interface, get_dhcp, get_access (38 tests) — PR #29
 - ✅ Phase 3: entity helpers — _skip_sensor, copy_attrs, MikrotikInterfaceEntityMixin (10 new tests), update.py pure functions (8 tests) — PR #29
 - ✅ Phase 3.5: coordinator extracted helpers — 58 new tests for host merging, hostname resolution, accounting classification, captive portal, etc. — PR #30
+- ✅ Phase 4: entity-level integration tests — 80 new tests covering all 6 platform entity types (sensor, binary_sensor, switch, button, device_tracker, update), MikrotikEntity base class, and init lifecycle — PR #31
 - ✅ Devcontainer setup for local testing with pytest-homeassistant-custom-component — PR #29
 - ✅ Ruff migration: all 32 source files pass lint and format — PR #29
 
-**Remaining (Phase 4 — separate PR):**
-- Integration lifecycle tests (async_setup_entry, async_migrate_entry) — needs devcontainer
-- Platform entity integration tests (async_turn_on, is_connected, native_value) — needs devcontainer
+**Remaining (Phase 5 — future PR):**
+- Full HA integration tests: async_setup_entry, async_unload_entry (requires full HA platform machinery)
 - Full coverage measurement and gap analysis
 
-**Reference:** 361 tests passing (303 from PR #29, 58 from PR #30), target ≥80% for SonarCloud Grade A
+**Reference:** 441 tests passing (303 PR #29, 58 PR #30, 80 PR #31), target ≥80% for SonarCloud Grade A
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,110 @@
 """Fixtures for Mikrotik Router tests."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
+
+from homeassistant.const import CONF_NAME, CONF_HOST
 
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable custom integrations in all tests."""
     yield
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for entity-level tests
+# ---------------------------------------------------------------------------
+
+
+def make_mock_entity_description(**overrides):
+    """Build a MagicMock entity description with all fields entity.py expects."""
+    desc = MagicMock()
+    defaults = {
+        "key": "test_key",
+        "name": "Test Sensor",
+        "func": "MikrotikSensor",
+        "ha_group": "System",
+        "ha_connection": None,
+        "ha_connection_value": None,
+        "data_path": "interface",
+        "data_attribute": "enabled",
+        "data_name": "name",
+        "data_name_comment": False,
+        "data_uid": "",
+        "data_reference": "name",
+        "data_attributes_list": [],
+        "data_switch_path": "/interface",
+        "data_switch_parameter": "disabled",
+        "icon_enabled": "mdi:check",
+        "icon_disabled": "mdi:close",
+        "native_unit_of_measurement": None,
+        "suggested_unit_of_measurement": None,
+        "title": "Test",
+    }
+    defaults.update(overrides)
+    for k, v in defaults.items():
+        setattr(desc, k, v)
+    return desc
+
+
+def make_mock_coordinator(data=None, options=None, name="TestRouter", host="10.0.0.1"):
+    """Build a lightweight coordinator mock for entity-level tests.
+
+    Unlike make_coordinator() in test_coordinator.py which uses object.__new__,
+    this returns a MagicMock so entities can be constructed without any real HA
+    coordinator machinery.
+    """
+    coord = MagicMock()
+    coord.data = data or {
+        "resource": {
+            "board-name": "hAP ax3",
+            "platform": "MikroTik",
+            "version": "7.16.2",
+        },
+        "routerboard": {
+            "serial-number": "HGR1234567",
+            "current-firmware": "7.16.2",
+            "upgrade-firmware": "7.16.2",
+        },
+        "interface": {},
+        "access": ["write", "policy", "reboot", "test"],
+        "host": {},
+        "fw-update": {
+            "installed-version": "7.16.2",
+            "latest-version": "7.16.2",
+            "available": False,
+        },
+    }
+    cfg = MagicMock()
+    cfg.data = {CONF_NAME: name, CONF_HOST: host}
+    cfg.options = options or {}
+    coord.config_entry = cfg
+    coord.set_value = MagicMock(return_value=True)
+    coord.execute = MagicMock()
+    coord.async_refresh = AsyncMock()
+    coord.api = MagicMock()
+    coord.api.run_script = MagicMock()
+    coord.option_zone = "home"
+    return coord
+
+
+def patch_coordinator_entity_init():
+    """Patch CoordinatorEntity.__init__ to only set self.coordinator.
+
+    The real __init__ registers with HA internals (event loops, listeners).
+    We only need the coordinator attribute for entity-level tests.
+    """
+    from unittest.mock import patch as _patch
+
+    def _init(self, coordinator, context=None):
+        self.coordinator = coordinator
+
+    return _patch(
+        "custom_components.mikrotik_router.entity.CoordinatorEntity.__init__",
+        _init,
+    )
 
 
 class MockMikrotikAPI:

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,207 @@
+"""Tests for Mikrotik Router binary sensor entities."""
+
+from custom_components.mikrotik_router.binary_sensor import (
+    MikrotikBinarySensor,
+    MikrotikPPPSecretBinarySensor,
+    MikrotikPortBinarySensor,
+)
+from custom_components.mikrotik_router.const import CONF_SENSOR_PPP
+
+from .conftest import (
+    make_mock_coordinator,
+    make_mock_entity_description,
+    patch_coordinator_entity_init,
+)
+
+
+def _make_binary_sensor(
+    cls=MikrotikBinarySensor, coordinator=None, desc_overrides=None, uid=None
+):
+    coord = coordinator or make_mock_coordinator()
+    desc = make_mock_entity_description(**(desc_overrides or {}))
+    with patch_coordinator_entity_init():
+        entity = cls(coord, desc, uid)
+    return entity
+
+
+# ---------------------------------------------------------------------------
+# MikrotikBinarySensor.is_on
+# ---------------------------------------------------------------------------
+
+
+class TestBinarySensorIsOn:
+    def test_is_on_true(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "running": True}}
+        entity = _make_binary_sensor(
+            coordinator=coord,
+            desc_overrides={"data_path": "interface", "data_attribute": "running"},
+            uid="ether1",
+        )
+        assert entity.is_on is True
+
+    def test_is_on_false(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "running": False}}
+        entity = _make_binary_sensor(
+            coordinator=coord,
+            desc_overrides={"data_path": "interface", "data_attribute": "running"},
+            uid="ether1",
+        )
+        assert entity.is_on is False
+
+
+# ---------------------------------------------------------------------------
+# MikrotikBinarySensor.icon
+# ---------------------------------------------------------------------------
+
+
+class TestBinarySensorIcon:
+    def test_icon_when_on(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "running": True}}
+        entity = _make_binary_sensor(
+            coordinator=coord,
+            desc_overrides={
+                "data_path": "interface",
+                "data_attribute": "running",
+                "icon_enabled": "mdi:lan-connect",
+                "icon_disabled": "mdi:lan-disconnect",
+            },
+            uid="ether1",
+        )
+        assert entity.icon == "mdi:lan-connect"
+
+    def test_icon_when_off(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "running": False}}
+        entity = _make_binary_sensor(
+            coordinator=coord,
+            desc_overrides={
+                "data_path": "interface",
+                "data_attribute": "running",
+                "icon_enabled": "mdi:lan-connect",
+                "icon_disabled": "mdi:lan-disconnect",
+            },
+            uid="ether1",
+        )
+        assert entity.icon == "mdi:lan-disconnect"
+
+    def test_icon_returns_none_when_no_icon_enabled(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "running": True}}
+        entity = _make_binary_sensor(
+            coordinator=coord,
+            desc_overrides={
+                "data_path": "interface",
+                "data_attribute": "running",
+                "icon_enabled": None,
+            },
+            uid="ether1",
+        )
+        assert entity.icon is None
+
+
+# ---------------------------------------------------------------------------
+# MikrotikPPPSecretBinarySensor.is_on
+# ---------------------------------------------------------------------------
+
+
+class TestPPPSecretBinarySensor:
+    def test_is_on_when_ppp_enabled(self):
+        coord = make_mock_coordinator(options={CONF_SENSOR_PPP: True})
+        coord.data["ppp_secret"] = {"user1": {"name": "user1", "connected": True}}
+        entity = _make_binary_sensor(
+            cls=MikrotikPPPSecretBinarySensor,
+            coordinator=coord,
+            desc_overrides={"data_path": "ppp_secret", "data_attribute": "connected"},
+            uid="user1",
+        )
+        assert entity.is_on is True
+
+    def test_is_on_false_when_ppp_disabled(self):
+        coord = make_mock_coordinator(options={CONF_SENSOR_PPP: False})
+        coord.data["ppp_secret"] = {"user1": {"name": "user1", "connected": True}}
+        entity = _make_binary_sensor(
+            cls=MikrotikPPPSecretBinarySensor,
+            coordinator=coord,
+            desc_overrides={"data_path": "ppp_secret", "data_attribute": "connected"},
+            uid="user1",
+        )
+        assert entity.is_on is False
+
+
+# ---------------------------------------------------------------------------
+# MikrotikPortBinarySensor.icon
+# ---------------------------------------------------------------------------
+
+
+class TestPortBinarySensorIcon:
+    def test_icon_disabled_interface(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": {
+                "name": "ether1",
+                "running": True,
+                "enabled": False,
+                "type": "ether",
+            }
+        }
+        entity = _make_binary_sensor(
+            cls=MikrotikPortBinarySensor,
+            coordinator=coord,
+            desc_overrides={
+                "data_path": "interface",
+                "data_attribute": "running",
+                "icon_enabled": "mdi:lan-connect",
+                "icon_disabled": "mdi:lan-pending",
+            },
+            uid="ether1",
+        )
+        assert entity.icon == "mdi:lan-disconnect"
+
+    def test_icon_enabled_and_running(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": {
+                "name": "ether1",
+                "running": True,
+                "enabled": True,
+                "type": "ether",
+            }
+        }
+        entity = _make_binary_sensor(
+            cls=MikrotikPortBinarySensor,
+            coordinator=coord,
+            desc_overrides={
+                "data_path": "interface",
+                "data_attribute": "running",
+                "icon_enabled": "mdi:lan-connect",
+                "icon_disabled": "mdi:lan-pending",
+            },
+            uid="ether1",
+        )
+        assert entity.icon == "mdi:lan-connect"
+
+    def test_icon_enabled_but_not_running(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": {
+                "name": "ether1",
+                "running": False,
+                "enabled": True,
+                "type": "ether",
+            }
+        }
+        entity = _make_binary_sensor(
+            cls=MikrotikPortBinarySensor,
+            coordinator=coord,
+            desc_overrides={
+                "data_path": "interface",
+                "data_attribute": "running",
+                "icon_enabled": "mdi:lan-connect",
+                "icon_disabled": "mdi:lan-pending",
+            },
+            uid="ether1",
+        )
+        assert entity.icon == "mdi:lan-pending"

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,75 @@
+"""Tests for Mikrotik Router button entities."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.mikrotik_router.button import (
+    MikrotikButton,
+    MikrotikScriptButton,
+)
+from custom_components.mikrotik_router.exceptions import ApiEntryNotFound
+
+from .conftest import (
+    make_mock_coordinator,
+    make_mock_entity_description,
+    patch_coordinator_entity_init,
+)
+
+
+def _make_button(cls=MikrotikButton, coordinator=None, desc_overrides=None, uid=None):
+    coord = coordinator or make_mock_coordinator()
+    desc = make_mock_entity_description(**(desc_overrides or {}))
+    with patch_coordinator_entity_init():
+        entity = cls(coord, desc, uid)
+    entity.hass = MagicMock()
+    entity.hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw)
+    )
+    return entity
+
+
+# ---------------------------------------------------------------------------
+# MikrotikButton
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikButton:
+    @pytest.mark.asyncio
+    async def test_async_press_is_noop(self):
+        entity = _make_button()
+        await entity.async_press()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# MikrotikScriptButton
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikScriptButton:
+    @pytest.mark.asyncio
+    async def test_async_press_calls_run_script(self):
+        coord = make_mock_coordinator()
+        coord.data["script"] = {"backup": {"name": "backup"}}
+        entity = _make_button(
+            cls=MikrotikScriptButton,
+            coordinator=coord,
+            desc_overrides={"data_path": "script", "data_reference": "name"},
+            uid="backup",
+        )
+        await entity.async_press()
+        coord.api.run_script.assert_called_once_with("backup")
+
+    @pytest.mark.asyncio
+    async def test_async_press_handles_api_entry_not_found(self):
+        coord = make_mock_coordinator()
+        coord.data["script"] = {"missing": {"name": "missing"}}
+        coord.api.run_script.side_effect = ApiEntryNotFound("script not found")
+        entity = _make_button(
+            cls=MikrotikScriptButton,
+            coordinator=coord,
+            desc_overrides={"data_path": "script", "data_reference": "name"},
+            uid="missing",
+        )
+        # Should log error, not raise
+        await entity.async_press()

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1,0 +1,248 @@
+"""Tests for Mikrotik Router device tracker entities."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from homeassistant.const import STATE_NOT_HOME
+
+from custom_components.mikrotik_router.device_tracker import (
+    MikrotikDeviceTracker,
+    MikrotikHostDeviceTracker,
+)
+from custom_components.mikrotik_router.const import (
+    CONF_TRACK_HOSTS,
+    CONF_TRACK_HOSTS_TIMEOUT,
+)
+
+from .conftest import (
+    make_mock_coordinator,
+    make_mock_entity_description,
+    patch_coordinator_entity_init,
+)
+
+
+def _make_tracker(
+    cls=MikrotikDeviceTracker, coordinator=None, desc_overrides=None, uid=None
+):
+    coord = coordinator or make_mock_coordinator()
+    desc = make_mock_entity_description(**(desc_overrides or {}))
+    with patch_coordinator_entity_init():
+        entity = cls(coord, desc, uid)
+    return entity
+
+
+def _host_data(source="arp", last_seen=None, available=True, **extra):
+    """Build a host data dict."""
+    data = {
+        "host-name": "MyPC",
+        "mac-address": "AA:BB:CC:DD:EE:FF",
+        "address": "192.168.1.100",
+        "source": source,
+        "available": available,
+        "last-seen": last_seen,
+    }
+    data.update(extra)
+    return data
+
+
+_HOST_DESC = {
+    "data_path": "host",
+    "data_attribute": "available",
+    "data_reference": "mac-address",
+    "data_name": "host-name",
+    "data_attributes_list": ["last-seen"],
+    "icon_enabled": "mdi:lan-connect",
+    "icon_disabled": "mdi:lan-disconnect",
+}
+
+
+# ---------------------------------------------------------------------------
+# MikrotikDeviceTracker
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikDeviceTracker:
+    def test_is_connected(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "running": True}}
+        entity = _make_tracker(
+            coordinator=coord,
+            desc_overrides={"data_path": "interface", "data_attribute": "running"},
+            uid="ether1",
+        )
+        assert entity.is_connected is True
+
+    def test_ip_address_present(self):
+        coord = make_mock_coordinator()
+        coord.data["host"] = {
+            "mac1": {
+                "host-name": "PC",
+                "address": "192.168.1.10",
+                "mac-address": "AA:BB",
+            }
+        }
+        entity = _make_tracker(
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        assert entity.ip_address == "192.168.1.10"
+
+    def test_ip_address_missing(self):
+        coord = make_mock_coordinator()
+        coord.data["host"] = {"mac1": {"host-name": "PC", "mac-address": "AA:BB"}}
+        entity = _make_tracker(
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        assert entity.ip_address is None
+
+    def test_mac_address(self):
+        coord = make_mock_coordinator()
+        coord.data["host"] = {
+            "mac1": {"host-name": "PC", "mac-address": "AA:BB:CC:DD:EE:FF"}
+        }
+        entity = _make_tracker(
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        assert entity.mac_address == "AA:BB:CC:DD:EE:FF"
+
+    def test_hostname(self):
+        coord = make_mock_coordinator()
+        coord.data["host"] = {"mac1": {"host-name": "MyPC", "mac-address": "AA:BB"}}
+        entity = _make_tracker(
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        assert entity.hostname == "MyPC"
+
+
+# ---------------------------------------------------------------------------
+# MikrotikHostDeviceTracker
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikHostDeviceTracker:
+    def test_is_connected_false_when_tracking_disabled(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: False})
+        coord.data["host"] = {"mac1": _host_data(available=True)}
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        assert entity.is_connected is False
+
+    def test_is_connected_wireless_source_uses_data_attribute(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: True})
+        coord.data["host"] = {"mac1": _host_data(source="wireless", available=True)}
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        assert entity.is_connected is True
+
+    def test_is_connected_capsman_source_uses_data_attribute(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: True})
+        coord.data["host"] = {"mac1": _host_data(source="capsman", available=False)}
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        assert entity.is_connected is False
+
+    def test_is_connected_arp_source_within_timeout(self):
+        now = datetime(2026, 3, 21, 12, 0, 0, tzinfo=timezone.utc)
+        coord = make_mock_coordinator(
+            options={CONF_TRACK_HOSTS: True, CONF_TRACK_HOSTS_TIMEOUT: 180}
+        )
+        coord.data["host"] = {
+            "mac1": _host_data(source="arp", last_seen=now - timedelta(seconds=60))
+        }
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        with patch(
+            "custom_components.mikrotik_router.device_tracker.utcnow",
+            return_value=now,
+        ):
+            assert entity.is_connected is True
+
+    def test_is_connected_arp_source_beyond_timeout(self):
+        now = datetime(2026, 3, 21, 12, 0, 0, tzinfo=timezone.utc)
+        coord = make_mock_coordinator(
+            options={CONF_TRACK_HOSTS: True, CONF_TRACK_HOSTS_TIMEOUT: 180}
+        )
+        coord.data["host"] = {
+            "mac1": _host_data(source="arp", last_seen=now - timedelta(seconds=300))
+        }
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        with patch(
+            "custom_components.mikrotik_router.device_tracker.utcnow",
+            return_value=now,
+        ):
+            assert entity.is_connected is False
+
+    def test_state_home_when_connected(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: True})
+        coord.data["host"] = {"mac1": _host_data(source="wireless", available=True)}
+        coord.option_zone = "home"
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        assert entity.state == "home"
+
+    def test_state_not_home_when_disconnected(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: False})
+        coord.data["host"] = {"mac1": _host_data(available=True)}
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        assert entity.state == STATE_NOT_HOME
+
+    def test_extra_state_attributes_connected_shows_now(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: True})
+        coord.data["host"] = {"mac1": _host_data(source="wireless", available=True)}
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        attrs = entity.extra_state_attributes
+        assert attrs["last_seen"] == "Now"
+
+    def test_extra_state_attributes_disconnected_no_last_seen_shows_unknown(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: False})
+        coord.data["host"] = {"mac1": _host_data(last_seen=None)}
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        attrs = entity.extra_state_attributes
+        assert attrs["last_seen"] == "Unknown"

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,11 +1,11 @@
-"""Unit tests for Mikrotik Router entity _skip_sensor() and MikrotikInterfaceEntityMixin."""
+"""Unit tests for Mikrotik Router entity _skip_sensor(), MikrotikInterfaceEntityMixin, and MikrotikEntity."""
 
-from unittest.mock import MagicMock
-
+from unittest.mock import MagicMock, patch
 
 from custom_components.mikrotik_router.entity import (
     copy_attrs,
     _skip_sensor,
+    MikrotikEntity,
     MikrotikInterfaceEntityMixin,
 )
 from custom_components.mikrotik_router.const import (
@@ -14,6 +14,11 @@ from custom_components.mikrotik_router.const import (
     CONF_SENSOR_NETWATCH_TRACKER,
     CONF_TRACK_HOSTS,
     CONF_SENSOR_POE,
+)
+from .conftest import (
+    make_mock_coordinator,
+    make_mock_entity_description,
+    patch_coordinator_entity_init,
 )
 
 # ---------------------------------------------------------------------------
@@ -35,6 +40,296 @@ def make_config_entry(options=None):
     cfg = MagicMock()
     cfg.options = options or {}
     return cfg
+
+
+def _make_entity(coordinator=None, desc_overrides=None, uid=None):
+    """Build a MikrotikEntity with patched CoordinatorEntity.__init__."""
+    coord = coordinator or make_mock_coordinator()
+    desc = make_mock_entity_description(**(desc_overrides or {}))
+    with patch_coordinator_entity_init():
+        entity = MikrotikEntity(coord, desc, uid)
+    return entity
+
+
+# ---------------------------------------------------------------------------
+# MikrotikEntity.__init__ tests
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikEntityInit:
+    """Tests for MikrotikEntity construction."""
+
+    def test_init_without_uid(self):
+        """Entity without uid uses data_path data directly."""
+        coord = make_mock_coordinator()
+        coord.data["health"] = {"temperature": 45}
+        desc = make_mock_entity_description(
+            data_path="health", data_attribute="temperature", data_reference=""
+        )
+        with patch_coordinator_entity_init():
+            entity = MikrotikEntity(coord, desc)
+        assert entity._inst == "TestRouter"
+        assert entity._uid is None
+        assert entity._data == {"temperature": 45}
+
+    def test_init_with_uid(self):
+        """Entity with uid indexes into nested data."""
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": {"name": "ether1", "enabled": True, "type": "ether"}
+        }
+        desc = make_mock_entity_description(
+            data_path="interface", data_reference="name"
+        )
+        with patch_coordinator_entity_init():
+            entity = MikrotikEntity(coord, desc, uid="ether1")
+        assert entity._uid == "ether1"
+        assert entity._data["name"] == "ether1"
+
+
+# ---------------------------------------------------------------------------
+# MikrotikEntity.custom_name tests
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikEntityCustomName:
+    """Tests for entity custom_name property."""
+
+    def test_custom_name_no_uid_returns_description_name(self):
+        entity = _make_entity(
+            desc_overrides={"name": "Uptime", "data_path": "resource"},
+            coordinator=make_mock_coordinator(
+                data={
+                    "resource": {"uptime": 12345},
+                    "routerboard": {"serial-number": "X"},
+                }
+            ),
+        )
+        assert entity.custom_name == "Uptime"
+
+    def test_custom_name_no_uid_comment_override(self):
+        coord = make_mock_coordinator(
+            data={
+                "resource": {"uptime": 12345, "comment": "My Router Uptime"},
+                "routerboard": {"serial-number": "X"},
+            }
+        )
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={
+                "name": "Uptime",
+                "data_path": "resource",
+                "data_name_comment": True,
+            },
+        )
+        assert entity.custom_name == "My Router Uptime"
+
+    def test_custom_name_with_uid_reference_equals_name_shortens(self):
+        """When data_reference == data_name, name is just entity_description.name."""
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": True}}
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={
+                "name": "Port",
+                "data_path": "interface",
+                "data_reference": "name",
+                "data_name": "name",
+            },
+            uid="ether1",
+        )
+        assert entity.custom_name == "Port"
+
+    def test_custom_name_with_uid_different_reference_and_name(self):
+        """When data_reference != data_name, includes data_name in output."""
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": {
+                "name": "ether1",
+                "default-name": "ether1",
+                "mac": "AA:BB:CC:DD:EE:FF",
+            }
+        }
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={
+                "name": "TX",
+                "data_path": "interface",
+                "data_reference": "mac",
+                "data_name": "name",
+            },
+            uid="ether1",
+        )
+        assert entity.custom_name == "ether1 TX"
+
+    def test_custom_name_with_uid_no_description_name(self):
+        """When entity_description.name is empty, returns just data_name."""
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1"}}
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={
+                "name": "",
+                "data_path": "interface",
+                "data_name": "name",
+            },
+            uid="ether1",
+        )
+        assert entity.custom_name == "ether1"
+
+
+# ---------------------------------------------------------------------------
+# MikrotikEntity.unique_id tests
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikEntityUniqueId:
+    def test_unique_id_without_uid(self):
+        entity = _make_entity(
+            desc_overrides={"key": "system_uptime", "data_path": "resource"},
+            coordinator=make_mock_coordinator(
+                data={"resource": {"uptime": 1}, "routerboard": {"serial-number": "X"}}
+            ),
+        )
+        assert entity.unique_id == "testrouter-system_uptime"
+
+    def test_unique_id_with_uid(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "mac": "AA:BB"}}
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={
+                "key": "port_status",
+                "data_path": "interface",
+                "data_reference": "name",
+            },
+            uid="ether1",
+        )
+        assert entity.unique_id == "testrouter-port_status-ether1"
+
+
+# ---------------------------------------------------------------------------
+# MikrotikEntity.device_info tests
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikEntityDeviceInfo:
+    def test_device_info_system_group(self):
+        coord = make_mock_coordinator()
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={
+                "ha_group": "System",
+                "data_path": "resource",
+                "data_reference": "",
+            },
+        )
+        info = entity.device_info
+        assert info["model"] == "hAP ax3"
+        assert info["manufacturer"] == "MikroTik"
+
+    def test_device_info_mac_address_group(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": {"name": "ether1", "mac-address": "AA:BB:CC:DD:EE:FF"}
+        }
+        coord.data["host"] = {
+            "AA:BB:CC:DD:EE:FF": {"host-name": "MyPC", "manufacturer": "Intel"}
+        }
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={
+                "ha_group": "Interface",
+                "data_path": "interface",
+                "data_reference": "mac-address",
+                "data_name": "name",
+                "ha_connection": None,
+                "ha_connection_value": "data__mac-address",
+            },
+            uid="ether1",
+        )
+        info = entity.device_info
+        assert info["name"] == "MyPC"
+        assert info["manufacturer"] == "Intel"
+
+    def test_device_info_generic_group(self):
+        coord = make_mock_coordinator()
+        coord.data["nat"] = {"rule1": {"name": "NAT Rule 1", "chain": "srcnat"}}
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={
+                "ha_group": "NAT",
+                "data_path": "nat",
+                "data_reference": "name",
+                "data_name": "name",
+                "ha_connection": None,
+                "ha_connection_value": None,
+            },
+            uid="rule1",
+        )
+        info = entity.device_info
+        assert "via_device" in info
+
+
+# ---------------------------------------------------------------------------
+# MikrotikEntity.extra_state_attributes tests
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikEntityExtraStateAttributes:
+    def test_copies_data_attributes_list(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": {"name": "ether1", "rate": "1Gbps", "status": "up"}
+        }
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={
+                "data_path": "interface",
+                "data_attributes_list": ["rate", "status"],
+            },
+            uid="ether1",
+        )
+        attrs = entity.extra_state_attributes
+        assert attrs["rate"] == "1Gbps"
+        assert attrs["status"] == "up"
+
+
+# ---------------------------------------------------------------------------
+# MikrotikEntity._handle_coordinator_update tests
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikEntityCoordinatorUpdate:
+    def test_handle_update_refreshes_data_with_uid(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": True}}
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={"data_path": "interface", "data_reference": "name"},
+            uid="ether1",
+        )
+        # Simulate coordinator data change
+        coord.data["interface"]["ether1"]["enabled"] = False
+        with patch.object(
+            type(entity).__mro__[2], "_handle_coordinator_update", return_value=None
+        ):
+            entity._handle_coordinator_update()
+        assert entity._data["enabled"] is False
+
+    def test_handle_update_refreshes_data_without_uid(self):
+        coord = make_mock_coordinator()
+        coord.data["resource"] = {"uptime": 100}
+        entity = _make_entity(
+            coordinator=coord,
+            desc_overrides={"data_path": "resource"},
+        )
+        coord.data["resource"]["uptime"] = 200
+        with patch.object(
+            type(entity).__mro__[2], "_handle_coordinator_update", return_value=None
+        ):
+            entity._handle_coordinator_update()
+        assert entity._data["uptime"] == 200
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,91 @@
+"""Tests for Mikrotik Router __init__.py — lifecycle functions."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.const import CONF_VERIFY_SSL
+
+from custom_components.mikrotik_router import (
+    async_migrate_entry,
+    async_remove_config_entry_device,
+)
+from custom_components.mikrotik_router.const import DEFAULT_VERIFY_SSL
+
+
+# ---------------------------------------------------------------------------
+# async_migrate_entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_v1_to_v2_adds_verify_ssl():
+    """Version 1 entry gets CONF_VERIFY_SSL injected and bumped to version 2."""
+    hass = MagicMock()
+    config_entry = MagicMock()
+    config_entry.version = 1
+    config_entry.minor_version = 0
+    config_entry.data = {"host": "10.0.0.1", "username": "admin"}
+
+    result = await async_migrate_entry(hass, config_entry)
+
+    assert result is True
+    hass.config_entries.async_update_entry.assert_called_once()
+    call_kwargs = hass.config_entries.async_update_entry.call_args
+    new_data = call_kwargs.kwargs.get("data") or call_kwargs[1].get("data")
+    assert new_data[CONF_VERIFY_SSL] == DEFAULT_VERIFY_SSL
+    assert call_kwargs.kwargs.get("version") or call_kwargs[1].get("version") == 2
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_v2_is_noop():
+    """Version 2 entry is already current — no update call."""
+    hass = MagicMock()
+    config_entry = MagicMock()
+    config_entry.version = 2
+    config_entry.minor_version = 0
+    config_entry.data = {"host": "10.0.0.1", CONF_VERIFY_SSL: False}
+
+    result = await async_migrate_entry(hass, config_entry)
+
+    assert result is True
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_preserves_existing_data():
+    """Migration preserves all existing config data while adding verify_ssl."""
+    hass = MagicMock()
+    config_entry = MagicMock()
+    config_entry.version = 1
+    config_entry.minor_version = 0
+    config_entry.data = {
+        "host": "10.0.0.1",
+        "username": "admin",
+        "password": "secret",
+    }
+
+    await async_migrate_entry(hass, config_entry)
+
+    call_kwargs = hass.config_entries.async_update_entry.call_args
+    new_data = call_kwargs.kwargs.get("data") or call_kwargs[1].get("data")
+    assert new_data["host"] == "10.0.0.1"
+    assert new_data["username"] == "admin"
+    assert new_data["password"] == "secret"
+    assert CONF_VERIFY_SSL in new_data
+
+
+# ---------------------------------------------------------------------------
+# async_remove_config_entry_device
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remove_config_entry_device_returns_true():
+    """Device removal always succeeds."""
+    hass = MagicMock()
+    config_entry = MagicMock()
+    device_entry = MagicMock()
+
+    result = await async_remove_config_entry_device(hass, config_entry, device_entry)
+    assert result is True

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,139 @@
+"""Tests for Mikrotik Router sensor entities."""
+
+from custom_components.mikrotik_router.sensor import (
+    MikrotikSensor,
+    MikrotikClientTrafficSensor,
+)
+
+from .conftest import (
+    make_mock_coordinator,
+    make_mock_entity_description,
+    patch_coordinator_entity_init,
+)
+
+
+def _make_sensor(cls=MikrotikSensor, coordinator=None, desc_overrides=None, uid=None):
+    """Build a sensor entity with patched CoordinatorEntity.__init__."""
+    coord = coordinator or make_mock_coordinator()
+    desc = make_mock_entity_description(**(desc_overrides or {}))
+    with patch_coordinator_entity_init():
+        entity = cls(coord, desc, uid)
+    return entity
+
+
+# ---------------------------------------------------------------------------
+# MikrotikSensor.native_value
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikSensorNativeValue:
+    def test_returns_data_attribute(self):
+        coord = make_mock_coordinator()
+        coord.data["health"] = {"temperature": 42}
+        entity = _make_sensor(
+            coordinator=coord,
+            desc_overrides={"data_path": "health", "data_attribute": "temperature"},
+        )
+        assert entity.native_value == 42
+
+    def test_returns_string_value(self):
+        coord = make_mock_coordinator()
+        coord.data["resource"] = {"version": "7.16.2"}
+        entity = _make_sensor(
+            coordinator=coord,
+            desc_overrides={"data_path": "resource", "data_attribute": "version"},
+        )
+        assert entity.native_value == "7.16.2"
+
+
+# ---------------------------------------------------------------------------
+# MikrotikSensor.native_unit_of_measurement
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikSensorUoM:
+    def test_static_uom(self):
+        entity = _make_sensor(
+            desc_overrides={
+                "native_unit_of_measurement": "°C",
+                "data_path": "health",
+            },
+            coordinator=make_mock_coordinator(
+                data={
+                    "health": {"temperature": 42},
+                    "resource": {"board-name": "x", "platform": "x", "version": "x"},
+                    "routerboard": {"serial-number": "x"},
+                }
+            ),
+        )
+        assert entity.native_unit_of_measurement == "°C"
+
+    def test_dynamic_uom_from_data(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "speed-unit": "Mbps"}}
+        entity = _make_sensor(
+            coordinator=coord,
+            desc_overrides={
+                "native_unit_of_measurement": "data__speed-unit",
+                "data_path": "interface",
+                "data_reference": "name",
+            },
+            uid="ether1",
+        )
+        assert entity.native_unit_of_measurement == "Mbps"
+
+    def test_dynamic_uom_key_missing_falls_back(self):
+        """When the data__ key isn't in _data, returns the raw string."""
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1"}}
+        entity = _make_sensor(
+            coordinator=coord,
+            desc_overrides={
+                "native_unit_of_measurement": "data__speed-unit",
+                "data_path": "interface",
+                "data_reference": "name",
+            },
+            uid="ether1",
+        )
+        assert entity.native_unit_of_measurement == "data__speed-unit"
+
+    def test_none_uom(self):
+        entity = _make_sensor(
+            desc_overrides={
+                "native_unit_of_measurement": None,
+                "data_path": "health",
+            },
+            coordinator=make_mock_coordinator(
+                data={
+                    "health": {"temperature": 42},
+                    "resource": {"board-name": "x", "platform": "x", "version": "x"},
+                    "routerboard": {"serial-number": "x"},
+                }
+            ),
+        )
+        assert entity.native_unit_of_measurement is None
+
+
+# ---------------------------------------------------------------------------
+# MikrotikClientTrafficSensor.custom_name
+# ---------------------------------------------------------------------------
+
+
+class TestClientTrafficSensorCustomName:
+    def test_always_returns_description_name(self):
+        coord = make_mock_coordinator()
+        coord.data["client_traffic"] = {
+            "AA:BB:CC:DD:EE:FF": {"host-name": "MyPC", "wan-tx": 1000}
+        }
+        entity = _make_sensor(
+            cls=MikrotikClientTrafficSensor,
+            coordinator=coord,
+            desc_overrides={
+                "name": "WAN TX",
+                "data_path": "client_traffic",
+                "data_reference": "mac-address",
+                "data_name": "host-name",
+            },
+            uid="AA:BB:CC:DD:EE:FF",
+        )
+        assert entity.custom_name == "WAN TX"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,397 @@
+"""Tests for Mikrotik Router switch entities."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.mikrotik_router.switch import (
+    MikrotikSwitch,
+    MikrotikPortSwitch,
+    MikrotikNATSwitch,
+    MikrotikQueueSwitch,
+    MikrotikKidcontrolPauseSwitch,
+)
+
+from .conftest import (
+    make_mock_coordinator,
+    make_mock_entity_description,
+    patch_coordinator_entity_init,
+)
+
+
+def _make_switch(cls=MikrotikSwitch, coordinator=None, desc_overrides=None, uid=None):
+    coord = coordinator or make_mock_coordinator()
+    desc = make_mock_entity_description(**(desc_overrides or {}))
+    with patch_coordinator_entity_init():
+        entity = cls(coord, desc, uid)
+    entity.hass = MagicMock()
+    entity.hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw)
+    )
+    return entity
+
+
+_SWITCH_DESC = {
+    "data_path": "interface",
+    "data_attribute": "enabled",
+    "data_reference": "name",
+    "data_name": "name",
+    "data_switch_path": "/interface",
+    "data_switch_parameter": "disabled",
+    "icon_enabled": "mdi:check",
+    "icon_disabled": "mdi:close",
+}
+
+
+# ---------------------------------------------------------------------------
+# MikrotikSwitch
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikSwitch:
+    def test_is_on_true(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": True}}
+        entity = _make_switch(
+            coordinator=coord,
+            desc_overrides={**_SWITCH_DESC},
+            uid="ether1",
+        )
+        assert entity.is_on is True
+
+    def test_is_on_false(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": False}}
+        entity = _make_switch(
+            coordinator=coord,
+            desc_overrides={**_SWITCH_DESC},
+            uid="ether1",
+        )
+        assert entity.is_on is False
+
+    def test_icon_when_on(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": True}}
+        entity = _make_switch(
+            coordinator=coord,
+            desc_overrides={**_SWITCH_DESC},
+            uid="ether1",
+        )
+        assert entity.icon == "mdi:check"
+
+    def test_icon_when_off(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": False}}
+        entity = _make_switch(
+            coordinator=coord,
+            desc_overrides={**_SWITCH_DESC},
+            uid="ether1",
+        )
+        assert entity.icon == "mdi:close"
+
+    @pytest.mark.asyncio
+    async def test_async_turn_on_calls_set_value(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": True}}
+        entity = _make_switch(
+            coordinator=coord, desc_overrides={**_SWITCH_DESC}, uid="ether1"
+        )
+        await entity.async_turn_on()
+        coord.set_value.assert_called_once_with(
+            "/interface", "name", "ether1", "disabled", False
+        )
+        coord.async_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_turn_off_calls_set_value(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": True}}
+        entity = _make_switch(
+            coordinator=coord, desc_overrides={**_SWITCH_DESC}, uid="ether1"
+        )
+        await entity.async_turn_off()
+        coord.set_value.assert_called_once_with(
+            "/interface", "name", "ether1", "disabled", True
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_turn_on_noop_without_write_access(self):
+        coord = make_mock_coordinator()
+        coord.data["access"] = ["policy", "reboot"]  # no "write"
+        coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": True}}
+        entity = _make_switch(
+            coordinator=coord, desc_overrides={**_SWITCH_DESC}, uid="ether1"
+        )
+        await entity.async_turn_on()
+        coord.set_value.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_turn_off_noop_without_write_access(self):
+        coord = make_mock_coordinator()
+        coord.data["access"] = ["policy"]
+        coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": True}}
+        entity = _make_switch(
+            coordinator=coord, desc_overrides={**_SWITCH_DESC}, uid="ether1"
+        )
+        await entity.async_turn_off()
+        coord.set_value.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# MikrotikPortSwitch
+# ---------------------------------------------------------------------------
+
+
+_PORT_DESC = {
+    **_SWITCH_DESC,
+    "func": "MikrotikPortSwitch",
+}
+
+
+class TestMikrotikPortSwitch:
+    def _make_port_data(self, **overrides):
+        data = {
+            "name": "ether1",
+            "enabled": True,
+            "running": True,
+            "type": "ether",
+            "about": "",
+            "port-mac-address": "AA:BB:CC:DD:EE:FF",
+        }
+        data.update(overrides)
+        return data
+
+    @pytest.mark.asyncio
+    async def test_turn_on_capsman_managed_returns_error(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "wlan1": self._make_port_data(name="wlan1", about="managed by CAPsMAN")
+        }
+        entity = _make_switch(
+            cls=MikrotikPortSwitch,
+            coordinator=coord,
+            desc_overrides={**_PORT_DESC},
+            uid="wlan1",
+        )
+        result = await entity.async_turn_on()
+        assert result == "managed by CAPsMAN"
+        coord.set_value.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_turn_on_uses_name_param_when_mac_has_dashes(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": self._make_port_data(port_mac="AA-BB-CC-DD-EE-FF")
+        }
+        # The port-mac-address has dashes → param should switch to "name"
+        coord.data["interface"]["ether1"]["port-mac-address"] = "AA-BB-CC-DD-EE-FF"
+        entity = _make_switch(
+            cls=MikrotikPortSwitch,
+            coordinator=coord,
+            desc_overrides={**_PORT_DESC},
+            uid="ether1",
+        )
+        await entity.async_turn_on()
+        # set_value should have been called with param="name"
+        call_args = coord.set_value.call_args[0]
+        assert call_args[1] == "name"
+
+    @pytest.mark.asyncio
+    async def test_turn_on_enables_poe_when_off(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {"ether1": self._make_port_data(**{"poe-out": "off"})}
+        entity = _make_switch(
+            cls=MikrotikPortSwitch,
+            coordinator=coord,
+            desc_overrides={**_PORT_DESC},
+            uid="ether1",
+        )
+        await entity.async_turn_on()
+        # Should have two set_value calls: interface enable + poe-out auto-on
+        assert coord.set_value.call_count == 2
+        poe_call = coord.set_value.call_args_list[1][0]
+        assert poe_call[0] == "/interface/ethernet"
+        assert poe_call[3] == "poe-out"
+        assert poe_call[4] == "auto-on"
+
+    @pytest.mark.asyncio
+    async def test_turn_off_disables_poe_when_auto_on(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": self._make_port_data(**{"poe-out": "auto-on"})
+        }
+        entity = _make_switch(
+            cls=MikrotikPortSwitch,
+            coordinator=coord,
+            desc_overrides={**_PORT_DESC},
+            uid="ether1",
+        )
+        await entity.async_turn_off()
+        assert coord.set_value.call_count == 2
+        poe_call = coord.set_value.call_args_list[1][0]
+        assert poe_call[3] == "poe-out"
+        assert poe_call[4] == "off"
+
+    def test_icon_disabled_interface(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": self._make_port_data(enabled=False, running=False)
+        }
+        entity = _make_switch(
+            cls=MikrotikPortSwitch,
+            coordinator=coord,
+            desc_overrides={**_PORT_DESC},
+            uid="ether1",
+        )
+        assert entity.icon == "mdi:lan-disconnect"
+
+    def test_icon_running(self):
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": self._make_port_data(enabled=True, running=True)
+        }
+        entity = _make_switch(
+            cls=MikrotikPortSwitch,
+            coordinator=coord,
+            desc_overrides={**_PORT_DESC},
+            uid="ether1",
+        )
+        assert entity.icon == "mdi:check"
+
+
+# ---------------------------------------------------------------------------
+# MikrotikNATSwitch
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikNATSwitch:
+    def _make_nat_data(self):
+        return {
+            "chain": "dstnat",
+            "action": "dst-nat",
+            "protocol": "tcp",
+            "in-interface": "ether1",
+            "dst-port": "80",
+            "out-interface": "",
+            "to-addresses": "192.168.1.10",
+            "to-ports": "8080",
+            "enabled": True,
+            "name": "NAT Rule",
+            "uniq-id": "dstnat,dst-nat,tcp,ether1:80-:192.168.1.10:8080",
+            ".id": "*1",
+        }
+
+    @pytest.mark.asyncio
+    async def test_turn_on_finds_id_by_uniq_id(self):
+        coord = make_mock_coordinator()
+        nat_data = self._make_nat_data()
+        coord.data["nat"] = {"rule1": nat_data}
+        coord.data["interface"] = {}  # not needed but data_path defaults
+        # Entity data references the nat rule
+        entity = _make_switch(
+            cls=MikrotikNATSwitch,
+            coordinator=coord,
+            desc_overrides={
+                **_SWITCH_DESC,
+                "data_path": "nat",
+                "data_switch_path": "/ip/firewall/nat",
+            },
+            uid="rule1",
+        )
+        await entity.async_turn_on()
+        call_args = coord.set_value.call_args[0]
+        assert call_args[1] == ".id"
+        assert call_args[2] == "*1"
+
+
+# ---------------------------------------------------------------------------
+# MikrotikQueueSwitch
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikQueueSwitch:
+    @pytest.mark.asyncio
+    async def test_turn_on_finds_id_by_name(self):
+        coord = make_mock_coordinator()
+        coord.data["queue"] = {
+            "q1": {"name": "download-limit", ".id": "*A", "enabled": True}
+        }
+        entity = _make_switch(
+            cls=MikrotikQueueSwitch,
+            coordinator=coord,
+            desc_overrides={
+                **_SWITCH_DESC,
+                "data_path": "queue",
+                "data_switch_path": "/queue/simple",
+            },
+            uid="q1",
+        )
+        await entity.async_turn_on()
+        call_args = coord.set_value.call_args[0]
+        assert call_args[1] == ".id"
+        assert call_args[2] == "*A"
+
+    @pytest.mark.asyncio
+    async def test_turn_off_finds_id_by_name(self):
+        coord = make_mock_coordinator()
+        coord.data["queue"] = {
+            "q1": {"name": "download-limit", ".id": "*A", "enabled": True}
+        }
+        entity = _make_switch(
+            cls=MikrotikQueueSwitch,
+            coordinator=coord,
+            desc_overrides={
+                **_SWITCH_DESC,
+                "data_path": "queue",
+                "data_switch_path": "/queue/simple",
+            },
+            uid="q1",
+        )
+        await entity.async_turn_off()
+        call_args = coord.set_value.call_args[0]
+        assert call_args[2] == "*A"
+
+
+# ---------------------------------------------------------------------------
+# MikrotikKidcontrolPauseSwitch
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikKidcontrolPauseSwitch:
+    @pytest.mark.asyncio
+    async def test_turn_on_calls_resume(self):
+        coord = make_mock_coordinator()
+        coord.data["kid-control"] = {"kid1": {"name": "kid1", "paused": True}}
+        entity = _make_switch(
+            cls=MikrotikKidcontrolPauseSwitch,
+            coordinator=coord,
+            desc_overrides={
+                **_SWITCH_DESC,
+                "data_path": "kid-control",
+                "data_switch_path": "/ip/kid-control",
+            },
+            uid="kid1",
+        )
+        await entity.async_turn_on()
+        coord.execute.assert_called_once()
+        call_args = coord.execute.call_args[0]
+        assert call_args[1] == "resume"
+
+    @pytest.mark.asyncio
+    async def test_turn_off_calls_pause(self):
+        coord = make_mock_coordinator()
+        coord.data["kid-control"] = {"kid1": {"name": "kid1", "paused": False}}
+        entity = _make_switch(
+            cls=MikrotikKidcontrolPauseSwitch,
+            coordinator=coord,
+            desc_overrides={
+                **_SWITCH_DESC,
+                "data_path": "kid-control",
+                "data_switch_path": "/ip/kid-control",
+            },
+            uid="kid1",
+        )
+        await entity.async_turn_off()
+        coord.execute.assert_called_once()
+        call_args = coord.execute.call_args[0]
+        assert call_args[1] == "pause"

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,10 +1,21 @@
-"""Tests for update.py pure functions — version list generation."""
+"""Tests for update.py — version list generation and update entities."""
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 from packaging.version import Version
 
 from custom_components.mikrotik_router.update import (
+    MikrotikRouterOSUpdate,
+    MikrotikRouterBoardFWUpdate,
     generate_version_list,
     decrement_version,
+)
+
+from .conftest import (
+    make_mock_coordinator,
+    make_mock_entity_description,
+    patch_coordinator_entity_init,
 )
 
 
@@ -62,3 +73,180 @@ class TestGenerateVersionList:
         result = generate_version_list("7.16.0", "7.16.3")
         versions = [Version(v) for v in result]
         assert versions == sorted(versions, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for entity tests
+# ---------------------------------------------------------------------------
+
+
+def _make_update_entity(
+    cls=MikrotikRouterOSUpdate, coordinator=None, desc_overrides=None, uid=None
+):
+    coord = coordinator or make_mock_coordinator()
+    desc = make_mock_entity_description(**(desc_overrides or {}))
+    with patch_coordinator_entity_init():
+        entity = cls(coord, desc, uid)
+    entity.hass = MagicMock()
+    entity.hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw)
+    )
+    return entity
+
+
+_FW_UPDATE_DESC = {
+    "data_path": "fw-update",
+    "data_attribute": "available",
+    "data_reference": "",
+    "data_name": "",
+    "title": "RouterOS",
+}
+
+
+# ---------------------------------------------------------------------------
+# MikrotikRouterOSUpdate
+# ---------------------------------------------------------------------------
+
+
+class TestMikrotikRouterOSUpdate:
+    def test_installed_version(self):
+        coord = make_mock_coordinator()
+        coord.data["fw-update"] = {
+            "installed-version": "7.16.1",
+            "latest-version": "7.16.2",
+            "available": True,
+        }
+        entity = _make_update_entity(
+            coordinator=coord, desc_overrides={**_FW_UPDATE_DESC}
+        )
+        assert entity.installed_version == "7.16.1"
+
+    def test_latest_version(self):
+        coord = make_mock_coordinator()
+        coord.data["fw-update"] = {
+            "installed-version": "7.16.1",
+            "latest-version": "7.16.2",
+            "available": True,
+        }
+        entity = _make_update_entity(
+            coordinator=coord, desc_overrides={**_FW_UPDATE_DESC}
+        )
+        assert entity.latest_version == "7.16.2"
+
+    @pytest.mark.asyncio
+    async def test_async_install_without_backup(self):
+        coord = make_mock_coordinator()
+        coord.data["fw-update"] = {
+            "installed-version": "7.16.1",
+            "latest-version": "7.16.2",
+            "available": True,
+        }
+        entity = _make_update_entity(
+            coordinator=coord, desc_overrides={**_FW_UPDATE_DESC}
+        )
+        await entity.async_install(version="7.16.2", backup=False)
+        coord.execute.assert_called_once_with(
+            "/system/package/update", "install", None, None
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_install_with_backup(self):
+        coord = make_mock_coordinator()
+        coord.data["fw-update"] = {
+            "installed-version": "7.16.1",
+            "latest-version": "7.16.2",
+            "available": True,
+        }
+        entity = _make_update_entity(
+            coordinator=coord, desc_overrides={**_FW_UPDATE_DESC}
+        )
+        await entity.async_install(version="7.16.2", backup=True)
+        assert coord.execute.call_count == 2
+        backup_call = coord.execute.call_args_list[0][0]
+        assert backup_call[0] == "/system/backup"
+        assert backup_call[1] == "save"
+        install_call = coord.execute.call_args_list[1][0]
+        assert install_call[0] == "/system/package/update"
+
+    def test_release_url(self):
+        entity = _make_update_entity(
+            desc_overrides={**_FW_UPDATE_DESC},
+            coordinator=make_mock_coordinator(
+                data={
+                    "fw-update": {
+                        "installed-version": "7.16.1",
+                        "latest-version": "7.16.2",
+                        "available": True,
+                    },
+                    "resource": {"board-name": "x", "platform": "x", "version": "x"},
+                    "routerboard": {"serial-number": "x"},
+                }
+            ),
+        )
+        assert "mikrotik.com" in entity.release_url
+
+
+# ---------------------------------------------------------------------------
+# MikrotikRouterBoardFWUpdate
+# ---------------------------------------------------------------------------
+
+
+_RB_UPDATE_DESC = {
+    "data_path": "routerboard",
+    "data_attribute": "available",
+    "data_reference": "",
+    "data_name": "",
+    "title": "RouterBOARD Firmware",
+}
+
+
+class TestMikrotikRouterBoardFWUpdate:
+    def test_installed_version(self):
+        coord = make_mock_coordinator()
+        coord.data["routerboard"] = {
+            "serial-number": "X",
+            "current-firmware": "7.16.1",
+            "upgrade-firmware": "7.16.2",
+        }
+        entity = _make_update_entity(
+            cls=MikrotikRouterBoardFWUpdate,
+            coordinator=coord,
+            desc_overrides={**_RB_UPDATE_DESC},
+        )
+        assert entity.installed_version == "7.16.1"
+
+    def test_latest_version(self):
+        coord = make_mock_coordinator()
+        coord.data["routerboard"] = {
+            "serial-number": "X",
+            "current-firmware": "7.16.1",
+            "upgrade-firmware": "7.16.2",
+        }
+        entity = _make_update_entity(
+            cls=MikrotikRouterBoardFWUpdate,
+            coordinator=coord,
+            desc_overrides={**_RB_UPDATE_DESC},
+        )
+        assert entity.latest_version == "7.16.2"
+
+    @pytest.mark.asyncio
+    async def test_async_install_upgrades_and_reboots(self):
+        coord = make_mock_coordinator()
+        coord.data["routerboard"] = {
+            "serial-number": "X",
+            "current-firmware": "7.16.1",
+            "upgrade-firmware": "7.16.2",
+        }
+        entity = _make_update_entity(
+            cls=MikrotikRouterBoardFWUpdate,
+            coordinator=coord,
+            desc_overrides={**_RB_UPDATE_DESC},
+        )
+        await entity.async_install(version="7.16.2", backup=False)
+        assert coord.execute.call_count == 2
+        upgrade_call = coord.execute.call_args_list[0][0]
+        assert upgrade_call[0] == "/system/routerboard"
+        assert upgrade_call[1] == "upgrade"
+        reboot_call = coord.execute.call_args_list[1][0]
+        assert reboot_call[0] == "/system"
+        assert reboot_call[1] == "reboot"


### PR DESCRIPTION
## Summary
- 80 new entity-level tests covering all 6 platform entity types (sensor, binary_sensor, switch, button, device_tracker, update) and the MikrotikEntity base class
- New shared test infrastructure: `make_mock_coordinator()`, `make_mock_entity_description()`, `patch_coordinator_entity_init()` in conftest.py
- Tests cover entity properties (is_on, native_value, icon, unique_id, device_info), async actions (turn_on/off, async_press, async_install), access guards, UID lookups, timeout logic, and coordinator update refresh
- Total tests: 441 passed, 5 skipped (up from 361)

### New test files
| File | Tests | Scope |
|------|-------|-------|
| test_init.py | 4 | async_migrate_entry, async_remove_config_entry_device |
| test_sensor.py | 7 | native_value, UoM (static/dynamic/None), ClientTrafficSensor |
| test_binary_sensor.py | 10 | is_on, icon, PPP guard, PortBinarySensor 3-state icon |
| test_switch.py | 19 | 5 switch classes: actions, write guard, CAPsMAN, PoE, NAT/Queue UID, Kidcontrol |
| test_button.py | 3 | Script execution, ApiEntryNotFound |
| test_device_tracker.py | 12 | is_connected (disabled/wireless/capsman/ARP timeout), state, attributes |

### Extended test files
| File | New tests | Scope |
|------|-----------|-------|
| test_entity.py | +15 | MikrotikEntity: init, custom_name, unique_id, device_info, attributes, coordinator update |
| test_update.py | +8 | RouterOS/RouterBOARD: install (with/without backup), version properties |
| conftest.py | — | Shared fixtures for entity-level testing |

## Test plan
- [x] `pytest tests/ -v --tb=short` — 441 passed, 5 skipped
- [x] `ruff check tests/` — 0 errors
- [x] `ruff format --check tests/` — 0 reformats needed
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)