### PR TITLE
fix: mangle rules with different interfaces incorrectly removed as duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Your existing configuration and entities are preserved — no reconfiguration ne
 ## Feature Highlights
 
 - **Interfaces** — enable/disable, SFP info, RX/TX traffic, connected device IP/MAC, interface presence
-- **PoE monitoring** *(new in v2.3.x)* — per-port status, voltage, current and power for PoE-capable switches
+- **PoE monitoring** *(v2.3.3+)* — per-port status, voltage, current and power for PoE-capable switches
 - **NAT rules** — enable/disable individual rules
 - **Mangle rules** — enable/disable individual rules
 - **Filter rules** — enable/disable individual rules
@@ -168,7 +168,7 @@ Monitor and control status on each MikroTik interface — LAN, WLAN, physical an
 ![Interface Switch](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/interface_switch.png)
 ![Interface Sensor](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/interface_sensor.png)
 
-## PoE Monitoring *(new — v2.3.x pre-release)*
+## PoE Monitoring *(v2.3.3+)*
 Monitor Power over Ethernet (PoE) status and power metrics for each PoE-capable port on your MikroTik switch or router directly in Home Assistant.
 
 More information about PoE-Out can be found on the [MikroTik support page](https://help.mikrotik.com/docs/display/ROS/PoE-Out).
@@ -349,7 +349,7 @@ This integration is distributed using [HACS](https://hacs.xyz/).
 
 **Minimum requirements:**
 - RouterOS v6.43 or v7.1+
-- Home Assistant 0.114.0+
+- Home Assistant 2024.3.0+
 
 ## Setup
 
@@ -404,13 +404,13 @@ This provides device presence detection and per-client traffic stats regardless 
 
 **Affected devices:** RB4011, RB5009, CCR1009, CCR1016, CCR1036, CCR2004, CCR2116, and any MikroTik router where the wireless package is absent.
 
-**Status:** Fixed in the [v2.3.x pre-release](#whats-new--v23x-pre-release). The fix checks which WiFi packages are installed before querying wireless endpoints. ([upstream #433](https://github.com/tomaae/homeassistant-mikrotik_router/issues/433))
+**Status:** Fixed in v2.3.3. The fix checks which WiFi packages are installed before querying wireless endpoints. ([upstream #433](https://github.com/tomaae/homeassistant-mikrotik_router/issues/433))
 
 ## Temperature sensors always show Celsius, ignore Fahrenheit preference
 
 **Affected users:** Home Assistant instances configured for imperial/Fahrenheit units.
 
-**Status:** Fixed in the [v2.3.x pre-release](#whats-new--v23x-pre-release). Temperature sensors now respect HA unit preferences and auto-convert. ([upstream #230](https://github.com/tomaae/homeassistant-mikrotik_router/issues/230))
+**Status:** Fixed in v2.3.3. Temperature sensors now respect HA unit preferences and auto-convert. ([upstream #230](https://github.com/tomaae/homeassistant-mikrotik_router/issues/230))
 
 ---
 

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1165,6 +1165,8 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 {"name": "dst-port", "default": "any"},
                 {"name": "src-address-list", "default": "any"},
                 {"name": "dst-address-list", "default": "any"},
+                {"name": "in-interface", "default": "any"},
+                {"name": "out-interface", "default": "any"},
                 {
                     "name": "enabled",
                     "source": "disabled",
@@ -1193,6 +1195,10 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     {"key": "src-address-list"},
                     {"text": "-"},
                     {"key": "dst-address-list"},
+                    {"text": ","},
+                    {"key": "in-interface"},
+                    {"text": "-"},
+                    {"key": "out-interface"},
                 ],
                 [
                     {"name": "name"},

--- a/custom_components/mikrotik_router/switch_types.py
+++ b/custom_components/mikrotik_router/switch_types.py
@@ -100,6 +100,8 @@ DEVICE_ATTRIBUTES_MANGLE = [
     "src-port",
     "dst-address",
     "dst-port",
+    "in-interface",
+    "out-interface",
     "comment",
 ]
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1510,6 +1510,40 @@ def test_mangle_duplicate_removal():
     assert len(coordinator.ds["mangle"]) == 0
 
 
+def test_mangle_interface_differentiates_rules():
+    """Rules with same chain/action/protocol but different interfaces are not duplicates."""
+    coordinator = make_coordinator(
+        api_responses={
+            "/ip/firewall/mangle": [
+                {
+                    ".id": "*1",
+                    "chain": "forward",
+                    "action": "change MSS",
+                    "protocol": "tcp",
+                    "in-interface": "pppoe-out1",
+                    "disabled": False,
+                },
+                {
+                    ".id": "*2",
+                    "chain": "forward",
+                    "action": "change MSS",
+                    "protocol": "tcp",
+                    "out-interface": "pppoe-out1",
+                    "disabled": False,
+                },
+            ]
+        }
+    )
+    coordinator.mangle_removed = {}
+    coordinator.host = "10.0.0.1"
+    coordinator.get_mangle()
+    assert len(coordinator.ds["mangle"]) == 2
+    assert "*1" in coordinator.ds["mangle"]
+    assert "*2" in coordinator.ds["mangle"]
+    assert coordinator.ds["mangle"]["*1"]["in-interface"] == "pppoe-out1"
+    assert coordinator.ds["mangle"]["*2"]["out-interface"] == "pppoe-out1"
+
+
 # ---------------------------------------------------------------------------
 # Group N: get_filter() — filter rule parsing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Mangle rules that differ only by `in-interface` / `out-interface` (e.g. MSS clamping for inbound vs outbound PPPoE) generated identical unique IDs, causing the duplicate detection to silently remove **both** rules
- Added `in-interface` and `out-interface` to the fetched API fields and the `uniq-id` formula so these rules are correctly differentiated
- Added both fields to `DEVICE_ATTRIBUTES_MANGLE` so they appear as entity attributes
- Updated README: HA minimum version corrected to 2024.3.0, stale "v2.3.x pre-release" references replaced with actual release versions

## Root Cause
The `uniq-id` for mangle rules was built from `chain,action,protocol,src:port-dst:port,src-list-dst-list` — interface fields were not included. Two rules with the same firewall match criteria but different interfaces (common for MSS clamping) produced identical unique IDs and were both deleted by the dedup logic.

## Test Plan
- [x] New test: `test_mangle_interface_differentiates_rules` — two rules with same chain/action/protocol but different in/out interfaces are both kept
- [x] Existing tests pass: `test_mangle_basic_rule`, `test_mangle_skips_dynamic_and_jump`, `test_mangle_duplicate_removal`
- [ ] Verify on live router: mangle rules appear as switches after enabling Mangle in integration options

🤖 Generated with [Claude Code](https://claude.com/claude-code)