### PR TITLE
fix: remove ~1300 junk attributes from interface and tracker entities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-- **Domain:** `mikrotik_router` | **Version:** 2.3.10 | **IoT:** `local_polling` (30s)
+- **Domain:** `mikrotik_router` | **Version:** 2.3.11-beta.1 | **IoT:** `local_polling` (30s)
 - **HA Min:** 2024.3.0 | **Python:** 3.13 | **Fork of:** `tomaae/homeassistant-mikrotik_router`
 - **Deps:** `librouteros>=3.4.1`, `mac-vendor-lookup>=0.1.12`
 - **Platforms:** sensor, binary_sensor, switch, button, device_tracker, update

--- a/README.md
+++ b/README.md
@@ -15,9 +15,26 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
-## What's New — v2.3.10
+## What's New — v2.3.11-beta.1
+
+**Attribute cleanup** — Removed ~1,300 meaningless default attributes from interface and device tracker entities across all devices:
+
+| Fix | Before | After |
+|-----|--------|-------|
+| SFP attributes on copper ports | 16 "unknown" SFP attrs per copper port | Only shown on actual SFP ports |
+| Copper attributes on SFP ports | `rate`, `full-duplex` on SFP | Only shown on copper ports |
+| PoE on non-PoE ports | `poe_out: "N/A"` everywhere | Only shown on PoE-capable ports |
+| Client IP/MAC on non-client interfaces | `"unknown"`/`"none"` on loopback, VLAN, PPPoE, WireGuard | Only shown when values are real |
+| Wireless metrics on wired hosts | `signal_strength`, `tx_ccq` on ARP-tracked devices | Only shown for wireless/CAPsMAN hosts |
+
+**Mangle fix** — Rules differing only by `in-interface`/`out-interface` (e.g. MSS clamping for inbound vs outbound PPPoE) were silently removed as duplicates. Interface fields now included in rule unique ID. ([PR #40](https://github.com/jnctech/homeassistant-mikrotik_router/pull/40))
+
+<details>
+<summary>Previous: v2.3.10 — Device tracker fix</summary>
 
 **Device tracker fix** — ARP entries with `"incomplete"` status were incorrectly treated as reachable, causing devices to show as "home" when they were actually unreachable. Both `"failed"` and `"incomplete"` ARP statuses are now filtered. See [ADR-001](docs/decisions/ADR-001-arp-failed-filtering.md).
+
+</details>
 
 <details>
 <summary>Previous: v2.3.9 — Upstream feature ports</summary>

--- a/custom_components/mikrotik_router/device_tracker.py
+++ b/custom_components/mikrotik_router/device_tracker.py
@@ -19,8 +19,12 @@ from homeassistant.util.dt import utcnow
 from homeassistant.components.device_tracker.const import SourceType
 
 from .coordinator import MikrotikCoordinator
-from .device_tracker_types import SENSOR_TYPES, SENSOR_SERVICES  # noqa: F401
-from .entity import _run_entity_setup_loop, MikrotikEntity
+from .device_tracker_types import (
+    SENSOR_TYPES,  # noqa: F401
+    SENSOR_SERVICES,  # noqa: F401
+    DEVICE_ATTRIBUTES_HOST_WIRELESS,
+)
+from .entity import _run_entity_setup_loop, MikrotikEntity, copy_attrs
 from .helper import format_attribute
 from .const import (
     DOMAIN,
@@ -190,5 +194,9 @@ class MikrotikHostDeviceTracker(MikrotikDeviceTracker):
 
         if not attributes[format_attribute("last-seen")]:
             attributes[format_attribute("last-seen")] = "Unknown"
+
+        # Wireless metrics only for wireless/capsman hosts
+        if self._data.get("source") in ("capsman", "wireless"):
+            copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_HOST_WIRELESS)
 
         return attributes

--- a/custom_components/mikrotik_router/device_tracker_types.py
+++ b/custom_components/mikrotik_router/device_tracker_types.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.components.switch import (
@@ -45,7 +44,7 @@ class MikrotikDeviceTrackerEntityDescription(SwitchEntityDescription):
     data_name_comment: bool = False
     data_uid: str | None = None
     data_reference: str | None = None
-    data_attributes_list: List = field(default_factory=lambda: [])
+    data_attributes_list: list = field(default_factory=lambda: [])
     func: str = "MikrotikDeviceTracker"
 
 

--- a/custom_components/mikrotik_router/device_tracker_types.py
+++ b/custom_components/mikrotik_router/device_tracker_types.py
@@ -16,6 +16,10 @@ DEVICE_ATTRIBUTES_HOST = [
     "authorized",
     "bypassed",
     "last-seen",
+]
+
+# Only shown for wireless/capsman hosts.
+DEVICE_ATTRIBUTES_HOST_WIRELESS = [
     "signal-strength",
     "tx-ccq",
     "tx-rate",

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -35,6 +35,7 @@ from .const import (
 from .coordinator import MikrotikCoordinator, MikrotikTrackerCoordinator
 from .helper import format_attribute
 from .iface_attributes import (
+    DEVICE_ATTRIBUTES_IFACE_CLIENT,
     DEVICE_ATTRIBUTES_IFACE_ETHER,
     DEVICE_ATTRIBUTES_IFACE_SFP,
     DEVICE_ATTRIBUTES_IFACE_WIRELESS,
@@ -43,11 +44,26 @@ from .iface_attributes import (
 _LOGGER = getLogger(__name__)
 
 
-def copy_attrs(attributes: dict, data: dict, variables: list) -> None:
-    """Copy data values for each variable in the list into attributes."""
+_JUNK_DEFAULTS = frozenset({"unknown", "none", "N/A"})
+
+
+def copy_attrs(
+    attributes: dict, data: dict, variables: list, *, skip_junk: bool = False
+) -> None:
+    """Copy data values for each variable in the list into attributes.
+
+    When *skip_junk* is True, values that are meaningless defaults
+    ("unknown", "none", "N/A", or None) are omitted so that entities
+    only expose attributes that carry real information.
+    """
     for variable in variables:
         if variable in data:
-            attributes[format_attribute(variable)] = data[variable]
+            value = data[variable]
+            if skip_junk and (
+                value is None or (isinstance(value, str) and value in _JUNK_DEFAULTS)
+            ):
+                continue
+            attributes[format_attribute(variable)] = value
 
 
 class MikrotikInterfaceEntityMixin:
@@ -62,10 +78,33 @@ class MikrotikInterfaceEntityMixin:
         """Return type-specific interface state attributes."""
         attributes = super().extra_state_attributes
 
+        # Client IP/MAC — only when values are meaningful
+        copy_attrs(
+            attributes,
+            self._data,
+            DEVICE_ATTRIBUTES_IFACE_CLIENT,
+            skip_junk=True,
+        )
+
         if self._data.get("type") == "ether":
-            copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_ETHER)
-            if "sfp-shutdown-temperature" in self._data:
-                copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_SFP)
+            has_sfp = self._data.get("sfp-shutdown-temperature") not in (
+                0,
+                "",
+                None,
+            )
+            if has_sfp:
+                copy_attrs(
+                    attributes,
+                    self._data,
+                    DEVICE_ATTRIBUTES_IFACE_SFP,
+                    skip_junk=True,
+                )
+            else:
+                copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_ETHER)
+            # PoE — only when the port actually supports it
+            poe_out = self._data.get("poe-out")
+            if poe_out not in (None, "N/A", ""):
+                attributes[format_attribute("poe-out")] = poe_out
         elif self._data.get("type") == "wlan":
             copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_WIRELESS)
 

--- a/custom_components/mikrotik_router/iface_attributes.py
+++ b/custom_components/mikrotik_router/iface_attributes.py
@@ -4,8 +4,6 @@ DEVICE_ATTRIBUTES_IFACE = [
     "running",
     "enabled",
     "comment",
-    "client-ip-address",
-    "client-mac-address",
     "port-mac-address",
     "last-link-down-time",
     "last-link-up-time",
@@ -15,13 +13,18 @@ DEVICE_ATTRIBUTES_IFACE = [
     "name",
 ]
 
+# Shown only when client tracking is enabled and values are meaningful.
+DEVICE_ATTRIBUTES_IFACE_CLIENT = [
+    "client-ip-address",
+    "client-mac-address",
+]
+
 DEVICE_ATTRIBUTES_IFACE_ETHER = [
     "status",
     "auto-negotiation",
     "rate",
     "full-duplex",
     "default-name",
-    "poe-out",
 ]
 
 DEVICE_ATTRIBUTES_IFACE_SFP = [

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.10"
+    "version": "2.3.11-beta.1"
 }

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .entity import MikrotikEntity, copy_attrs, async_add_entities
+from .helper import format_attribute
 from .switch_types import (
     SENSOR_TYPES,  # noqa: F401
     SENSOR_SERVICES,  # noqa: F401
@@ -20,6 +21,7 @@ from .switch_types import (
     DEVICE_ATTRIBUTES_IFACE_SFP,
     DEVICE_ATTRIBUTES_IFACE_WIRELESS,
 )
+from .iface_attributes import DEVICE_ATTRIBUTES_IFACE_CLIENT
 
 _LOGGER = getLogger(__name__)
 
@@ -106,10 +108,33 @@ class MikrotikPortSwitch(MikrotikSwitch):
         """Return the state attributes."""
         attributes = super().extra_state_attributes
 
+        # Client IP/MAC — only when values are meaningful
+        copy_attrs(
+            attributes,
+            self._data,
+            DEVICE_ATTRIBUTES_IFACE_CLIENT,
+            skip_junk=True,
+        )
+
         if self._data["type"] == "ether":
-            copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_ETHER)
-            if "sfp-shutdown-temperature" in self._data:
-                copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_SFP)
+            has_sfp = self._data.get("sfp-shutdown-temperature") not in (
+                0,
+                "",
+                None,
+            )
+            if has_sfp:
+                copy_attrs(
+                    attributes,
+                    self._data,
+                    DEVICE_ATTRIBUTES_IFACE_SFP,
+                    skip_junk=True,
+                )
+            else:
+                copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_ETHER)
+            # PoE — only when the port actually supports it
+            poe_out = self._data.get("poe-out")
+            if poe_out not in (None, "N/A", ""):
+                attributes[format_attribute("poe-out")] = poe_out
         elif self._data["type"] == "wlan":
             copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_WIRELESS)
 

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from logging import getLogger
-from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
@@ -12,16 +11,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .entity import MikrotikEntity, copy_attrs, async_add_entities
-from .helper import format_attribute
+from .entity import MikrotikEntity, MikrotikInterfaceEntityMixin, async_add_entities
 from .switch_types import (
     SENSOR_TYPES,  # noqa: F401
     SENSOR_SERVICES,  # noqa: F401
-    DEVICE_ATTRIBUTES_IFACE_ETHER,
-    DEVICE_ATTRIBUTES_IFACE_SFP,
-    DEVICE_ATTRIBUTES_IFACE_WIRELESS,
 )
-from .iface_attributes import DEVICE_ATTRIBUTES_IFACE_CLIENT
 
 _LOGGER = getLogger(__name__)
 
@@ -100,45 +94,8 @@ class MikrotikSwitch(MikrotikEntity, SwitchEntity, RestoreEntity):
 # ---------------------------
 #   MikrotikPortSwitch
 # ---------------------------
-class MikrotikPortSwitch(MikrotikSwitch):
+class MikrotikPortSwitch(MikrotikInterfaceEntityMixin, MikrotikSwitch):
     """Representation of a network port switch."""
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any]:
-        """Return the state attributes."""
-        attributes = super().extra_state_attributes
-
-        # Client IP/MAC — only when values are meaningful
-        copy_attrs(
-            attributes,
-            self._data,
-            DEVICE_ATTRIBUTES_IFACE_CLIENT,
-            skip_junk=True,
-        )
-
-        if self._data["type"] == "ether":
-            has_sfp = self._data.get("sfp-shutdown-temperature") not in (
-                0,
-                "",
-                None,
-            )
-            if has_sfp:
-                copy_attrs(
-                    attributes,
-                    self._data,
-                    DEVICE_ATTRIBUTES_IFACE_SFP,
-                    skip_junk=True,
-                )
-            else:
-                copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_ETHER)
-            # PoE — only when the port actually supports it
-            poe_out = self._data.get("poe-out")
-            if poe_out not in (None, "N/A", ""):
-                attributes[format_attribute("poe-out")] = poe_out
-        elif self._data["type"] == "wlan":
-            copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_WIRELESS)
-
-        return attributes
 
     @property
     def icon(self) -> str:

