### PR TITLE
fix: restore SENSOR_SERVICES imports — integration completely broken

### DIFF
--- a/custom_components/mikrotik_router/binary_sensor.py
+++ b/custom_components/mikrotik_router/binary_sensor.py
@@ -16,6 +16,7 @@ from .const import (
     DEFAULT_SENSOR_PORT_TRACKER,
 )
 from .entity import MikrotikEntity, MikrotikInterfaceEntityMixin, async_add_entities
+from .binary_sensor_types import SENSOR_TYPES, SENSOR_SERVICES  # noqa: F401
 
 _LOGGER = getLogger(__name__)
 

--- a/custom_components/mikrotik_router/button.py
+++ b/custom_components/mikrotik_router/button.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import MikrotikEntity, async_add_entities
+from .button_types import SENSOR_TYPES, SENSOR_SERVICES  # noqa: F401
 from .exceptions import ApiEntryNotFound
 
 _LOGGER = getLogger(__name__)

--- a/custom_components/mikrotik_router/device_tracker.py
+++ b/custom_components/mikrotik_router/device_tracker.py
@@ -19,6 +19,7 @@ from homeassistant.util.dt import utcnow
 from homeassistant.components.device_tracker.const import SourceType
 
 from .coordinator import MikrotikCoordinator
+from .device_tracker_types import SENSOR_TYPES, SENSOR_SERVICES  # noqa: F401
 from .entity import _run_entity_setup_loop, MikrotikEntity
 from .helper import format_attribute
 from .const import (

--- a/custom_components/mikrotik_router/sensor.py
+++ b/custom_components/mikrotik_router/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import MikrotikCoordinator
 from .entity import MikrotikEntity, MikrotikInterfaceEntityMixin, async_add_entities
+from .sensor_types import SENSOR_TYPES, SENSOR_SERVICES  # noqa: F401
 
 _LOGGER = getLogger(__name__)
 

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -14,6 +14,8 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .entity import MikrotikEntity, copy_attrs, async_add_entities
 from .switch_types import (
+    SENSOR_TYPES,  # noqa: F401
+    SENSOR_SERVICES,  # noqa: F401
     DEVICE_ATTRIBUTES_IFACE_ETHER,
     DEVICE_ATTRIBUTES_IFACE_SFP,
     DEVICE_ATTRIBUTES_IFACE_WIRELESS,

--- a/custom_components/mikrotik_router/update.py
+++ b/custom_components/mikrotik_router/update.py
@@ -19,6 +19,7 @@ from homeassistant.components.update import (
 
 from .coordinator import MikrotikCoordinator
 from .entity import MikrotikEntity, async_add_entities
+from .update_types import SENSOR_TYPES, SENSOR_SERVICES  # noqa: F401
 from packaging.version import Version
 
 _LOGGER = getLogger(__name__)


### PR DESCRIPTION
## Summary
- Restores `SENSOR_SERVICES` and `SENSOR_TYPES` imports to all 6 platform modules
- These were removed by ruff F401 in PR #29 as "unused imports"
- They are accessed at runtime via `platform.platform.SENSOR_SERVICES` in entity.py:208
- Without them, every platform fails: `AttributeError: module has no attribute 'SENSOR_SERVICES'`
- Added `# noqa: F401` to prevent future removal

**This is a critical hotfix** — the integration is completely non-functional without these imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)