### PR TITLE
chore: bump v2.3.10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-- **Domain:** `mikrotik_router` | **Version:** 2.3.8 | **IoT:** `local_polling` (30s)
+- **Domain:** `mikrotik_router` | **Version:** 2.3.10 | **IoT:** `local_polling` (30s)
 - **HA Min:** 2024.3.0 | **Python:** 3.13 | **Fork of:** `tomaae/homeassistant-mikrotik_router`
 - **Deps:** `librouteros>=3.4.1`, `mac-vendor-lookup>=0.1.12`
 - **Platforms:** sensor, binary_sensor, switch, button, device_tracker, update

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
-## What's New — v2.3.9
+## What's New — v2.3.10
+
+**Device tracker fix** — ARP entries with `"incomplete"` status were incorrectly treated as reachable, causing devices to show as "home" when they were actually unreachable. Both `"failed"` and `"incomplete"` ARP statuses are now filtered. See [ADR-001](docs/decisions/ADR-001-arp-failed-filtering.md).
+
+<details>
+<summary>Previous: v2.3.9 — Upstream feature ports</summary>
 
 Four upstream feature requests implemented.
 
@@ -27,6 +32,8 @@ Four upstream feature requests implemented.
 | **Script env refresh** | Coordinator refreshes immediately after script button press — environment variables update without waiting for next poll. | [#298](https://github.com/tomaae/homeassistant-mikrotik_router/issues/298) |
 
 Also includes: cognitive complexity reduction (ADR-007), 461 automated tests, ruff migration, and CI/CD improvements from v2.3.8 dev work.
+
+</details>
 
 <details>
 <summary>Previous: v2.3.8 — Bug fixes</summary>

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -2390,6 +2390,15 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
     # ---------------------------
     #   _merge_arp_hosts
     # ---------------------------
+    # RouterOS ARP statuses (Linux neighbor table states):
+    #   ""          – static entry or no explicit status  → reachable
+    #   reachable   – confirmed via ARP reply             → reachable
+    #   stale       – previously reachable, not refreshed → reachable
+    #   delay       – waiting for confirmation probe      → reachable (transitional)
+    #   probe       – actively sending ARP probes         → reachable (transitional)
+    #   noarp       – interface doesn't use ARP           → reachable
+    #   incomplete  – ARP request sent, no reply yet      → UNREACHABLE
+    #   failed      – ARP resolution failed               → UNREACHABLE
     _ARP_UNREACHABLE_STATUSES = frozenset({"failed", "incomplete"})
 
     def _merge_arp_hosts(self) -> dict:

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -2390,17 +2390,19 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
     # ---------------------------
     #   _merge_arp_hosts
     # ---------------------------
+    _ARP_UNREACHABLE_STATUSES = frozenset({"failed", "incomplete"})
+
     def _merge_arp_hosts(self) -> dict:
         """Merge ARP hosts into ds['host'] and return detected set.
 
-        Only count non-failed ARP entries as detected — failed entries
-        indicate the device is unreachable (#17).  We keep failed entries
-        in ds["arp"] so that bridge-interface lookups still work for the
-        tracker coordinator's ping logic.
+        Only count reachable ARP entries as detected — failed/incomplete
+        entries indicate the device is unreachable (#17).  We keep all
+        entries in ds["arp"] so that bridge-interface lookups still work
+        for the tracker coordinator's ping logic.
         """
         detected = {}
         for uid, vals in self.ds["arp"].items():
-            if vals.get("status") != "failed":
+            if vals.get("status") not in self._ARP_UNREACHABLE_STATUSES:
                 detected[uid] = True
             if uid not in self.ds["host"]:
                 self.ds["host"][uid] = {"source": "arp"}

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.9"
+    "version": "2.3.10"
 }

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -8,7 +8,7 @@ Changes listed in reverse chronological order.
 
 **Date:** 2026-03-24
 **Branch:** `claude/fix-device-tracker-incomplete-nYKrC`