--- a/custom_components/mikrotik_router/switch_types.py
+++ b/custom_components/mikrotik_router/switch_types.py
@@ -16,8 +16,6 @@ DEVICE_ATTRIBUTES_IFACE = [
     "running",
     "enabled",
     "comment",
-    "client-ip-address",
-    "client-mac-address",
     "port-mac-address",
     "last-link-down-time",
     "last-link-up-time",
@@ -33,7 +31,6 @@ DEVICE_ATTRIBUTES_IFACE_ETHER = [
     "rate",
     "full-duplex",
     "default-name",
-    "poe-out",
 ]
 
 DEVICE_ATTRIBUTES_IFACE_SFP = [

--- a/custom_components/mikrotik_router/switch_types.py
+++ b/custom_components/mikrotik_router/switch_types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
+
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -11,73 +11,7 @@ from homeassistant.components.switch import (
 )
 
 from .const import DOMAIN
-
-DEVICE_ATTRIBUTES_IFACE = [
-    "running",
-    "enabled",
-    "comment",
-    "port-mac-address",
-    "last-link-down-time",
-    "last-link-up-time",
-    "link-downs",
-    "actual-mtu",
-    "type",
-    "name",
-]
-
-DEVICE_ATTRIBUTES_IFACE_ETHER = [
-    "status",
-    "auto-negotiation",
-    "rate",
-    "full-duplex",
-    "default-name",
-]
-
-DEVICE_ATTRIBUTES_IFACE_SFP = [
-    "status",
-    "auto-negotiation",
-    "advertising",
-    "link-partner-advertising",
-    "sfp-temperature",
-    "sfp-supply-voltage",
-    "sfp-module-present",
-    "sfp-tx-bias-current",
-    "sfp-tx-power",
-    "sfp-rx-power",
-    "sfp-rx-loss",
-    "sfp-tx-fault",
-    "sfp-type",
-    "sfp-connector-type",
-    "sfp-vendor-name",
-    "sfp-vendor-part-number",
-    "sfp-vendor-revision",
-    "sfp-vendor-serial",
-    "sfp-manufacturing-date",
-    "eeprom-checksum",
-]
-
-DEVICE_ATTRIBUTES_IFACE_WIRELESS = [
-    "ssid",
-    "mode",
-    "radio-name",
-    "interface-type",
-    "country",
-    "installation",
-    "antenna-gain",
-    "frequency",
-    "band",
-    "channel-width",
-    "secondary-frequency",
-    "wireless-protocol",
-    "rate-set",
-    "distance",
-    "tx-power-mode",
-    "vlan-id",
-    "wds-mode",
-    "wds-default-bridge",
-    "bridge-mode",
-    "hide-ssid",
-]
+from .iface_attributes import DEVICE_ATTRIBUTES_IFACE
 
 DEVICE_ATTRIBUTES_NAT = [
     "protocol",
@@ -200,7 +134,7 @@ class MikrotikSwitchEntityDescription(SwitchEntityDescription):
     data_name_comment: bool = False
     data_uid: str | None = None
     data_reference: str | None = None
-    data_attributes_list: List = field(default_factory=lambda: [])
+    data_attributes_list: list = field(default_factory=lambda: [])
     func: str = "MikrotikSwitch"
 
 

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,71 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260325-attribute-cleanup — Remove junk attributes from interface and tracker entities
+
+**Date:** 2026-03-25
+**Branch:** `feature/attribute-cleanup`
+**Status:** Beta (v2.3.11-beta.1)
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `entity.py` | `MikrotikInterfaceEntityMixin` now uses exclusive SFP/copper attribute selection based on `sfp-shutdown-temperature` value (not key existence); adds `client-ip/mac` and `poe-out` conditionally; `copy_attrs` gains `skip_junk` parameter to filter "unknown"/"none"/"N/A"/None values |
+| `switch.py` | `MikrotikPortSwitch` now inherits `MikrotikInterfaceEntityMixin` instead of duplicating attribute logic (-41 lines) |
+| `iface_attributes.py` | Moved `client-ip-address`/`client-mac-address` to new `DEVICE_ATTRIBUTES_IFACE_CLIENT` list; removed `poe-out` from `DEVICE_ATTRIBUTES_IFACE_ETHER` |
+| `switch_types.py` | Eliminated 4 duplicated attribute lists — now imports from `iface_attributes.py` (-66 lines) |
+| `device_tracker.py` | Wireless attrs (`signal-strength`, `tx-ccq`, `tx/rx-rate`) only added for wireless/capsman hosts |
+| `device_tracker_types.py` | Split `DEVICE_ATTRIBUTES_HOST_WIRELESS` from `DEVICE_ATTRIBUTES_HOST` |
+| `tests/` | 10 new tests (SFP/copper exclusivity, skip_junk, poe-out conditional, client filtering, wireless tracker attrs); 472 total |
+
+### Why
+
+Entity attributes were polluted with ~1,300 meaningless defaults across 3 tested devices (rb4011, hapax3, hapac2/csr310). Root cause: `parse_api` adds all declared fields with defaults, then `copy_attrs` unconditionally includes them. Key examples:
+- 16 SFP attributes (all "unknown") on every copper ethernet port
+- `poe_out: "N/A"` on every non-PoE port
+- `client_ip_address: "unknown"` on loopback, vlan, pppoe, wireguard, bonding interfaces
+- `signal_strength`, `tx_ccq` on wired device tracker hosts
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint | 0 errors | ✅ |
+| Ruff format | 0 reformats needed | ✅ |
+| Tests | 472 passed, 5 skipped | ✅ |
+
+---
+
+## CR-260325-mangle-interface-dedup — Include interface fields in mangle rule unique ID
+
+**Date:** 2026-03-25
+**Branch:** `fix/mangle-duplicate-interface`
+**PR:** #40 (targeting dev)
+**Status:** In Review
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `coordinator.py` | Added `in-interface` and `out-interface` to mangle `uniq-id` formula and API query fields |
+| `switch_types.py` | Added `in-interface` and `out-interface` to `DEVICE_ATTRIBUTES_MANGLE` |
+| `tests/` | New test: `test_mangle_interface_differentiates_rules` |
+
+### Why
+
+Mangle rules differing only by `in-interface`/`out-interface` (e.g. MSS clamping for inbound vs outbound PPPoE) generated identical unique IDs, causing the duplicate detection to silently remove both rules.
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint | 0 errors | ✅ |
+| Ruff format | 0 reformats needed | ✅ |
+| Tests | 472 passed, 5 skipped | ✅ |
+
+---
+
 ## CR-260324-arp-incomplete-filtering — Treat ARP "incomplete" as unreachable
 
 **Date:** 2026-03-24

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -160,6 +160,14 @@ Silent-failure audit (pr-review-toolkit:silent-failure-hunter) found 12 issues. 
 
 ## Completed
 
+### ISS-260325-attribute-bloat — ~1300 junk attributes on interface and tracker entities
+**Type:** Bug/Quality | **Priority:** High | **Created:** 2026-03-25
+**Status:** 🔴 Closed — fixed in v2.3.11-beta.1 (feature/attribute-cleanup)
+
+### ISS-260325-mangle-dedup — Mangle rules with different interfaces removed as duplicates
+**Type:** Bug | **Priority:** High | **Created:** 2026-03-25
+**Status:** 🔴 Closed — fixed in PR #40 (fix/mangle-duplicate-interface)
+
 ### ISS-260324-arp-incomplete — ARP "incomplete" status incorrectly shows device as home
 **Type:** Bug | **Priority:** High | **Created:** 2026-03-24
 **Status:** 🔴 Closed — fixed in v2.3.10 (PR #38)

--- a/info.md
+++ b/info.md
@@ -4,7 +4,11 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
-### What's new in v2.3.10
+### What's new in v2.3.11-beta.1
+- **Attribute cleanup** — Removed ~1,300 meaningless default attributes (SFP fields on copper ports, PoE on non-PoE, client IP on loopback/VLAN, wireless metrics on wired hosts)
+- **Mangle fix** — Rules differing only by interface were silently dropped as duplicates ([PR #40](https://github.com/jnctech/homeassistant-mikrotik_router/pull/40))
+
+### v2.3.10
 - **Device tracker fix** — ARP `"incomplete"` status no longer falsely shows devices as "home" ([PR #38](https://github.com/jnctech/homeassistant-mikrotik_router/pull/38))
 
 ### v2.3.9

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -246,3 +246,55 @@ class TestMikrotikHostDeviceTracker:
         )
         attrs = entity.extra_state_attributes
         assert attrs["last_seen"] == "Unknown"
+
+    def test_extra_state_attributes_wireless_host_shows_signal_attrs(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: True})
+        coord.data["host"] = {
+            "mac1": _host_data(
+                source="wireless",
+                available=True,
+                **{
+                    "signal-strength": -55,
+                    "tx-ccq": 90,
+                    "tx-rate": "54Mbps",
+                    "rx-rate": "72Mbps",
+                },
+            )
+        }
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        attrs = entity.extra_state_attributes
+        assert attrs["signal_strength"] == -55
+        assert attrs["tx_ccq"] == 90
+        assert attrs["tx_rate"] == "54Mbps"
+        assert attrs["rx_rate"] == "72Mbps"
+
+    def test_extra_state_attributes_wired_host_no_wireless_attrs(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: True})
+        coord.data["host"] = {
+            "mac1": _host_data(
+                source="arp",
+                available=True,
+                **{
+                    "signal-strength": 0,
+                    "tx-ccq": 0,
+                    "tx-rate": "",
+                    "rx-rate": "",
+                },
+            )
+        }
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        attrs = entity.extra_state_attributes
+        assert "signal_strength" not in attrs
+        assert "tx_ccq" not in attrs
+        assert "tx_rate" not in attrs
+        assert "rx_rate" not in attrs

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -566,6 +566,9 @@ def test_mixin_ether_adds_ether_attributes():
     assert attrs["status"] == "link-ok"
     assert "rate" in attrs
     assert attrs["rate"] == "1Gbps"
+    # SFP attrs should NOT be present on copper ports
+    assert "sfp_temperature" not in attrs
+    assert "sfp_vendor_name" not in attrs
 
 
 def test_mixin_ether_skips_missing_ether_keys():
@@ -591,6 +594,28 @@ def test_mixin_ether_with_sfp_adds_sfp_attributes():
     assert "sfp_temperature" in attrs
     assert attrs["sfp_temperature"] == "45C"
     assert "sfp_vendor_name" in attrs
+    # Copper-only attrs should NOT appear on SFP ports
+    assert "rate" not in attrs
+    assert "full_duplex" not in attrs
+
+
+def test_mixin_ether_sfp_skips_junk_defaults():
+    """SFP attributes with 'unknown' or None values are omitted."""
+    entity = _ConcreteEntity(
+        {
+            "type": "ether",
+            "sfp-shutdown-temperature": "95C",
+            "sfp-temperature": "45C",
+            "sfp-vendor-name": "unknown",
+            "sfp-rx-power": None,
+            "sfp-module-present": "yes",
+        }
+    )
+    attrs = entity.extra_state_attributes
+    assert attrs["sfp_temperature"] == "45C"
+    assert "sfp_vendor_name" not in attrs
+    assert "sfp_rx_power" not in attrs
+    assert attrs["sfp_module_present"] == "yes"
 
 
 def test_mixin_ether_without_sfp_does_not_add_sfp_attributes():
@@ -603,6 +628,64 @@ def test_mixin_ether_without_sfp_does_not_add_sfp_attributes():
     assert "sfp_temperature" not in attrs
 
 
+def test_mixin_ether_sfp_shutdown_temp_zero_means_no_sfp():
+    """sfp-shutdown-temperature defaulting to 0 (coordinator default) is treated as no SFP."""
+    entity = _ConcreteEntity(
+        {
+            "type": "ether",
+            "sfp-shutdown-temperature": 0,
+            "sfp-temperature": 0,
+            "sfp-vendor-name": "unknown",
+            "status": "link-ok",
+            "rate": "1Gbps",
+        }
+    )
+    attrs = entity.extra_state_attributes
+    # Should show copper attrs, NOT SFP attrs
+    assert attrs["status"] == "link-ok"
+    assert attrs["rate"] == "1Gbps"
+    assert "sfp_temperature" not in attrs
+    assert "sfp_vendor_name" not in attrs
+
+
+def test_mixin_ether_poe_out_shown_when_supported():
+    """poe-out is shown only when the port has PoE support."""
+    entity = _ConcreteEntity({"type": "ether", "poe-out": "auto-on"})
+    attrs = entity.extra_state_attributes
+    assert attrs["poe_out"] == "auto-on"
+
+
+def test_mixin_ether_poe_out_hidden_when_na():
+    """poe-out 'N/A' (non-PoE ports) is not shown."""
+    entity = _ConcreteEntity({"type": "ether", "poe-out": "N/A"})
+    attrs = entity.extra_state_attributes
+    assert "poe_out" not in attrs
+
+
+def test_mixin_client_attrs_shown_when_meaningful():
+    """client-ip-address and client-mac-address shown when they have real values."""
+    entity = _ConcreteEntity(
+        {
+            "type": "ether",
+            "client-ip-address": "192.168.1.10",
+            "client-mac-address": "AA:BB:CC:DD:EE:FF",
+        }
+    )
+    attrs = entity.extra_state_attributes
+    assert attrs["client_ip_address"] == "192.168.1.10"
+    assert attrs["client_mac_address"] == "AA:BB:CC:DD:EE:FF"
+
+
+def test_mixin_client_attrs_hidden_when_junk():
+    """client-ip-address and client-mac-address hidden when 'unknown'/'none'."""
+    entity = _ConcreteEntity(
+        {"type": "ether", "client-ip-address": "unknown", "client-mac-address": "none"}
+    )
+    attrs = entity.extra_state_attributes
+    assert "client_ip_address" not in attrs
+    assert "client_mac_address" not in attrs
+
+
 def test_mixin_wlan_adds_wireless_attributes():
     """Wlan-type interface populates wireless-specific attributes."""
     entity = _ConcreteEntity({"type": "wlan", "ssid": "MyWifi", "band": "2ghz-b/g/n"})
@@ -612,13 +695,12 @@ def test_mixin_wlan_adds_wireless_attributes():
     assert "band" in attrs
 
 
-def test_mixin_other_type_adds_no_extra_attributes():
-    """Non-ether/wlan interfaces (e.g. bridge) produce no extra attributes."""
+def test_mixin_other_type_adds_no_type_specific_attributes():
+    """Non-ether/wlan interfaces (e.g. bridge) produce no type-specific attributes."""
     entity = _ConcreteEntity({"type": "bridge", "status": "active"})
     attrs = entity.extra_state_attributes
     assert "status" not in attrs
-    # Only the base attribution key is present
-    assert list(attrs.keys()) == ["attribution"]
+    assert "attribution" in attrs
 
 
 def test_mixin_missing_type_adds_no_extra_attributes():
@@ -626,7 +708,7 @@ def test_mixin_missing_type_adds_no_extra_attributes():
     entity = _ConcreteEntity({"status": "active"})
     attrs = entity.extra_state_attributes
     assert "status" not in attrs
-    assert list(attrs.keys()) == ["attribution"]
+    assert "attribution" in attrs
 
 
 def test_mixin_preserves_base_attributes():
@@ -666,6 +748,43 @@ def testcopy_attrs_empty_variables_list():
     data = {"status": "up"}
     copy_attrs(attributes, data, [])
     assert len(attributes) == 0
+
+
+def testcopy_attrs_skip_junk_filters_defaults():
+    """skip_junk=True omits 'unknown', 'none', 'N/A', and None values."""
+    attributes = {}
+    data = {
+        "real": "link-ok",
+        "junk1": "unknown",
+        "junk2": "none",
+        "junk3": "N/A",
+        "junk4": None,
+        "zero": 0,
+        "empty": "",
+    }
+    copy_attrs(
+        attributes,
+        data,
+        ["real", "junk1", "junk2", "junk3", "junk4", "zero", "empty"],
+        skip_junk=True,
+    )
+    assert attributes["real"] == "link-ok"
+    assert "junk1" not in attributes
+    assert "junk2" not in attributes
+    assert "junk3" not in attributes
+    assert "junk4" not in attributes
+    # 0 and "" are NOT filtered — they can be valid values
+    assert attributes["zero"] == 0
+    assert attributes["empty"] == ""
+
+
+def testcopy_attrs_without_skip_junk_includes_all():
+    """Default skip_junk=False preserves all values including junk defaults."""
+    attributes = {}
+    data = {"status": "unknown", "rate": None}
+    copy_attrs(attributes, data, ["status", "rate"])
+    assert attributes["status"] == "unknown"
+    assert attributes["rate"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Attribute cleanup**: Removed ~1,300 meaningless default attributes from interface sensors, binary sensors, switches, and device tracker entities
  - SFP attributes (16 × "unknown") no longer shown on copper ethernet ports
  - Copper attributes (`rate`, `full-duplex`) no longer shown on SFP ports — lists are now mutually exclusive
  - `poe_out: "N/A"` no longer shown on non-PoE ports
  - `client_ip_address: "unknown"` / `client_mac_address: "none"` no longer shown on loopback, VLAN, PPPoE, WireGuard, bonding interfaces
  - Wireless metrics (`signal_strength`, `tx_ccq`, `tx/rx_rate`) no longer shown on wired device tracker hosts
- **Refactor**: `MikrotikPortSwitch` now inherits `MikrotikInterfaceEntityMixin` instead of duplicating attribute logic (-41 lines)
- **Refactor**: Eliminated 4 duplicated attribute lists from `switch_types.py` — single source of truth in `iface_attributes.py` (-66 lines)
- **`copy_attrs` enhancement**: New `skip_junk` parameter filters "unknown"/"none"/"N/A"/None values at the attribute copy level
- Version bumped to `2.3.11-beta.1` for testing

## Root Cause
`parse_api` adds all declared fields with defaults (e.g. `sfp-shutdown-temperature: 0`, `poe-out: "N/A"`, `client-ip-address: "unknown"`). The condition `if "key" in self._data` always evaluated True since the key was always present. Entity attribute display then unconditionally included these meaningless values.

## Test Plan
- [x] 472 tests pass, 5 skipped
- [x] Ruff lint + format clean
- [x] 10 new tests covering SFP/copper exclusivity, skip_junk filtering, poe-out conditional, client attr filtering, wireless tracker attrs
- [ ] Beta test on rb4011: run HA template to confirm junk attributes eliminated
- [ ] Beta test on hapax3: verify SFP attrs absent on copper ports
- [ ] Beta test: verify mangle rules appear with interface attrs
- [ ] Verify no entity history breakage from removed attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)