### PR TITLE
fix: release zip structure for HACS compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Create release zip
-        run: cd custom_components && zip -r ../mikrotik_router.zip mikrotik_router/
+        run: cd custom_components/mikrotik_router && zip -r ../../mikrotik_router.zip ./
 
       - name: Generate SBOM
         uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d  # v0


### PR DESCRIPTION
## Summary
- Fix release workflow zip structure: files must be at zip root, not nested under `mikrotik_router/`
- HACS extracts directly into `custom_components/mikrotik_router/`, so nesting caused "Integration not found"
- Matches the v2.3.8 workflow that worked correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)