-**Status:** In Progress
+**Status:** Released (v2.3.10)
 
 ### What Changed
 

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,26 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260324-arp-incomplete-filtering — Treat ARP "incomplete" as unreachable
+
+**Date:** 2026-03-24
+**Branch:** `claude/fix-device-tracker-incomplete-nYKrC`
+**Status:** In Progress
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `coordinator.py` | `_merge_arp_hosts()` now excludes both `"failed"` and `"incomplete"` ARP statuses from the detected set via `_ARP_UNREACHABLE_STATUSES` frozenset |
+| `tests/test_coordinator.py` | Updated existing tests and added new test for `"incomplete"` status |
+| `docs/decisions/ADR-001` | Updated to cover `"incomplete"` status alongside `"failed"` |
+
+### Why
+
+Devices with ARP status `"incomplete"` (ARP request sent, no reply received) were incorrectly shown as "home" in the device tracker. Only `"failed"` was being filtered. Both statuses indicate the device is unreachable and should result in `not_home`.
+
+---
+
 ## CR-260322-port-upstream-frs — Port upstream feature requests (#310, #321, #334, #298)
 
 **Date:** 2026-03-22

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -2,45 +2,13 @@
 
 ## Current Priorities
 
-1. ISS-260324-arp-incomplete — ARP "incomplete" status treated as home (fix in progress)
-2. ISS-260322-upstream-frs — Port upstream feature requests (in review)
-3. ISS-260320-test-coverage — Increase test coverage to ≥80%
-4. ISS-260320-new-device-discovery — New devices require HA restart to appear
-5. ISS-260320-deprecated-datetime — Remaining naive datetime.now() calls
+1. ISS-260320-test-coverage — Increase test coverage to ≥80%
+2. ISS-260320-new-device-discovery — New devices require HA restart to appear
+3. ISS-260320-deprecated-datetime — Remaining naive datetime.now() calls
 
 ---
 
 ## Active
-
-### ISS-260324-arp-incomplete — ARP "incomplete" status incorrectly shows device as home
-**Type:** Bug
-**Priority:** High
-**Created:** 2026-03-24
-**Status:** 🟢 Active — fix in progress (claude/fix-device-tracker-incomplete-nYKrC)
-
-**Context:**
-Device tracker showed devices as "home" when ARP status was `"incomplete"`. The `"incomplete"` status means the router sent an ARP request but received no reply — semantically identical to `"failed"`. ADR-001 only covered `"failed"`; now extended to both.
-
-**Fix:** `_merge_arp_hosts()` uses `_ARP_UNREACHABLE_STATUSES = frozenset({"failed", "incomplete"})` instead of checking only `"failed"`.
-
----
-
-### ISS-260322-upstream-frs — Port upstream feature requests
-**Type:** Feature
-**Priority:** High
-**Created:** 2026-03-22
-**Status:** 🟢 Active — PR in review (feature/port-upstream-frs → dev)
-
-**Context:**
-Four upstream feature requests ported from FR branch to refactored `dev`:
-- ✅ tomaae#334: Container monitoring & control (RouterOS 7.4+)
-- ✅ tomaae#310: Firewall RAW rule enable/disable switches
-- ✅ tomaae#321: DHCP client sensors (status, address, gateway, DNS, lease expiry)
-- ✅ tomaae#298: Environment refresh after script execution
-
-**Reference:** ADR-008, CR-260322-port-upstream-frs. 20 new tests, 461 total.
-
----
 
 ### ISS-260320-test-coverage — Increase test coverage to ≥80%
 **Type:** Testing
@@ -191,6 +159,14 @@ Silent-failure audit (pr-review-toolkit:silent-failure-hunter) found 12 issues. 
 ---
 
 ## Completed
