### PR TITLE
fix: HACS-compatible release asset name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: mikrotik_router.zip
-          asset_name: mikrotik_router-${{ steps.version.outputs.version }}.zip
+          asset_name: mikrotik_router.zip
           tag: ${{ github.ref }}
           overwrite: true
 


### PR DESCRIPTION
## Summary
- Fix release workflow to name zip asset `mikrotik_router.zip` instead of `mikrotik_router-{version}.zip`
- HACS expects exactly `mikrotik_router.zip` — the version suffix caused 404 download errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)