+
+### ISS-260324-arp-incomplete — ARP "incomplete" status incorrectly shows device as home
+**Type:** Bug | **Priority:** High | **Created:** 2026-03-24
+**Status:** 🔴 Closed — fixed in v2.3.10 (PR #38)
+
+### ISS-260322-upstream-frs — Port upstream feature requests
+**Type:** Feature | **Priority:** High | **Created:** 2026-03-22
+**Status:** 🔴 Closed — released in v2.3.9 (PR #32)
 
 ### ISS-260320-options-flow-crash — Options flow crash on HA 2025.12+
 **Type:** Bug | **Priority:** Critical | **Created:** 2026-03-20

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -2,14 +2,28 @@
 
 ## Current Priorities
 
-1. ISS-260322-upstream-frs — Port upstream feature requests (in review)
-2. ISS-260320-test-coverage — Increase test coverage to ≥80%
-3. ISS-260320-new-device-discovery — New devices require HA restart to appear
-4. ISS-260320-deprecated-datetime — Remaining naive datetime.now() calls
+1. ISS-260324-arp-incomplete — ARP "incomplete" status treated as home (fix in progress)
+2. ISS-260322-upstream-frs — Port upstream feature requests (in review)
+3. ISS-260320-test-coverage — Increase test coverage to ≥80%
+4. ISS-260320-new-device-discovery — New devices require HA restart to appear
+5. ISS-260320-deprecated-datetime — Remaining naive datetime.now() calls
 
 ---
 
 ## Active
+
+### ISS-260324-arp-incomplete — ARP "incomplete" status incorrectly shows device as home
+**Type:** Bug
+**Priority:** High
+**Created:** 2026-03-24
+**Status:** 🟢 Active — fix in progress (claude/fix-device-tracker-incomplete-nYKrC)
+
+**Context:**
+Device tracker showed devices as "home" when ARP status was `"incomplete"`. The `"incomplete"` status means the router sent an ARP request but received no reply — semantically identical to `"failed"`. ADR-001 only covered `"failed"`; now extended to both.
+
+**Fix:** `_merge_arp_hosts()` uses `_ARP_UNREACHABLE_STATUSES = frozenset({"failed", "incomplete"})` instead of checking only `"failed"`.
+
+---
 
 ### ISS-260322-upstream-frs — Port upstream feature requests
 **Type:** Feature

--- a/docs/decisions/ADR-001-arp-failed-filtering.md
+++ b/docs/decisions/ADR-001-arp-failed-filtering.md
@@ -1,21 +1,22 @@
-# ADR-001: ARP Failed-Status Filtering Strategy
+# ADR-001: ARP Unreachable-Status Filtering Strategy
 
 **Date:** 2026-03-20
 **Status:** Accepted
+**Updated:** 2026-03-24 — added `incomplete` status (same semantics as `failed`)
 
 ## Context
 
-ARP entries with `status: failed` were causing devices to incorrectly show as "home" in device tracking. The failed status means the router sent an ARP request but received no reply — the device is unreachable. However, ARP entries are also used for bridge-interface resolution in the device tracker coordinator's ping logic.
+ARP entries with `status: failed` were causing devices to incorrectly show as "home" in device tracking. The failed status means the router sent an ARP request but received no reply — the device is unreachable. The same applies to `status: incomplete`, which MikroTik uses when an ARP resolution is in progress but no reply has been received. However, ARP entries are also used for bridge-interface resolution in the device tracker coordinator's ping logic.
 
 The initial fix (v2.3.6) filtered failed entries in `get_arp()`, but this broke bridge-interface lookups because the entries were removed from `ds["arp"]` entirely.
 
 ## Decision
 
-Filter ARP failed-status entries in `async_process_host()` rather than in `get_arp()`. Failed entries remain in `ds["arp"]` for bridge-interface resolution but are excluded from the `arp_detected` set used for availability checks.
+Filter ARP unreachable-status entries in `async_process_host()` rather than in `get_arp()`. Unreachable entries remain in `ds["arp"]` for bridge-interface resolution but are excluded from the `arp_detected` set used for availability checks.
 
 Specifically:
 - `get_arp()` keeps all ARP entries regardless of status
-- `async_process_host()` builds an `arp_detected` set excluding entries where `status == "failed"`
+- `async_process_host()` builds an `arp_detected` set excluding entries where `status` is in `{"failed", "incomplete"}`
 - Host availability is determined by presence in `arp_detected`, not `ds["arp"]`
 
 ## Alternatives Considered
@@ -29,5 +30,5 @@ Rejected — simpler to filter at the point of use (host processing) than to thr
 ## Consequences
 
 - Bridge-interface resolution continues to work for all hosts including unreachable ones
-- 4 regression tests added to verify the filtering behaviour
+- Regression tests added to verify the filtering behaviour for both statuses
 - Device tracker accurately reflects network reachability

--- a/info.md
+++ b/info.md
@@ -4,7 +4,10 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
-### What's new in v2.3.9
+### What's new in v2.3.10
+- **Device tracker fix** — ARP `"incomplete"` status no longer falsely shows devices as "home" ([PR #38](https://github.com/jnctech/homeassistant-mikrotik_router/pull/38))
+
+### v2.3.9
 - **Firewall RAW switches** — enable/disable individual RAW rules ([upstream #310](https://github.com/tomaae/homeassistant-mikrotik_router/issues/310))
 - **Container monitoring** — monitor and start/stop MikroTik containers, RouterOS 7.4+ ([upstream #334](https://github.com/tomaae/homeassistant-mikrotik_router/issues/334))
 - **DHCP client sensors** — WAN IP, gateway, DNS, lease expiry per interface ([upstream #321](https://github.com/tomaae/homeassistant-mikrotik_router/issues/321))

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -656,10 +656,11 @@ async def test_arp_empty_status_detected():
 
 
 @pytest.mark.asyncio
-async def test_mixed_arp_statuses_only_failed_excluded():
-    """Only 'failed' ARP entries are excluded from detection; others are detected."""
+async def test_mixed_arp_statuses_only_unreachable_excluded():
+    """Only 'failed'/'incomplete' ARP entries are excluded; others are detected."""
     mac_ok = "AA:BB:CC:DD:EE:A1"
     mac_failed = "AA:BB:CC:DD:EE:A2"
+    mac_incomplete = "AA:BB:CC:DD:EE:A3"
     coordinator = make_coordinator_for_host(
         arp_entries={
             mac_ok: {
@@ -674,6 +675,12 @@ async def test_mixed_arp_statuses_only_failed_excluded():
                 "interface": "ether1",
                 "status": "failed",
             },
+            mac_incomplete: {
+                "mac-address": mac_incomplete,
+                "address": "192.168.1.62",
+                "interface": "ether1",
+                "status": "incomplete",
+            },
         }
     )
 
@@ -681,6 +688,38 @@ async def test_mixed_arp_statuses_only_failed_excluded():
 
     assert coordinator.ds["host"][mac_ok]["available"] is True
     assert coordinator.ds["host"][mac_failed]["available"] is False
+    assert coordinator.ds["host"][mac_incomplete]["available"] is False
+
+
+@pytest.mark.asyncio
+async def test_arp_incomplete_status_not_detected_but_host_created():
+    """ARP entry with status 'incomplete' is NOT counted as detected.
+
+    'incomplete' means the router sent an ARP request but received no reply —
+    the device is unreachable, same as 'failed'.
+    """
+    mac = "AA:BB:CC:DD:EE:F4"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac: {
+                "mac-address": mac,
+                "address": "192.168.1.53",
+                "interface": "ether1",
+                "status": "incomplete",
+                "bridge": "bridge",
+            }
+        }
+    )
+
+    await coordinator.async_process_host()
+
+    # Host entry created (visible in UI) but marked unavailable
+    assert mac in coordinator.ds["host"]
+    assert coordinator.ds["host"][mac]["available"] is False
+
+    # Entry kept in ds["arp"] for bridge lookups
+    assert mac in coordinator.ds["arp"]
+    assert coordinator.ds["arp"][mac]["bridge"] == "bridge"
 
 
 # ---------------------------------------------------------------------------
@@ -3329,8 +3368,8 @@ def test_merge_dhcp_hosts_skips_disabled():
     assert "AA:BB:CC:DD:EE:05" not in coordinator.ds["host"]
 
 
-def test_merge_arp_hosts_returns_detected_excluding_failed():
-    """_merge_arp_hosts returns detected set excluding failed entries."""
+def test_merge_arp_hosts_returns_detected_excluding_unreachable():
+    """_merge_arp_hosts returns detected set excluding failed/incomplete entries."""
     coordinator = make_coordinator_for_host()
     coordinator.ds["arp"] = {
         "AA:BB:CC:DD:EE:06": {
@@ -3345,15 +3384,23 @@ def test_merge_arp_hosts_returns_detected_excluding_failed():
             "interface": "ether1",
             "status": "failed",
         },
+        "AA:BB:CC:DD:EE:08": {
+            "address": "192.168.1.24",
+            "mac-address": "AA:BB:CC:DD:EE:08",
+            "interface": "ether1",
+            "status": "incomplete",
+        },
     }
 
     detected = coordinator._merge_arp_hosts()
 
     assert "AA:BB:CC:DD:EE:06" in detected
     assert "AA:BB:CC:DD:EE:07" not in detected
-    # Both still get added as hosts
+    assert "AA:BB:CC:DD:EE:08" not in detected
+    # All still get added as hosts
     assert "AA:BB:CC:DD:EE:06" in coordinator.ds["host"]
     assert "AA:BB:CC:DD:EE:07" in coordinator.ds["host"]
+    assert "AA:BB:CC:DD:EE:08" in coordinator.ds["host"]
 
 
 def test_recover_hass_hosts_runs_once():


### PR DESCRIPTION
## Summary
- Merge PR #38: fix ARP "incomplete" status incorrectly showing devices as "home"
- Bump version to 2.3.10
- Update docs (CHANGE-REGISTER, ISSUES, ADR-001, README, info.md)

## Test plan
- [ ] Verify device with ARP "incomplete" status shows as `not_home`
- [ ] Verify existing ARP "failed" filtering still works
- [ ] HACS install from release zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)