### PR TITLE
Release v2.3.11 — Attribute cleanup, mangle fix, SFP monitor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-- **Domain:** `mikrotik_router` | **Version:** 2.3.10 | **IoT:** `local_polling` (30s)
+- **Domain:** `mikrotik_router` | **Version:** 2.3.11-beta.1 | **IoT:** `local_polling` (30s)
 - **HA Min:** 2024.3.0 | **Python:** 3.13 | **Fork of:** `tomaae/homeassistant-mikrotik_router`
 - **Deps:** `librouteros>=3.4.1`, `mac-vendor-lookup>=0.1.12`
 - **Platforms:** sensor, binary_sensor, switch, button, device_tracker, update

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-- **Domain:** `mikrotik_router` | **Version:** 2.3.11-beta.1 | **IoT:** `local_polling` (30s)
+- **Domain:** `mikrotik_router` | **Version:** 2.3.11 | **IoT:** `local_polling` (30s)
 - **HA Min:** 2024.3.0 | **Python:** 3.13 | **Fork of:** `tomaae/homeassistant-mikrotik_router`
 - **Deps:** `librouteros>=3.4.1`, `mac-vendor-lookup>=0.1.12`
 - **Platforms:** sensor, binary_sensor, switch, button, device_tracker, update

--- a/README.md
+++ b/README.md
@@ -15,9 +15,26 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
-## What's New — v2.3.10
+## What's New — v2.3.11-beta.1
+
+**Attribute cleanup** — Removed ~1,300 meaningless default attributes from interface and device tracker entities across all devices:
+
+| Fix | Before | After |
+|-----|--------|-------|
+| SFP attributes on copper ports | 16 "unknown" SFP attrs per copper port | Only shown on actual SFP ports |
+| Copper attributes on SFP ports | `rate`, `full-duplex` on SFP | Only shown on copper ports |
+| PoE on non-PoE ports | `poe_out: "N/A"` everywhere | Only shown on PoE-capable ports |
+| Client IP/MAC on non-client interfaces | `"unknown"`/`"none"` on loopback, VLAN, PPPoE, WireGuard | Only shown when values are real |
+| Wireless metrics on wired hosts | `signal_strength`, `tx_ccq` on ARP-tracked devices | Only shown for wireless/CAPsMAN hosts |
+
+**Mangle fix** — Rules differing only by `in-interface`/`out-interface` (e.g. MSS clamping for inbound vs outbound PPPoE) were silently removed as duplicates. Interface fields now included in rule unique ID. ([PR #40](https://github.com/jnctech/homeassistant-mikrotik_router/pull/40))
+
+<details>
+<summary>Previous: v2.3.10 — Device tracker fix</summary>
 
 **Device tracker fix** — ARP entries with `"incomplete"` status were incorrectly treated as reachable, causing devices to show as "home" when they were actually unreachable. Both `"failed"` and `"incomplete"` ARP statuses are now filtered. See [ADR-001](docs/decisions/ADR-001-arp-failed-filtering.md).
+
+</details>
 
 <details>
 <summary>Previous: v2.3.9 — Upstream feature ports</summary>

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ Your existing configuration and entities are preserved — no reconfiguration ne
 - **Kid Control** — monitor and control internet schedules
 - **Multiple devices** — monitor several MikroTik devices simultaneously
 
+### Roadmap
+For a full analysis of potential new sensors and capabilities, including WireGuard VPN monitoring, address list management, LTE modem stats, certificate expiry alerts, and more, see the [Sensor Gap Analysis](docs/sensor-gap-analysis.md).
+
 ---
 
 # Features

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
-## What's New — v2.3.11-beta.1
+## What's New — v2.3.11
 
-**Attribute cleanup** — Removed ~1,300 meaningless default attributes from interface and device tracker entities across all devices:
+**Attribute cleanup** — Entity attributes now only show information relevant to each port type. Previously, all ethernet ports displayed SFP diagnostics, PoE status, and client tracking fields regardless of hardware capability. Now:
 
-| Fix | Before | After |
-|-----|--------|-------|
-| SFP attributes on copper ports | 16 "unknown" SFP attrs per copper port | Only shown on actual SFP ports |
-| Copper attributes on SFP ports | `rate`, `full-duplex` on SFP | Only shown on copper ports |
-| PoE on non-PoE ports | `poe_out: "N/A"` everywhere | Only shown on PoE-capable ports |
-| Client IP/MAC on non-client interfaces | `"unknown"`/`"none"` on loopback, VLAN, PPPoE, WireGuard | Only shown when values are real |
-| Wireless metrics on wired hosts | `signal_strength`, `tx_ccq` on ARP-tracked devices | Only shown for wireless/CAPsMAN hosts |
+| Attribute type | Before | After |
+|----------------|--------|-------|
+| SFP diagnostics | Shown on all ethernet ports | Only SFP ports |
+| Link rate & duplex | Only copper ports | Both copper and SFP ports |
+| PoE status | Shown as "N/A" on non-PoE ports | Only PoE-capable ports |
+| Client IP/MAC | Shown as "unknown" on all interfaces | Only when a client is connected |
+| Wireless metrics | Shown on all tracked devices | Only wireless/CAPsMAN clients |
 
-**Mangle fix** — Rules differing only by `in-interface`/`out-interface` (e.g. MSS clamping for inbound vs outbound PPPoE) were silently removed as duplicates. Interface fields now included in rule unique ID. ([PR #40](https://github.com/jnctech/homeassistant-mikrotik_router/pull/40))
+**Mangle fix** — Rules differing only by `in-interface`/`out-interface` (e.g. MSS clamping for inbound vs outbound PPPoE) were silently removed as duplicates. Interface fields are now included in the rule unique ID.
 
 <details>
 <summary>Previous: v2.3.10 — Device tracker fix</summary>

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Your existing configuration and entities are preserved — no reconfiguration ne
 ## Feature Highlights
 
 - **Interfaces** — enable/disable, SFP info, RX/TX traffic, connected device IP/MAC, interface presence
-- **PoE monitoring** *(new in v2.3.x)* — per-port status, voltage, current and power for PoE-capable switches
+- **PoE monitoring** *(v2.3.3+)* — per-port status, voltage, current and power for PoE-capable switches
 - **NAT rules** — enable/disable individual rules
 - **Mangle rules** — enable/disable individual rules
 - **Filter rules** — enable/disable individual rules
@@ -168,7 +168,7 @@ Monitor and control status on each MikroTik interface — LAN, WLAN, physical an
 ![Interface Switch](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/interface_switch.png)
 ![Interface Sensor](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/interface_sensor.png)
 
-## PoE Monitoring *(new — v2.3.x pre-release)*
+## PoE Monitoring *(v2.3.3+)*
 Monitor Power over Ethernet (PoE) status and power metrics for each PoE-capable port on your MikroTik switch or router directly in Home Assistant.
 
 More information about PoE-Out can be found on the [MikroTik support page](https://help.mikrotik.com/docs/display/ROS/PoE-Out).
@@ -349,7 +349,7 @@ This integration is distributed using [HACS](https://hacs.xyz/).
 
 **Minimum requirements:**
 - RouterOS v6.43 or v7.1+
-- Home Assistant 0.114.0+
+- Home Assistant 2024.3.0+
 
 ## Setup
 
@@ -404,13 +404,13 @@ This provides device presence detection and per-client traffic stats regardless 
 
 **Affected devices:** RB4011, RB5009, CCR1009, CCR1016, CCR1036, CCR2004, CCR2116, and any MikroTik router where the wireless package is absent.
 
-**Status:** Fixed in the [v2.3.x pre-release](#whats-new--v23x-pre-release). The fix checks which WiFi packages are installed before querying wireless endpoints. ([upstream #433](https://github.com/tomaae/homeassistant-mikrotik_router/issues/433))
+**Status:** Fixed in v2.3.3. The fix checks which WiFi packages are installed before querying wireless endpoints. ([upstream #433](https://github.com/tomaae/homeassistant-mikrotik_router/issues/433))
 
 ## Temperature sensors always show Celsius, ignore Fahrenheit preference
 
 **Affected users:** Home Assistant instances configured for imperial/Fahrenheit units.
 
-**Status:** Fixed in the [v2.3.x pre-release](#whats-new--v23x-pre-release). Temperature sensors now respect HA unit preferences and auto-convert. ([upstream #230](https://github.com/tomaae/homeassistant-mikrotik_router/issues/230))
+**Status:** Fixed in v2.3.3. Temperature sensors now respect HA unit preferences and auto-convert. ([upstream #230](https://github.com/tomaae/homeassistant-mikrotik_router/issues/230))
 
 ---
 

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1165,6 +1165,8 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 {"name": "dst-port", "default": "any"},
                 {"name": "src-address-list", "default": "any"},
                 {"name": "dst-address-list", "default": "any"},
+                {"name": "in-interface", "default": "any"},
+                {"name": "out-interface", "default": "any"},
                 {
                     "name": "enabled",
                     "source": "disabled",
@@ -1193,6 +1195,10 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     {"key": "src-address-list"},
                     {"text": "-"},
                     {"key": "dst-address-list"},
+                    {"text": ","},
+                    {"key": "in-interface"},
+                    {"text": "-"},
+                    {"key": "out-interface"},
                 ],
                 [
                     {"name": "name"},

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -786,10 +786,12 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
     # ---------------------------
     _SFP_MONITOR_VALS = [
         {"name": "status", "default": "unknown"},
+        {"name": "rate", "default": "unknown"},
+        {"name": "full-duplex", "default": "unknown"},
         {"name": "auto-negotiation", "default": "unknown"},
         {"name": "advertising", "default": "unknown"},
         {"name": "link-partner-advertising", "default": "unknown"},
-        {"name": "sfp-temperature", "default": 0},
+        {"name": "sfp-temperature", "default": None},
         {"name": "sfp-supply-voltage", "default": "unknown"},
         {"name": "sfp-module-present", "default": "unknown"},
         {"name": "sfp-tx-bias-current", "default": "unknown"},

--- a/custom_components/mikrotik_router/device_tracker.py
+++ b/custom_components/mikrotik_router/device_tracker.py
@@ -19,8 +19,12 @@ from homeassistant.util.dt import utcnow
 from homeassistant.components.device_tracker.const import SourceType
 
 from .coordinator import MikrotikCoordinator
-from .device_tracker_types import SENSOR_TYPES, SENSOR_SERVICES  # noqa: F401
-from .entity import _run_entity_setup_loop, MikrotikEntity
+from .device_tracker_types import (
+    SENSOR_TYPES,  # noqa: F401
+    SENSOR_SERVICES,  # noqa: F401
+    DEVICE_ATTRIBUTES_HOST_WIRELESS,
+)
+from .entity import _run_entity_setup_loop, MikrotikEntity, copy_attrs
 from .helper import format_attribute
 from .const import (
     DOMAIN,
@@ -190,5 +194,9 @@ class MikrotikHostDeviceTracker(MikrotikDeviceTracker):
 
         if not attributes[format_attribute("last-seen")]:
             attributes[format_attribute("last-seen")] = "Unknown"
+
+        # Wireless metrics only for wireless/capsman hosts
+        if self._data.get("source") in ("capsman", "wireless"):
+            copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_HOST_WIRELESS)
 
         return attributes

--- a/custom_components/mikrotik_router/device_tracker_types.py
+++ b/custom_components/mikrotik_router/device_tracker_types.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.components.switch import (
@@ -45,7 +44,7 @@ class MikrotikDeviceTrackerEntityDescription(SwitchEntityDescription):
     data_name_comment: bool = False
     data_uid: str | None = None
     data_reference: str | None = None
-    data_attributes_list: List = field(default_factory=lambda: [])
+    data_attributes_list: list = field(default_factory=lambda: [])
     func: str = "MikrotikDeviceTracker"
 
 

--- a/custom_components/mikrotik_router/device_tracker_types.py
+++ b/custom_components/mikrotik_router/device_tracker_types.py
@@ -16,6 +16,10 @@ DEVICE_ATTRIBUTES_HOST = [
     "authorized",
     "bypassed",
     "last-seen",
+]
+
+# Only shown for wireless/capsman hosts.
+DEVICE_ATTRIBUTES_HOST_WIRELESS = [
     "signal-strength",
     "tx-ccq",
     "tx-rate",

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -35,6 +35,7 @@ from .const import (
 from .coordinator import MikrotikCoordinator, MikrotikTrackerCoordinator
 from .helper import format_attribute
 from .iface_attributes import (
+    DEVICE_ATTRIBUTES_IFACE_CLIENT,
     DEVICE_ATTRIBUTES_IFACE_ETHER,
     DEVICE_ATTRIBUTES_IFACE_SFP,
     DEVICE_ATTRIBUTES_IFACE_WIRELESS,
@@ -43,11 +44,26 @@ from .iface_attributes import (
 _LOGGER = getLogger(__name__)
 
 
-def copy_attrs(attributes: dict, data: dict, variables: list) -> None:
-    """Copy data values for each variable in the list into attributes."""
+_JUNK_DEFAULTS = frozenset({"unknown", "none", "N/A"})
+
+
+def copy_attrs(
+    attributes: dict, data: dict, variables: list, *, skip_junk: bool = False
+) -> None:
+    """Copy data values for each variable in the list into attributes.
+
+    When *skip_junk* is True, values that are meaningless defaults
+    ("unknown", "none", "N/A", or None) are omitted so that entities
+    only expose attributes that carry real information.
+    """
     for variable in variables:
         if variable in data:
-            attributes[format_attribute(variable)] = data[variable]
+            value = data[variable]
+            if skip_junk and (
+                value is None or (isinstance(value, str) and value in _JUNK_DEFAULTS)
+            ):
+                continue
+            attributes[format_attribute(variable)] = value
 
 
 class MikrotikInterfaceEntityMixin:
@@ -62,10 +78,33 @@ class MikrotikInterfaceEntityMixin:
         """Return type-specific interface state attributes."""
         attributes = super().extra_state_attributes
 
+        # Client IP/MAC — only when values are meaningful
+        copy_attrs(
+            attributes,
+            self._data,
+            DEVICE_ATTRIBUTES_IFACE_CLIENT,
+            skip_junk=True,
+        )
+
         if self._data.get("type") == "ether":
-            copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_ETHER)
-            if "sfp-shutdown-temperature" in self._data:
-                copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_SFP)
+            has_sfp = self._data.get("sfp-shutdown-temperature") not in (
+                0,
+                "",
+                None,
+            )
+            if has_sfp:
+                copy_attrs(
+                    attributes,
+                    self._data,
+                    DEVICE_ATTRIBUTES_IFACE_SFP,
+                    skip_junk=True,
+                )
+            else:
+                copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_ETHER)
+            # PoE — only when the port actually supports it
+            poe_out = self._data.get("poe-out")
+            if poe_out not in (None, "N/A", ""):
+                attributes[format_attribute("poe-out")] = poe_out
         elif self._data.get("type") == "wlan":
             copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_WIRELESS)
 

--- a/custom_components/mikrotik_router/iface_attributes.py
+++ b/custom_components/mikrotik_router/iface_attributes.py
@@ -4,8 +4,6 @@ DEVICE_ATTRIBUTES_IFACE = [
     "running",
     "enabled",
     "comment",
-    "client-ip-address",
-    "client-mac-address",
     "port-mac-address",
     "last-link-down-time",
     "last-link-up-time",
@@ -15,13 +13,18 @@ DEVICE_ATTRIBUTES_IFACE = [
     "name",
 ]
 
+# Shown only when client tracking is enabled and values are meaningful.
+DEVICE_ATTRIBUTES_IFACE_CLIENT = [
+    "client-ip-address",
+    "client-mac-address",
+]
+
 DEVICE_ATTRIBUTES_IFACE_ETHER = [
     "status",
     "auto-negotiation",
     "rate",
     "full-duplex",
     "default-name",
-    "poe-out",
 ]
 
 DEVICE_ATTRIBUTES_IFACE_SFP = [

--- a/custom_components/mikrotik_router/iface_attributes.py
+++ b/custom_components/mikrotik_router/iface_attributes.py
@@ -29,7 +29,10 @@ DEVICE_ATTRIBUTES_IFACE_ETHER = [
 
 DEVICE_ATTRIBUTES_IFACE_SFP = [
     "status",
+    "rate",
+    "full-duplex",
     "auto-negotiation",
+    "default-name",
     "advertising",
     "link-partner-advertising",
     "sfp-temperature",

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.11-beta.1"
+    "version": "2.3.11-beta.2"
 }

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.11-beta.3"
+    "version": "2.3.11"
 }

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.11-beta.2"
+    "version": "2.3.11-beta.3"
 }

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.10"
+    "version": "2.3.11-beta.1"
 }

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .entity import MikrotikEntity, copy_attrs, async_add_entities
+from .helper import format_attribute
 from .switch_types import (
     SENSOR_TYPES,  # noqa: F401
     SENSOR_SERVICES,  # noqa: F401
@@ -20,6 +21,7 @@ from .switch_types import (
     DEVICE_ATTRIBUTES_IFACE_SFP,
     DEVICE_ATTRIBUTES_IFACE_WIRELESS,
 )
+from .iface_attributes import DEVICE_ATTRIBUTES_IFACE_CLIENT
 
 _LOGGER = getLogger(__name__)
 
@@ -106,10 +108,33 @@ class MikrotikPortSwitch(MikrotikSwitch):
         """Return the state attributes."""
         attributes = super().extra_state_attributes
 
+        # Client IP/MAC — only when values are meaningful
+        copy_attrs(
+            attributes,
+            self._data,
+            DEVICE_ATTRIBUTES_IFACE_CLIENT,
+            skip_junk=True,
+        )
+
         if self._data["type"] == "ether":
-            copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_ETHER)
-            if "sfp-shutdown-temperature" in self._data:
-                copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_SFP)
+            has_sfp = self._data.get("sfp-shutdown-temperature") not in (
+                0,
+                "",
+                None,
+            )
+            if has_sfp:
+                copy_attrs(
+                    attributes,
+                    self._data,
+                    DEVICE_ATTRIBUTES_IFACE_SFP,
+                    skip_junk=True,
+                )
+            else:
+                copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_ETHER)
+            # PoE — only when the port actually supports it
+            poe_out = self._data.get("poe-out")
+            if poe_out not in (None, "N/A", ""):
+                attributes[format_attribute("poe-out")] = poe_out
         elif self._data["type"] == "wlan":
             copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_WIRELESS)
 

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from logging import getLogger
-from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
@@ -12,16 +11,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .entity import MikrotikEntity, copy_attrs, async_add_entities
-from .helper import format_attribute
+from .entity import MikrotikEntity, MikrotikInterfaceEntityMixin, async_add_entities
 from .switch_types import (
     SENSOR_TYPES,  # noqa: F401
     SENSOR_SERVICES,  # noqa: F401
-    DEVICE_ATTRIBUTES_IFACE_ETHER,
-    DEVICE_ATTRIBUTES_IFACE_SFP,
-    DEVICE_ATTRIBUTES_IFACE_WIRELESS,
 )
-from .iface_attributes import DEVICE_ATTRIBUTES_IFACE_CLIENT
 
 _LOGGER = getLogger(__name__)
 
@@ -100,45 +94,8 @@ class MikrotikSwitch(MikrotikEntity, SwitchEntity, RestoreEntity):
 # ---------------------------
 #   MikrotikPortSwitch
 # ---------------------------
-class MikrotikPortSwitch(MikrotikSwitch):
+class MikrotikPortSwitch(MikrotikInterfaceEntityMixin, MikrotikSwitch):
     """Representation of a network port switch."""
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any]:
-        """Return the state attributes."""
-        attributes = super().extra_state_attributes
-
-        # Client IP/MAC — only when values are meaningful
-        copy_attrs(
-            attributes,
-            self._data,
-            DEVICE_ATTRIBUTES_IFACE_CLIENT,
-            skip_junk=True,
-        )
-
-        if self._data["type"] == "ether":
-            has_sfp = self._data.get("sfp-shutdown-temperature") not in (
-                0,
-                "",
-                None,
-            )
-            if has_sfp:
-                copy_attrs(
-                    attributes,
-                    self._data,
-                    DEVICE_ATTRIBUTES_IFACE_SFP,
-                    skip_junk=True,
-                )
-            else:
-                copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_ETHER)
-            # PoE — only when the port actually supports it
-            poe_out = self._data.get("poe-out")
-            if poe_out not in (None, "N/A", ""):
-                attributes[format_attribute("poe-out")] = poe_out
-        elif self._data["type"] == "wlan":
-            copy_attrs(attributes, self._data, DEVICE_ATTRIBUTES_IFACE_WIRELESS)
-
-        return attributes
 
     @property
     def icon(self) -> str:

--- a/custom_components/mikrotik_router/switch_types.py
+++ b/custom_components/mikrotik_router/switch_types.py
@@ -16,8 +16,6 @@ DEVICE_ATTRIBUTES_IFACE = [
     "running",
     "enabled",
     "comment",
-    "client-ip-address",
-    "client-mac-address",
     "port-mac-address",
     "last-link-down-time",
     "last-link-up-time",
@@ -33,7 +31,6 @@ DEVICE_ATTRIBUTES_IFACE_ETHER = [
     "rate",
     "full-duplex",
     "default-name",
-    "poe-out",
 ]
 
 DEVICE_ATTRIBUTES_IFACE_SFP = [

--- a/custom_components/mikrotik_router/switch_types.py
+++ b/custom_components/mikrotik_router/switch_types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
+
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -11,73 +11,7 @@ from homeassistant.components.switch import (
 )
 
 from .const import DOMAIN
-
-DEVICE_ATTRIBUTES_IFACE = [
-    "running",
-    "enabled",
-    "comment",
-    "port-mac-address",
-    "last-link-down-time",
-    "last-link-up-time",
-    "link-downs",
-    "actual-mtu",
-    "type",
-    "name",
-]
-
-DEVICE_ATTRIBUTES_IFACE_ETHER = [
-    "status",
-    "auto-negotiation",
-    "rate",
-    "full-duplex",
-    "default-name",
-]
-
-DEVICE_ATTRIBUTES_IFACE_SFP = [
-    "status",
-    "auto-negotiation",
-    "advertising",
-    "link-partner-advertising",
-    "sfp-temperature",
-    "sfp-supply-voltage",
-    "sfp-module-present",
-    "sfp-tx-bias-current",
-    "sfp-tx-power",
-    "sfp-rx-power",
-    "sfp-rx-loss",
-    "sfp-tx-fault",
-    "sfp-type",
-    "sfp-connector-type",
-    "sfp-vendor-name",
-    "sfp-vendor-part-number",
-    "sfp-vendor-revision",
-    "sfp-vendor-serial",
-    "sfp-manufacturing-date",
-    "eeprom-checksum",
-]
-
-DEVICE_ATTRIBUTES_IFACE_WIRELESS = [
-    "ssid",
-    "mode",
-    "radio-name",
-    "interface-type",
-    "country",
-    "installation",
-    "antenna-gain",
-    "frequency",
-    "band",
-    "channel-width",
-    "secondary-frequency",
-    "wireless-protocol",
-    "rate-set",
-    "distance",
-    "tx-power-mode",
-    "vlan-id",
-    "wds-mode",
-    "wds-default-bridge",
-    "bridge-mode",
-    "hide-ssid",
-]
+from .iface_attributes import DEVICE_ATTRIBUTES_IFACE
 
 DEVICE_ATTRIBUTES_NAT = [
     "protocol",
@@ -200,7 +134,7 @@ class MikrotikSwitchEntityDescription(SwitchEntityDescription):
     data_name_comment: bool = False
     data_uid: str | None = None
     data_reference: str | None = None
-    data_attributes_list: List = field(default_factory=lambda: [])
+    data_attributes_list: list = field(default_factory=lambda: [])
     func: str = "MikrotikSwitch"
 
 

--- a/custom_components/mikrotik_router/switch_types.py
+++ b/custom_components/mikrotik_router/switch_types.py
@@ -100,6 +100,8 @@ DEVICE_ATTRIBUTES_MANGLE = [
     "src-port",
     "dst-address",
     "dst-port",
+    "in-interface",
+    "out-interface",
     "comment",
 ]
 

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -8,7 +8,7 @@ Changes listed in reverse chronological order.
 
 **Date:** 2026-03-25
 **Branch:** `feature/attribute-cleanup`
-**Status:** Beta (v2.3.11-beta.1)
+**Status:** Released (v2.3.11)
 
 ### What Changed
 

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,71 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260325-attribute-cleanup — Remove junk attributes from interface and tracker entities
+
+**Date:** 2026-03-25
+**Branch:** `feature/attribute-cleanup`
+**Status:** Beta (v2.3.11-beta.1)
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `entity.py` | `MikrotikInterfaceEntityMixin` now uses exclusive SFP/copper attribute selection based on `sfp-shutdown-temperature` value (not key existence); adds `client-ip/mac` and `poe-out` conditionally; `copy_attrs` gains `skip_junk` parameter to filter "unknown"/"none"/"N/A"/None values |
+| `switch.py` | `MikrotikPortSwitch` now inherits `MikrotikInterfaceEntityMixin` instead of duplicating attribute logic (-41 lines) |
+| `iface_attributes.py` | Moved `client-ip-address`/`client-mac-address` to new `DEVICE_ATTRIBUTES_IFACE_CLIENT` list; removed `poe-out` from `DEVICE_ATTRIBUTES_IFACE_ETHER` |
+| `switch_types.py` | Eliminated 4 duplicated attribute lists — now imports from `iface_attributes.py` (-66 lines) |
+| `device_tracker.py` | Wireless attrs (`signal-strength`, `tx-ccq`, `tx/rx-rate`) only added for wireless/capsman hosts |
+| `device_tracker_types.py` | Split `DEVICE_ATTRIBUTES_HOST_WIRELESS` from `DEVICE_ATTRIBUTES_HOST` |
+| `tests/` | 10 new tests (SFP/copper exclusivity, skip_junk, poe-out conditional, client filtering, wireless tracker attrs); 472 total |
+
+### Why
+
+Entity attributes were polluted with ~1,300 meaningless defaults across 3 tested devices (rb4011, hapax3, hapac2/csr310). Root cause: `parse_api` adds all declared fields with defaults, then `copy_attrs` unconditionally includes them. Key examples:
+- 16 SFP attributes (all "unknown") on every copper ethernet port
+- `poe_out: "N/A"` on every non-PoE port
+- `client_ip_address: "unknown"` on loopback, vlan, pppoe, wireguard, bonding interfaces
+- `signal_strength`, `tx_ccq` on wired device tracker hosts
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint | 0 errors | ✅ |
+| Ruff format | 0 reformats needed | ✅ |
+| Tests | 472 passed, 5 skipped | ✅ |
+
+---
+
+## CR-260325-mangle-interface-dedup — Include interface fields in mangle rule unique ID
+
+**Date:** 2026-03-25
+**Branch:** `fix/mangle-duplicate-interface`
+**PR:** #40 (targeting dev)
+**Status:** In Review
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `coordinator.py` | Added `in-interface` and `out-interface` to mangle `uniq-id` formula and API query fields |
+| `switch_types.py` | Added `in-interface` and `out-interface` to `DEVICE_ATTRIBUTES_MANGLE` |
+| `tests/` | New test: `test_mangle_interface_differentiates_rules` |
+
+### Why
+
+Mangle rules differing only by `in-interface`/`out-interface` (e.g. MSS clamping for inbound vs outbound PPPoE) generated identical unique IDs, causing the duplicate detection to silently remove both rules.
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint | 0 errors | ✅ |
+| Ruff format | 0 reformats needed | ✅ |
+| Tests | 472 passed, 5 skipped | ✅ |
+
+---
+
 ## CR-260324-arp-incomplete-filtering — Treat ARP "incomplete" as unreachable
 
 **Date:** 2026-03-24

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -29,7 +29,7 @@
 - Full HA integration tests: async_setup_entry, async_unload_entry (requires full HA platform machinery)
 - Full coverage measurement and gap analysis
 
-**Reference:** 461 tests passing (303 PR #29, 58 PR #30, 80 PR #31, 20 upstream FR port), target ≥80% for SonarCloud Grade A
+**Reference:** 473 tests passing (303 PR #29, 58 PR #30, 80 PR #31, 20 upstream FR port, 12 attribute cleanup), target ≥80% for SonarCloud Grade A
 
 ---
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -160,6 +160,14 @@ Silent-failure audit (pr-review-toolkit:silent-failure-hunter) found 12 issues. 
 
 ## Completed
 
+### ISS-260325-attribute-bloat — ~1300 junk attributes on interface and tracker entities
+**Type:** Bug/Quality | **Priority:** High | **Created:** 2026-03-25
+**Status:** 🔴 Closed — fixed in v2.3.11-beta.1 (feature/attribute-cleanup)
+
+### ISS-260325-mangle-dedup — Mangle rules with different interfaces removed as duplicates
+**Type:** Bug | **Priority:** High | **Created:** 2026-03-25
+**Status:** 🔴 Closed — fixed in PR #40 (fix/mangle-duplicate-interface)
+
 ### ISS-260324-arp-incomplete — ARP "incomplete" status incorrectly shows device as home
 **Type:** Bug | **Priority:** High | **Created:** 2026-03-24
 **Status:** 🔴 Closed — fixed in v2.3.10 (PR #38)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,27 @@ Large coordinator methods have been decomposed into focused helpers. Each helper
 **Entity skip logic** (`_skip_sensor` orchestrates):
 - `_skip_interface_traffic()`, `_skip_binary_sensor()`, `_skip_device_tracker()`, `_skip_poe_sensor()`
 
+## Attribute Selection Patterns (ADR-009)
+
+Entity attributes are filtered by hardware capability to avoid displaying meaningless defaults.
+
+**`copy_attrs(skip_junk=True)`** — filters `"unknown"`, `"none"`, `"N/A"`, and `None` values. Does NOT filter `0`, `False`, or `""` (valid operational states). Used for SFP diagnostics and client IP/MAC attributes.
+
+**`MikrotikInterfaceEntityMixin`** — shared mixin for `MikrotikInterfaceTrafficSensor`, `MikrotikPortBinarySensor`, and `MikrotikPortSwitch`. Selects attribute set based on interface type:
+
+| Interface type | Detection | Attribute list |
+|----------------|-----------|----------------|
+| Copper ethernet | `sfp-shutdown-temperature` is `0`/empty/absent | `DEVICE_ATTRIBUTES_IFACE_ETHER` |
+| SFP ethernet | `sfp-shutdown-temperature` has real value | `DEVICE_ATTRIBUTES_IFACE_SFP` (with `skip_junk`) |
+| Wireless | `type == "wlan"` | `DEVICE_ATTRIBUTES_IFACE_WIRELESS` |
+
+Additionally:
+- `client-ip-address`/`client-mac-address` — shown only when meaningful (via `DEVICE_ATTRIBUTES_IFACE_CLIENT` + `skip_junk`)
+- `poe-out` — shown only when port has PoE support (not `"N/A"`)
+- Wireless metrics (`signal-strength`, `tx-ccq`, `tx/rx-rate`) — shown only for wireless/CAPsMAN hosts in device tracker
+
+**Canonical attribute lists** live in `iface_attributes.py`. All entity types import from there (no duplicates).
+
 ## Known Caveats
 
 - `ds` dict shared between coordinators (mutation overlap risk)

--- a/docs/decisions/ADR-009-attribute-filtering-by-hardware.md
+++ b/docs/decisions/ADR-009-attribute-filtering-by-hardware.md
@@ -1,0 +1,65 @@
+# ADR-009: Entity Attribute Filtering by Hardware Capability
+
+**Date:** 2026-03-25
+**Status:** Accepted
+
+## Context
+
+All interface entities (sensors, binary sensors, switches, device trackers) displayed every attribute that `parse_api` returned, regardless of hardware type. Since `parse_api` always adds declared fields with default values, entities accumulated irrelevant attributes:
+
+- SFP diagnostics (16 fields) on copper-only ports, all showing "unknown"
+- `poe-out: "N/A"` on ports without PoE hardware
+- `client-ip-address: "unknown"` on loopback, VLAN, PPPoE, WireGuard, bonding interfaces
+- Wireless metrics (`signal-strength`, `tx-ccq`) on wired device tracker hosts
+- Copper-specific fields (`rate`, `full-duplex`) missing from SFP ports
+
+The root cause: `copy_attrs` checked only whether a key existed in `_data` (always true due to defaults), not whether the value was meaningful.
+
+## Decision
+
+### 1. Conditional attribute sets by hardware type
+
+SFP and copper attribute lists are **mutually exclusive**. The `sfp-shutdown-temperature` field (fetched for all ethernet ports) determines which set applies:
+
+- Value is non-zero/non-empty → SFP port → show `DEVICE_ATTRIBUTES_IFACE_SFP`
+- Value is `0`/empty/absent → copper port → show `DEVICE_ATTRIBUTES_IFACE_ETHER`
+
+Previously both lists were additive (ether always, then SFP on top).
+
+### 2. Junk default filtering via `copy_attrs(skip_junk=True)`
+
+A `skip_junk` keyword parameter on `copy_attrs` filters values matching `_JUNK_DEFAULTS` (`"unknown"`, `"none"`, `"N/A"`) and `None`. Applied to SFP and client attribute lists where defaults are commonly meaningless.
+
+Values of `0`, `False`, and `""` are **not** filtered — these can be valid operational states (e.g. `link_downs: 0`, `running: false`).
+
+### 3. Conditional attribute inclusion
+
+| Attribute | Condition | Previously |
+|-----------|-----------|------------|
+| `poe-out` | Shown only when value is not `None`/`"N/A"`/`""` | Always shown on all ether ports |
+| `client-ip-address`, `client-mac-address` | Shown only when value is meaningful (via `skip_junk`) | Always shown on all interfaces |
+| Wireless metrics (`signal-strength`, `tx-ccq`, `tx-rate`, `rx-rate`) | Shown only for `source` in `("capsman", "wireless")` | Shown on all tracked hosts |
+
+### 4. Single source of truth for attribute lists
+
+`iface_attributes.py` is the canonical source. `switch_types.py` previously had duplicate copies; these are removed. `MikrotikPortSwitch` now inherits `MikrotikInterfaceEntityMixin` instead of duplicating the attribute logic.
+
+### 5. SFP monitor parity with copper
+
+Added `rate` and `full-duplex` to `_SFP_MONITOR_VALS` so SFP ports report link speed. Changed `sfp-temperature` default from `0` to `None` so empty SFP cages don't show a misleading temperature.
+
+## Consequences
+
+### Positive
+- Entities only expose attributes relevant to their hardware
+- Cleaner UI — no scrolling past 16 "unknown" SFP fields on copper ports
+- SFP ports now show link rate (was missing entirely)
+
+### Negative
+- **Breaking change for automations** that relied on the presence of always-defaulted attributes (e.g. checking `state_attr('sensor.ether1_tx', 'sfp_temperature') != None`). These automations were likely unintentional since the values were always "unknown".
+- Slightly more complex attribute selection logic in `MikrotikInterfaceEntityMixin`
+
+### Neutral
+- No entity identity changes (unique IDs, entity IDs unchanged)
+- No change to the coordinator data model (`ds` dict still contains all keys)
+- `copy_attrs` without `skip_junk` behaves identically to before (backward compatible)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,6 +14,7 @@ Lightweight records of key design decisions for mikrotik_router HACS integration
 | [ADR-006](ADR-006-naive-datetime-removal.md) | Replace naive datetime.now() with HA utility | Proposed |
 | [ADR-007](ADR-007-complexity-reduction-extraction.md) | Cognitive Complexity Reduction via Helper Extraction | Accepted |
 | [ADR-008](ADR-008-upstream-feature-port.md) | Port Upstream Feature Requests (#310, #321, #334, #298) | Accepted |
+| [ADR-009](ADR-009-attribute-filtering-by-hardware.md) | Entity Attribute Filtering by Hardware Capability | Accepted |
 
 ## Template
 

--- a/docs/sensor-gap-analysis.md
+++ b/docs/sensor-gap-analysis.md
@@ -1,0 +1,244 @@
+# Sensor Gap Analysis — MikroTik Router HACS Integration
+
+**Date:** 2026-03-25
+**Branch:** `claude/sensor-gap-analysis-GGBIz`
+**Status:** Draft for review — no code changes
+
+---
+
+## 1. Executive Summary
+
+The integration currently surfaces **~44 sensor entities, 4 binary sensors, 10 switch types, 1 button type, 1 device tracker type, and 2 update entities** across 6 platforms. It queries **~33 RouterOS API endpoints**.
+
+This analysis identifies **3 categories of gaps**:
+- **Category A** — Data already fetched but not surfaced as entities (low effort)
+- **Category B** — RouterOS API endpoints not queried, high home-automation value (medium effort)
+- **Category C** — RouterOS API endpoints not queried, niche/advanced use (higher effort)
+
+---
+
+## 2. Category A — Already Fetched, Not Surfaced
+
+These items are the lowest-hanging fruit. The data is already in `self.ds` and just needs entity definitions in `*_types.py`.
+
+| # | Data Point | Source in `self.ds` | Proposed Entity | Platform | Effort | HA Value |
+|---|-----------|---------------------|-----------------|----------|--------|----------|
+| A1 | Firewall rule byte/packet counters | `nat`, `filter`, `mangle`, `raw` | Per-rule traffic counter sensor | sensor | Low | Medium — see which rules are active |
+| A2 | Interface `tx-queue-drop` | `interface` | Queue drops per interface | sensor | Low | Medium — detect congestion |
+| A3 | Interface `link-downs` count | `interface` | Link flap counter | sensor | Low | High — detect unstable links |
+| A4 | DHCP lease `status` | `dhcp` | Lease status (bound/waiting) | sensor | Low | Low |
+| A5 | DHCP lease count | `dhcp` | Total active DHCP leases | sensor | Low | Medium — network utilization |
+| A6 | DNS static entry count | `dns` | DNS entries count | sensor | Low | Low |
+| A7 | ARP table size | `arp` | ARP entries count | sensor | Low | Medium — detect network scans |
+| A8 | Queue actual rate (download/upload) | `queue` | Current throughput per queue | sensor | Low | High — bandwidth monitoring |
+| A9 | Wireless client signal strength | `wireless_hosts` | Per-client signal quality | sensor | Low | High — WiFi health monitoring |
+| A10 | Wireless client TX/RX rate | `wireless_hosts` | Per-client link rate | sensor | Low | High — WiFi performance |
+| A11 | Container status | `container` | Container running state | binary_sensor | Low | High — service monitoring |
+| A12 | Bridge host count | `bridge_host` | Devices per bridge | sensor | Low | Low |
+| A13 | PPP active connection details | `ppp_active` | PPP caller-id, encoding, address | sensor attr | Low | Medium — VPN user tracking |
+| A14 | Resource `platform` / `board-name` | `resource` | Diagnostic sensor | sensor | Low | Low — already in device info |
+| A15 | Hotspot authorized/bypassed counts | `hostspot_host` (sic) | Captive portal stats | sensor | Low | Medium |
+
+**Estimated total effort for Category A:** 2-3 days (mostly boilerplate `*_types.py` entries)
+
+---
+
+## 3. Category B — Not Fetched, High Home-Automation Value
+
+These require new API calls in the coordinator plus entity definitions. Prioritized by alignment with typical home automation use cases.
+
+| # | RouterOS API Path | Proposed Entities | Platform | Effort | HA Value | Rationale |
+|---|------------------|-------------------|----------|--------|----------|-----------|
+| B1 | `/ip/firewall/address-list` | Address list entries (enable/disable) | switch + sensor | Medium | **Very High** | Widely used for ad-blocking, geo-blocking, parental control, dynamic allow/deny lists. Users frequently toggle these from HA. |
+| B2 | `/interface/wireguard` + `/interface/wireguard/peers` | WireGuard tunnel status, peer connected, last handshake, TX/RX, endpoint | binary_sensor + sensor | Medium | **Very High** | WireGuard is the dominant VPN for home users. Presence detection via VPN, remote access monitoring. |
+| B3 | `/ip/neighbor` (MNDP/CDP/LLDP) | Neighbor device discovery | sensor | Medium | **High** | Network topology awareness, detect new devices on network, identify switches/APs. |
+| B4 | `/ip/route` | Active route count, default gateway status, specific route monitoring | sensor + binary_sensor | Medium | **High** | Failover detection, multi-WAN monitoring, route availability. |
+| B5 | `/ip/address` | IP addresses per interface | sensor | Low-Med | **High** | Track WAN IP changes, interface addressing, useful for DDNS-like automations. |
+| B6 | `/system/scheduler` | Scheduled task status, next-run, run-count | sensor | Low-Med | **Medium** | Monitor cron-like tasks, detect missed runs. |
+| B7 | `/ip/cloud` | DDNS hostname, status, public IP | sensor | Low | **High** | Dynamic DNS monitoring, external IP detection without third-party service. |
+| B8 | `/system/ntp/client` | NTP sync status, offset, last adjustment | binary_sensor + sensor | Low | **Medium** | Time accuracy monitoring for security-sensitive setups. |
+| B9 | `/certificate` | Certificate name, expiry date, days until expiry | sensor | Low-Med | **High** | TLS certificate expiry alerts — critical for HTTPS services, VPN, hotspot. |
+| B10 | `/interface/lte` | LTE signal (RSSI, RSRP, RSRQ, SINR), carrier, connection status | sensor + binary_sensor | Medium | **Very High** | LTE failover monitoring is a top request for rural/backup internet users. But only relevant if router has LTE. |
+| B11 | `/ip/firewall/connection` (tracking summary) | Active connection count, TCP/UDP/ICMP counts | sensor | Low-Med | **High** | Network activity monitoring, detect anomalies, connection table saturation. |
+| B12 | `/interface/pppoe-client` | PPPoE connection status, uptime, IP assigned | binary_sensor + sensor | Low-Med | **High** | Many ISPs use PPPoE — connection monitoring and failover. |
+| B13 | `/ip/service` | Service enabled status (winbox, ssh, www, api, ftp) | binary_sensor | Low | **Medium** | Security monitoring — alert if unexpected services enabled. |
+| B14 | `/ip/pool` | Pool name, used/total addresses | sensor | Low | **Medium** | DHCP pool exhaustion detection. |
+| B15 | `/log` (last N entries) | Recent log entries | sensor | Medium | **Medium** | Surfacing critical router events (login failures, interface down, etc.) into HA. High noise risk. |
+| B16 | `/interface/bridge` + `/interface/bridge/port` | Bridge STP status, port roles, path cost | sensor | Low-Med | **Low-Med** | STP topology change detection. Niche but useful for larger setups. |
+| B17 | `/interface/vlan` | VLAN interface info | sensor | Low | **Low** | Mostly informational — VLANs are already interfaces. |
+
+**Estimated total effort for Category B:** 3-5 weeks (depending on scope selected)
+
+---
+
+## 4. Category C — Not Fetched, Niche/Advanced
+
+Lower priority items for specialized use cases.
+
+| # | RouterOS API Path | Proposed Entities | Effort | HA Value | Notes |
+|---|------------------|-------------------|--------|----------|-------|
+| C1 | `/ip/ipsec/active-peers` + `/ip/ipsec/installed-sa` | IPsec tunnel status | Medium | Medium | Site-to-site VPN monitoring |
+| C2 | `/routing/ospf/neighbor` | OSPF neighbor status | Medium | Low | Enterprise routing, very niche for HA |
+| C3 | `/routing/bgp/session` | BGP session status | Medium | Low | Enterprise, very niche |
+| C4 | `/ipv6/address` | IPv6 addresses | Low | Low-Med | Growing relevance as IPv6 adoption increases |
+| C5 | `/ipv6/firewall/filter` | IPv6 firewall rules | Medium | Low | Mirror of IPv4 firewall |
+| C6 | `/disk` | Disk name, size, free, type | Low | Low | ROS7 only, most routers have minimal storage |
+| C7 | `/snmp` | SNMP status | Low | Low | Informational only |
+| C8 | `/ip/proxy` | Web proxy stats | Low | Low | Rarely used in home setups |
+| C9 | `/system/license` | License level, deadline | Low | Low | Informational |
+| C10 | `/interface/ovpn-server` + `/interface/sstp-server` | OpenVPN/SSTP server connections | Medium | Medium | Being replaced by WireGuard |
+| C11 | `/tool/torch` (live traffic) | Real-time per-protocol traffic | High | Medium | Very high API load, not suited for polling |
+| C12 | `/ip/dns/cache` | DNS cache size, entries | Low | Low | Informational only |
+| C13 | `/system/history` | Command audit log | Low | Low-Med | Security audit trail |
+
+---
+
+## 5. Recommended Implementation Priority
+
+### Phase 1 — Quick Wins (Category A, ~2-3 days)
+Items that add value with minimal risk since the data is already collected:
+
+1. **A3** — Interface link-downs counter (network reliability)
+2. **A8** — Queue actual rates (bandwidth visibility)
+3. **A9/A10** — Wireless client signal/rate (WiFi monitoring)
+4. **A11** — Container running binary_sensor
+5. **A1** — Firewall rule counters
+6. **A5** — DHCP lease count
+7. **A2** — Queue drops per interface
+
+### Phase 2 — High-Value New Data (Category B, ~2-3 weeks)
+New API calls with the highest home-automation alignment:
+
+1. **B1** — Address list management (extremely popular use case)
+2. **B2** — WireGuard VPN monitoring (modern VPN standard)
+3. **B5** — IP address tracking (WAN IP change detection)
+4. **B7** — Cloud/DDNS status (external IP without third-party)
+5. **B4** — Route monitoring (failover detection)
+6. **B11** — Connection tracking stats (activity monitoring)
+
+### Phase 3 — Conditional/Hardware-Specific (Category B, ~1-2 weeks)
+Only relevant for specific hardware:
+
+1. **B10** — LTE modem stats (if hardware present)
+2. **B12** — PPPoE client status (if ISP uses PPPoE)
+3. **B9** — Certificate expiry monitoring
+4. **B13** — Service status (security hardening)
+
+### Phase 4 — Nice to Have
+Cherry-pick from remaining Category B and C items based on user demand.
+
+---
+
+## 6. Implementation Complexity Notes
+
+### Adding a Category A sensor (template)
+1. Add entry to `sensor_types.py` (or appropriate `*_types.py`)
+2. Ensure `data_path` and `data_attribute` match existing `self.ds` keys
+3. Add to sensor list filter in `sensor.py` if needed
+4. Write tests
+5. **No coordinator changes needed**
+
+### Adding a Category B sensor (template)
+1. Add new API query method in `coordinator.py` (e.g., `get_wireguard()`)
+2. Initialize `self.ds["wireguard"]` in coordinator `__init__`
+3. Add call to `_async_update_data()` loop
+4. Optionally gate behind capability check (like wireless/container)
+5. Add entity descriptions in `*_types.py`
+6. Add entity class if custom logic needed (or reuse existing)
+7. Write tests for both coordinator method and entity
+8. **Coordinator changes required — higher review bar**
+
+### Performance Considerations
+- Each new API call adds ~50-200ms to the polling cycle (currently 30s)
+- Category A items add **zero** polling overhead
+- Category B items should be gated behind capability detection (e.g., don't query WireGuard if not installed)
+- Some endpoints (like `/log`, `/ip/firewall/connection`) can return large datasets — need pagination or filtering
+- Consider making new data sources opt-in via config flow options
+
+### Breaking Change Risk
+- Category A: **None** — additive only
+- Category B: **None** — new entities, no changes to existing
+- No ADR required unless changing entity identity patterns or data formats
+
+---
+
+## 7. Comparison with Other Router Integrations
+
+For context, here's what comparable HA integrations surface:
+
+| Feature | This Integration | UniFi | Fritz!Box | OpenWrt |
+|---------|-----------------|-------|-----------|---------|
+| System health (CPU/mem/temp) | ✅ | ✅ | ✅ | ✅ |
+| Interface traffic | ✅ | ✅ | ✅ | ✅ |
+| Per-client traffic | ✅ | ✅ | ❌ | ❌ |
+| Device tracker | ✅ | ✅ | ✅ | ✅ |
+| Firewall rule control | ✅ | ❌ | ❌ | ❌ |
+| VPN status (WireGuard) | ❌ | ✅ | ✅ | ✅ |
+| Address list management | ❌ | N/A | N/A | ❌ |
+| WAN IP monitoring | ❌ | ✅ | ✅ | ✅ |
+| LTE modem stats | ❌ | N/A | ✅ | ✅ |
+| Certificate expiry | ❌ | ❌ | ❌ | ❌ |
+| Connection count | ❌ | ✅ | ✅ | ❌ |
+| PoE management | ✅ | ✅ | N/A | N/A |
+| Container management | ✅ | N/A | N/A | ✅ |
+| WiFi signal per client | ❌* | ✅ | ✅ | ✅ |
+| DDNS/Cloud status | ❌ | ✅ | ✅ | ✅ |
+
+*Signal data is fetched and available as device_tracker attribute, but not as a dedicated sensor entity.
+
+---
+
+## 8. Decision Required
+
+Before implementation:
+1. **Scope** — Which phases/items to include in first PR?
+2. **Opt-in vs auto-discover** — Should new sensors be enabled by default or require config flow opt-in?
+3. **Polling impact** — Accept increased polling time for Category B, or make them configurable poll intervals?
+4. **Entity naming** — Follow existing naming conventions or take opportunity to align with HA 2024+ entity naming standards?
+
+---
+
+## Appendix: Currently Surfaced Entities (Complete List)
+
+<details>
+<summary>Click to expand full current entity list</summary>
+
+### Sensors (44)
+- System: temperature, voltage, cpu-temperature, switch-temperature, board-temperature1, phy-temperature, power-consumption, poe-out-consumption, poe-in-voltage, poe-in-current, fan1-4 speed, psu1-2 current/voltage
+- Resources: uptime, cpu-load, memory-usage, hdd-usage, clients-wired, clients-wireless, captive-authorized
+- PoE ports: poe-out-status, poe-out-voltage, poe-out-current, poe-out-power
+- Interface traffic: tx, rx, tx-total, rx-total (per interface)
+- Client traffic: lan-tx, lan-rx, wan-tx, wan-rx, tx, rx (per client)
+- GPS: latitude, longitude
+- Environment: value
+- DHCP client: status, address
+
+### Binary Sensors (4)
+- UPS on-line status
+- PPP secret connected
+- Interface running
+- Netwatch status
+
+### Switches (10 types)
+- Interface enable/disable
+- NAT rule enable/disable
+- Mangle rule enable/disable
+- Filter rule enable/disable
+- RAW rule enable/disable
+- PPP secret enable/disable
+- Queue enable/disable
+- Kid control enable/disable
+- Kid control pause/resume
+- Container start/stop
+
+### Buttons (1)
+- Script execution
+
+### Device Trackers (1)
+- Host connection status
+
+### Update Entities (2)
+- RouterOS update
+- RouterBOARD firmware update
+
+</details>

--- a/docs/sensor-gap-analysis.md
+++ b/docs/sensor-gap-analysis.md
@@ -1,170 +1,78 @@
 # Sensor Gap Analysis — MikroTik Router HACS Integration
 
-**Date:** 2026-03-25
-**Branch:** `claude/sensor-gap-analysis-GGBIz`
-**Status:** Draft for review — no code changes
+This document catalogues RouterOS data points that could be surfaced as Home Assistant entities. Items are grouped by whether the data is already fetched by the coordinator or requires new API calls.
 
 ---
 
-## 1. Executive Summary
+## Data Already Fetched — Not Yet Surfaced
 
-The integration currently surfaces **~44 sensor entities, 4 binary sensors, 10 switch types, 1 button type, 1 device tracker type, and 2 update entities** across 6 platforms. It queries **~33 RouterOS API endpoints**.
+The coordinator already queries these from RouterOS. Surfacing them as entities requires only new definitions in `*_types.py`.
 
-This analysis identifies **3 categories of gaps**:
-- **Category A** — Data already fetched but not surfaced as entities (low effort)
-- **Category B** — RouterOS API endpoints not queried, high home-automation value (medium effort)
-- **Category C** — RouterOS API endpoints not queried, niche/advanced use (higher effort)
-
----
-
-## 2. Category A — Already Fetched, Not Surfaced
-
-These items are the lowest-hanging fruit. The data is already in `self.ds` and just needs entity definitions in `*_types.py`.
-
-| # | Data Point | Source in `self.ds` | Proposed Entity | Platform | Effort | HA Value |
-|---|-----------|---------------------|-----------------|----------|--------|----------|
-| A1 | Firewall rule byte/packet counters | `nat`, `filter`, `mangle`, `raw` | Per-rule traffic counter sensor | sensor | Low | Medium — see which rules are active |
-| A2 | Interface `tx-queue-drop` | `interface` | Queue drops per interface | sensor | Low | Medium — detect congestion |
-| A3 | Interface `link-downs` count | `interface` | Link flap counter | sensor | Low | High — detect unstable links |
-| A4 | DHCP lease `status` | `dhcp` | Lease status (bound/waiting) | sensor | Low | Low |
-| A5 | DHCP lease count | `dhcp` | Total active DHCP leases | sensor | Low | Medium — network utilization |
-| A6 | DNS static entry count | `dns` | DNS entries count | sensor | Low | Low |
-| A7 | ARP table size | `arp` | ARP entries count | sensor | Low | Medium — detect network scans |
-| A8 | Queue actual rate (download/upload) | `queue` | Current throughput per queue | sensor | Low | High — bandwidth monitoring |
-| A9 | Wireless client signal strength | `wireless_hosts` | Per-client signal quality | sensor | Low | High — WiFi health monitoring |
-| A10 | Wireless client TX/RX rate | `wireless_hosts` | Per-client link rate | sensor | Low | High — WiFi performance |
-| A11 | Container status | `container` | Container running state | binary_sensor | Low | High — service monitoring |
-| A12 | Bridge host count | `bridge_host` | Devices per bridge | sensor | Low | Low |
-| A13 | PPP active connection details | `ppp_active` | PPP caller-id, encoding, address | sensor attr | Low | Medium — VPN user tracking |
-| A14 | Resource `platform` / `board-name` | `resource` | Diagnostic sensor | sensor | Low | Low — already in device info |
-| A15 | Hotspot authorized/bypassed counts | `hostspot_host` (sic) | Captive portal stats | sensor | Low | Medium |
-
-**Estimated total effort for Category A:** 2-3 days (mostly boilerplate `*_types.py` entries)
+| Data Point | Source | Proposed Entity | Use Case |
+|-----------|--------|-----------------|----------|
+| Firewall rule byte/packet counters | `nat`, `filter`, `mangle`, `raw` | Per-rule traffic counter | See which rules are active |
+| Interface `tx-queue-drop` | `interface` | Queue drops per interface | Detect congestion |
+| Interface `link-downs` count | `interface` | Link flap counter | Detect unstable links |
+| DHCP lease `status` | `dhcp` | Lease status (bound/waiting) | Lease monitoring |
+| DHCP lease count | `dhcp` | Total active leases | Network utilisation |
+| DNS static entry count | `dns` | DNS entries count | Informational |
+| ARP table size | `arp` | ARP entries count | Detect network scans |
+| Queue actual rate | `queue` | Current throughput per queue | Bandwidth monitoring |
+| Wireless client signal strength | `wireless_hosts` | Per-client signal quality | WiFi health |
+| Wireless client TX/RX rate | `wireless_hosts` | Per-client link rate | WiFi performance |
+| Container status | `container` | Container running state | Service monitoring |
+| Bridge host count | `bridge_host` | Devices per bridge | Informational |
+| PPP active connection details | `ppp_active` | Caller-id, encoding, address | VPN user tracking |
+| Hotspot authorised/bypassed counts | `hostspot_host` | Captive portal stats | Hotspot monitoring |
 
 ---
 
-## 3. Category B — Not Fetched, High Home-Automation Value
+## New API Calls — High Home-Automation Value
 
-These require new API calls in the coordinator plus entity definitions. Prioritized by alignment with typical home automation use cases.
+These require new RouterOS API queries in the coordinator. Ordered by relevance to typical home automation setups.
 
-| # | RouterOS API Path | Proposed Entities | Platform | Effort | HA Value | Rationale |
-|---|------------------|-------------------|----------|--------|----------|-----------|
-| B1 | `/ip/firewall/address-list` | Address list entries (enable/disable) | switch + sensor | Medium | **Very High** | Widely used for ad-blocking, geo-blocking, parental control, dynamic allow/deny lists. Users frequently toggle these from HA. |
-| B2 | `/interface/wireguard` + `/interface/wireguard/peers` | WireGuard tunnel status, peer connected, last handshake, TX/RX, endpoint | binary_sensor + sensor | Medium | **Very High** | WireGuard is the dominant VPN for home users. Presence detection via VPN, remote access monitoring. |
-| B3 | `/ip/neighbor` (MNDP/CDP/LLDP) | Neighbor device discovery | sensor | Medium | **High** | Network topology awareness, detect new devices on network, identify switches/APs. |
-| B4 | `/ip/route` | Active route count, default gateway status, specific route monitoring | sensor + binary_sensor | Medium | **High** | Failover detection, multi-WAN monitoring, route availability. |
-| B5 | `/ip/address` | IP addresses per interface | sensor | Low-Med | **High** | Track WAN IP changes, interface addressing, useful for DDNS-like automations. |
-| B6 | `/system/scheduler` | Scheduled task status, next-run, run-count | sensor | Low-Med | **Medium** | Monitor cron-like tasks, detect missed runs. |
-| B7 | `/ip/cloud` | DDNS hostname, status, public IP | sensor | Low | **High** | Dynamic DNS monitoring, external IP detection without third-party service. |
-| B8 | `/system/ntp/client` | NTP sync status, offset, last adjustment | binary_sensor + sensor | Low | **Medium** | Time accuracy monitoring for security-sensitive setups. |
-| B9 | `/certificate` | Certificate name, expiry date, days until expiry | sensor | Low-Med | **High** | TLS certificate expiry alerts — critical for HTTPS services, VPN, hotspot. |
-| B10 | `/interface/lte` | LTE signal (RSSI, RSRP, RSRQ, SINR), carrier, connection status | sensor + binary_sensor | Medium | **Very High** | LTE failover monitoring is a top request for rural/backup internet users. But only relevant if router has LTE. |
-| B11 | `/ip/firewall/connection` (tracking summary) | Active connection count, TCP/UDP/ICMP counts | sensor | Low-Med | **High** | Network activity monitoring, detect anomalies, connection table saturation. |
-| B12 | `/interface/pppoe-client` | PPPoE connection status, uptime, IP assigned | binary_sensor + sensor | Low-Med | **High** | Many ISPs use PPPoE — connection monitoring and failover. |
-| B13 | `/ip/service` | Service enabled status (winbox, ssh, www, api, ftp) | binary_sensor | Low | **Medium** | Security monitoring — alert if unexpected services enabled. |
-| B14 | `/ip/pool` | Pool name, used/total addresses | sensor | Low | **Medium** | DHCP pool exhaustion detection. |
-| B15 | `/log` (last N entries) | Recent log entries | sensor | Medium | **Medium** | Surfacing critical router events (login failures, interface down, etc.) into HA. High noise risk. |
-| B16 | `/interface/bridge` + `/interface/bridge/port` | Bridge STP status, port roles, path cost | sensor | Low-Med | **Low-Med** | STP topology change detection. Niche but useful for larger setups. |
-| B17 | `/interface/vlan` | VLAN interface info | sensor | Low | **Low** | Mostly informational — VLANs are already interfaces. |
-
-**Estimated total effort for Category B:** 3-5 weeks (depending on scope selected)
+| RouterOS API | Proposed Entities | Use Case |
+|-------------|-------------------|----------|
+| `/ip/firewall/address-list` | Address list entries (enable/disable) | Ad-blocking, geo-blocking, parental control, dynamic allow/deny lists |
+| `/interface/wireguard` + `/interface/wireguard/peers` | Tunnel status, peer connected, last handshake, TX/RX | VPN presence detection, remote access monitoring |
+| `/ip/neighbor` (MNDP/CDP/LLDP) | Neighbour device discovery | Network topology awareness, detect new devices |
+| `/ip/route` | Active route count, default gateway status | Failover detection, multi-WAN monitoring |
+| `/ip/address` | IP addresses per interface | WAN IP change detection, DDNS-like automations |
+| `/ip/cloud` | DDNS hostname, status, public IP | External IP detection without third-party service |
+| `/system/scheduler` | Task status, next-run, run-count | Monitor scheduled tasks, detect missed runs |
+| `/system/ntp/client` | NTP sync status, offset | Time accuracy monitoring |
+| `/certificate` | Certificate name, expiry date, days until expiry | TLS certificate expiry alerts for HTTPS, VPN, hotspot |
+| `/interface/lte` | Signal (RSSI, RSRP, RSRQ, SINR), carrier, status | LTE failover monitoring (hardware-dependent) |
+| `/ip/firewall/connection` | Active connection count, TCP/UDP/ICMP | Network activity monitoring, connection table saturation |
+| `/interface/pppoe-client` | Connection status, uptime, IP assigned | PPPoE ISP connection monitoring |
+| `/ip/service` | Service enabled status (winbox, ssh, www, api, ftp) | Security monitoring — alert on unexpected services |
+| `/ip/pool` | Pool name, used/total addresses | DHCP pool exhaustion detection |
+| `/log` (last N entries) | Recent log entries | Router event surfacing (login failures, interface down) |
+| `/interface/bridge` + `/interface/bridge/port` | STP status, port roles | Topology change detection |
 
 ---
 
-## 4. Category C — Not Fetched, Niche/Advanced
+## New API Calls — Niche / Advanced
 
-Lower priority items for specialized use cases.
+Specialised use cases — lower priority for typical home setups.
 
-| # | RouterOS API Path | Proposed Entities | Effort | HA Value | Notes |
-|---|------------------|-------------------|--------|----------|-------|
-| C1 | `/ip/ipsec/active-peers` + `/ip/ipsec/installed-sa` | IPsec tunnel status | Medium | Medium | Site-to-site VPN monitoring |
-| C2 | `/routing/ospf/neighbor` | OSPF neighbor status | Medium | Low | Enterprise routing, very niche for HA |
-| C3 | `/routing/bgp/session` | BGP session status | Medium | Low | Enterprise, very niche |
-| C4 | `/ipv6/address` | IPv6 addresses | Low | Low-Med | Growing relevance as IPv6 adoption increases |
-| C5 | `/ipv6/firewall/filter` | IPv6 firewall rules | Medium | Low | Mirror of IPv4 firewall |
-| C6 | `/disk` | Disk name, size, free, type | Low | Low | ROS7 only, most routers have minimal storage |
-| C7 | `/snmp` | SNMP status | Low | Low | Informational only |
-| C8 | `/ip/proxy` | Web proxy stats | Low | Low | Rarely used in home setups |
-| C9 | `/system/license` | License level, deadline | Low | Low | Informational |
-| C10 | `/interface/ovpn-server` + `/interface/sstp-server` | OpenVPN/SSTP server connections | Medium | Medium | Being replaced by WireGuard |
-| C11 | `/tool/torch` (live traffic) | Real-time per-protocol traffic | High | Medium | Very high API load, not suited for polling |
-| C12 | `/ip/dns/cache` | DNS cache size, entries | Low | Low | Informational only |
-| C13 | `/system/history` | Command audit log | Low | Low-Med | Security audit trail |
+| RouterOS API | Proposed Entities | Use Case |
+|-------------|-------------------|----------|
+| `/ip/ipsec/active-peers` + `/ip/ipsec/installed-sa` | IPsec tunnel status | Site-to-site VPN monitoring |
+| `/routing/ospf/neighbor` | OSPF neighbour status | Enterprise dynamic routing |
+| `/routing/bgp/session` | BGP session status | Enterprise / multi-homing |
+| `/ipv6/address` | IPv6 addresses | IPv6 network monitoring |
+| `/ipv6/firewall/filter` | IPv6 firewall rules | Mirror of IPv4 firewall for dual-stack |
+| `/disk` | Disk name, size, free, type | Storage monitoring (ROS7 only) |
+| `/interface/ovpn-server` + `/interface/sstp-server` | OpenVPN/SSTP connections | Legacy VPN monitoring |
+| `/tool/torch` | Real-time per-protocol traffic | Live traffic analysis (high API load) |
+| `/ip/dns/cache` | DNS cache size | Informational |
+| `/system/history` | Command audit log | Security audit trail |
+| `/system/license` | Licence level, deadline | Informational |
 
 ---
 
-## 5. Recommended Implementation Priority
-
-### Phase 1 — Quick Wins (Category A, ~2-3 days)
-Items that add value with minimal risk since the data is already collected:
-
-1. **A3** — Interface link-downs counter (network reliability)
-2. **A8** — Queue actual rates (bandwidth visibility)
-3. **A9/A10** — Wireless client signal/rate (WiFi monitoring)
-4. **A11** — Container running binary_sensor
-5. **A1** — Firewall rule counters
-6. **A5** — DHCP lease count
-7. **A2** — Queue drops per interface
-
-### Phase 2 — High-Value New Data (Category B, ~2-3 weeks)
-New API calls with the highest home-automation alignment:
-
-1. **B1** — Address list management (extremely popular use case)
-2. **B2** — WireGuard VPN monitoring (modern VPN standard)
-3. **B5** — IP address tracking (WAN IP change detection)
-4. **B7** — Cloud/DDNS status (external IP without third-party)
-5. **B4** — Route monitoring (failover detection)
-6. **B11** — Connection tracking stats (activity monitoring)
-
-### Phase 3 — Conditional/Hardware-Specific (Category B, ~1-2 weeks)
-Only relevant for specific hardware:
-
-1. **B10** — LTE modem stats (if hardware present)
-2. **B12** — PPPoE client status (if ISP uses PPPoE)
-3. **B9** — Certificate expiry monitoring
-4. **B13** — Service status (security hardening)
-
-### Phase 4 — Nice to Have
-Cherry-pick from remaining Category B and C items based on user demand.
-
----
-
-## 6. Implementation Complexity Notes
-
-### Adding a Category A sensor (template)
-1. Add entry to `sensor_types.py` (or appropriate `*_types.py`)
-2. Ensure `data_path` and `data_attribute` match existing `self.ds` keys
-3. Add to sensor list filter in `sensor.py` if needed
-4. Write tests
-5. **No coordinator changes needed**
-
-### Adding a Category B sensor (template)
-1. Add new API query method in `coordinator.py` (e.g., `get_wireguard()`)
-2. Initialize `self.ds["wireguard"]` in coordinator `__init__`
-3. Add call to `_async_update_data()` loop
-4. Optionally gate behind capability check (like wireless/container)
-5. Add entity descriptions in `*_types.py`
-6. Add entity class if custom logic needed (or reuse existing)
-7. Write tests for both coordinator method and entity
-8. **Coordinator changes required — higher review bar**
-
-### Performance Considerations
-- Each new API call adds ~50-200ms to the polling cycle (currently 30s)
-- Category A items add **zero** polling overhead
-- Category B items should be gated behind capability detection (e.g., don't query WireGuard if not installed)
-- Some endpoints (like `/log`, `/ip/firewall/connection`) can return large datasets — need pagination or filtering
-- Consider making new data sources opt-in via config flow options
-
-### Breaking Change Risk
-- Category A: **None** — additive only
-- Category B: **None** — new entities, no changes to existing
-- No ADR required unless changing entity identity patterns or data formats
-
----
-
-## 7. Comparison with Other Router Integrations
-
-For context, here's what comparable HA integrations surface:
+## Comparison with Other Router Integrations
 
 | Feature | This Integration | UniFi | Fritz!Box | OpenWrt |
 |---------|-----------------|-------|-----------|---------|
@@ -184,61 +92,32 @@ For context, here's what comparable HA integrations surface:
 | WiFi signal per client | ❌* | ✅ | ✅ | ✅ |
 | DDNS/Cloud status | ❌ | ✅ | ✅ | ✅ |
 
-*Signal data is fetched and available as device_tracker attribute, but not as a dedicated sensor entity.
+*Signal data is available as a device tracker attribute but not as a dedicated sensor entity.
 
 ---
 
-## 8. Decision Required
-
-Before implementation:
-1. **Scope** — Which phases/items to include in first PR?
-2. **Opt-in vs auto-discover** — Should new sensors be enabled by default or require config flow opt-in?
-3. **Polling impact** — Accept increased polling time for Category B, or make them configurable poll intervals?
-4. **Entity naming** — Follow existing naming conventions or take opportunity to align with HA 2024+ entity naming standards?
-
----
-
-## Appendix: Currently Surfaced Entities (Complete List)
+## Current Entity Summary
 
 <details>
-<summary>Click to expand full current entity list</summary>
+<summary>Click to expand</summary>
 
-### Sensors (44)
-- System: temperature, voltage, cpu-temperature, switch-temperature, board-temperature1, phy-temperature, power-consumption, poe-out-consumption, poe-in-voltage, poe-in-current, fan1-4 speed, psu1-2 current/voltage
-- Resources: uptime, cpu-load, memory-usage, hdd-usage, clients-wired, clients-wireless, captive-authorized
-- PoE ports: poe-out-status, poe-out-voltage, poe-out-current, poe-out-power
-- Interface traffic: tx, rx, tx-total, rx-total (per interface)
-- Client traffic: lan-tx, lan-rx, wan-tx, wan-rx, tx, rx (per client)
-- GPS: latitude, longitude
-- Environment: value
-- DHCP client: status, address
+### Sensors
+- **System:** temperature, voltage, cpu-temperature, switch-temperature, board-temperature1, phy-temperature, power-consumption, poe-out-consumption, poe-in-voltage, poe-in-current, fan1-4 speed, psu1-2 current/voltage
+- **Resources:** uptime, cpu-load, memory-usage, hdd-usage, clients-wired, clients-wireless, captive-authorised
+- **PoE ports:** poe-out-status, poe-out-voltage, poe-out-current, poe-out-power
+- **Interface traffic:** tx, rx, tx-total, rx-total (per interface)
+- **Client traffic:** lan-tx, lan-rx, wan-tx, wan-rx, tx, rx (per client)
+- **GPS:** latitude, longitude
+- **Environment:** value
+- **DHCP client:** status, address
 
-### Binary Sensors (4)
-- UPS on-line status
-- PPP secret connected
-- Interface running
-- Netwatch status
+### Binary Sensors
+- UPS on-line status, PPP secret connected, interface running, netwatch status
 
 ### Switches (10 types)
-- Interface enable/disable
-- NAT rule enable/disable
-- Mangle rule enable/disable
-- Filter rule enable/disable
-- RAW rule enable/disable
-- PPP secret enable/disable
-- Queue enable/disable
-- Kid control enable/disable
-- Kid control pause/resume
-- Container start/stop
+- Interface, NAT, mangle, filter, RAW, PPP secret, queue, kid control, kid control pause, container
 
-### Buttons (1)
-- Script execution
-
-### Device Trackers (1)
-- Host connection status
-
-### Update Entities (2)
-- RouterOS update
-- RouterBOARD firmware update
+### Other
+- Script execution (button), host connection status (device tracker), RouterOS update, RouterBOARD firmware update
 
 </details>

--- a/info.md
+++ b/info.md
@@ -4,9 +4,9 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
-### What's new in v2.3.11-beta.1
-- **Attribute cleanup** — Removed ~1,300 meaningless default attributes (SFP fields on copper ports, PoE on non-PoE, client IP on loopback/VLAN, wireless metrics on wired hosts)
-- **Mangle fix** — Rules differing only by interface were silently dropped as duplicates ([PR #40](https://github.com/jnctech/homeassistant-mikrotik_router/pull/40))
+### What's new in v2.3.11
+- **Attribute cleanup** — Entity attributes now only show information relevant to each port type (SFP diagnostics on SFP ports only, PoE on PoE-capable ports only, wireless metrics on wireless clients only)
+- **Mangle fix** — Rules differing only by interface were silently dropped as duplicates
 
 ### v2.3.10
 - **Device tracker fix** — ARP `"incomplete"` status no longer falsely shows devices as "home" ([PR #38](https://github.com/jnctech/homeassistant-mikrotik_router/pull/38))

--- a/info.md
+++ b/info.md
@@ -4,7 +4,11 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
-### What's new in v2.3.10
+### What's new in v2.3.11-beta.1
+- **Attribute cleanup** — Removed ~1,300 meaningless default attributes (SFP fields on copper ports, PoE on non-PoE, client IP on loopback/VLAN, wireless metrics on wired hosts)
+- **Mangle fix** — Rules differing only by interface were silently dropped as duplicates ([PR #40](https://github.com/jnctech/homeassistant-mikrotik_router/pull/40))
+
+### v2.3.10
 - **Device tracker fix** — ARP `"incomplete"` status no longer falsely shows devices as "home" ([PR #38](https://github.com/jnctech/homeassistant-mikrotik_router/pull/38))
 
 ### v2.3.9

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1510,6 +1510,40 @@ def test_mangle_duplicate_removal():
     assert len(coordinator.ds["mangle"]) == 0
 
 
+def test_mangle_interface_differentiates_rules():
+    """Rules with same chain/action/protocol but different interfaces are not duplicates."""
+    coordinator = make_coordinator(
+        api_responses={
+            "/ip/firewall/mangle": [
+                {
+                    ".id": "*1",
+                    "chain": "forward",
+                    "action": "change MSS",
+                    "protocol": "tcp",
+                    "in-interface": "pppoe-out1",
+                    "disabled": False,
+                },
+                {
+                    ".id": "*2",
+                    "chain": "forward",
+                    "action": "change MSS",
+                    "protocol": "tcp",
+                    "out-interface": "pppoe-out1",
+                    "disabled": False,
+                },
+            ]
+        }
+    )
+    coordinator.mangle_removed = {}
+    coordinator.host = "10.0.0.1"
+    coordinator.get_mangle()
+    assert len(coordinator.ds["mangle"]) == 2
+    assert "*1" in coordinator.ds["mangle"]
+    assert "*2" in coordinator.ds["mangle"]
+    assert coordinator.ds["mangle"]["*1"]["in-interface"] == "pppoe-out1"
+    assert coordinator.ds["mangle"]["*2"]["out-interface"] == "pppoe-out1"
+
+
 # ---------------------------------------------------------------------------
 # Group N: get_filter() — filter rule parsing
 # ---------------------------------------------------------------------------

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -246,3 +246,55 @@ class TestMikrotikHostDeviceTracker:
         )
         attrs = entity.extra_state_attributes
         assert attrs["last_seen"] == "Unknown"
+
+    def test_extra_state_attributes_wireless_host_shows_signal_attrs(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: True})
+        coord.data["host"] = {
+            "mac1": _host_data(
+                source="wireless",
+                available=True,
+                **{
+                    "signal-strength": -55,
+                    "tx-ccq": 90,
+                    "tx-rate": "54Mbps",
+                    "rx-rate": "72Mbps",
+                },
+            )
+        }
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        attrs = entity.extra_state_attributes
+        assert attrs["signal_strength"] == -55
+        assert attrs["tx_ccq"] == 90
+        assert attrs["tx_rate"] == "54Mbps"
+        assert attrs["rx_rate"] == "72Mbps"
+
+    def test_extra_state_attributes_wired_host_no_wireless_attrs(self):
+        coord = make_mock_coordinator(options={CONF_TRACK_HOSTS: True})
+        coord.data["host"] = {
+            "mac1": _host_data(
+                source="arp",
+                available=True,
+                **{
+                    "signal-strength": 0,
+                    "tx-ccq": 0,
+                    "tx-rate": "",
+                    "rx-rate": "",
+                },
+            )
+        }
+        entity = _make_tracker(
+            cls=MikrotikHostDeviceTracker,
+            coordinator=coord,
+            desc_overrides={**_HOST_DESC},
+            uid="mac1",
+        )
+        attrs = entity.extra_state_attributes
+        assert "signal_strength" not in attrs
+        assert "tx_ccq" not in attrs
+        assert "tx_rate" not in attrs
+        assert "rx_rate" not in attrs

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -566,6 +566,9 @@ def test_mixin_ether_adds_ether_attributes():
     assert attrs["status"] == "link-ok"
     assert "rate" in attrs
     assert attrs["rate"] == "1Gbps"
+    # SFP attrs should NOT be present on copper ports
+    assert "sfp_temperature" not in attrs
+    assert "sfp_vendor_name" not in attrs
 
 
 def test_mixin_ether_skips_missing_ether_keys():
@@ -591,6 +594,28 @@ def test_mixin_ether_with_sfp_adds_sfp_attributes():
     assert "sfp_temperature" in attrs
     assert attrs["sfp_temperature"] == "45C"
     assert "sfp_vendor_name" in attrs
+    # Copper-only attrs should NOT appear on SFP ports
+    assert "rate" not in attrs
+    assert "full_duplex" not in attrs
+
+
+def test_mixin_ether_sfp_skips_junk_defaults():
+    """SFP attributes with 'unknown' or None values are omitted."""
+    entity = _ConcreteEntity(
+        {
+            "type": "ether",
+            "sfp-shutdown-temperature": "95C",
+            "sfp-temperature": "45C",
+            "sfp-vendor-name": "unknown",
+            "sfp-rx-power": None,
+            "sfp-module-present": "yes",
+        }
+    )
+    attrs = entity.extra_state_attributes
+    assert attrs["sfp_temperature"] == "45C"
+    assert "sfp_vendor_name" not in attrs
+    assert "sfp_rx_power" not in attrs
+    assert attrs["sfp_module_present"] == "yes"
 
 
 def test_mixin_ether_without_sfp_does_not_add_sfp_attributes():
@@ -603,6 +628,64 @@ def test_mixin_ether_without_sfp_does_not_add_sfp_attributes():
     assert "sfp_temperature" not in attrs
 
 
+def test_mixin_ether_sfp_shutdown_temp_zero_means_no_sfp():
+    """sfp-shutdown-temperature defaulting to 0 (coordinator default) is treated as no SFP."""
+    entity = _ConcreteEntity(
+        {
+            "type": "ether",
+            "sfp-shutdown-temperature": 0,
+            "sfp-temperature": 0,
+            "sfp-vendor-name": "unknown",
+            "status": "link-ok",
+            "rate": "1Gbps",
+        }
+    )
+    attrs = entity.extra_state_attributes
+    # Should show copper attrs, NOT SFP attrs
+    assert attrs["status"] == "link-ok"
+    assert attrs["rate"] == "1Gbps"
+    assert "sfp_temperature" not in attrs
+    assert "sfp_vendor_name" not in attrs
+
+
+def test_mixin_ether_poe_out_shown_when_supported():
+    """poe-out is shown only when the port has PoE support."""
+    entity = _ConcreteEntity({"type": "ether", "poe-out": "auto-on"})
+    attrs = entity.extra_state_attributes
+    assert attrs["poe_out"] == "auto-on"
+
+
+def test_mixin_ether_poe_out_hidden_when_na():
+    """poe-out 'N/A' (non-PoE ports) is not shown."""
+    entity = _ConcreteEntity({"type": "ether", "poe-out": "N/A"})
+    attrs = entity.extra_state_attributes
+    assert "poe_out" not in attrs
+
+
+def test_mixin_client_attrs_shown_when_meaningful():
+    """client-ip-address and client-mac-address shown when they have real values."""
+    entity = _ConcreteEntity(
+        {
+            "type": "ether",
+            "client-ip-address": "192.168.1.10",
+            "client-mac-address": "AA:BB:CC:DD:EE:FF",
+        }
+    )
+    attrs = entity.extra_state_attributes
+    assert attrs["client_ip_address"] == "192.168.1.10"
+    assert attrs["client_mac_address"] == "AA:BB:CC:DD:EE:FF"
+
+
+def test_mixin_client_attrs_hidden_when_junk():
+    """client-ip-address and client-mac-address hidden when 'unknown'/'none'."""
+    entity = _ConcreteEntity(
+        {"type": "ether", "client-ip-address": "unknown", "client-mac-address": "none"}
+    )
+    attrs = entity.extra_state_attributes
+    assert "client_ip_address" not in attrs
+    assert "client_mac_address" not in attrs
+
+
 def test_mixin_wlan_adds_wireless_attributes():
     """Wlan-type interface populates wireless-specific attributes."""
     entity = _ConcreteEntity({"type": "wlan", "ssid": "MyWifi", "band": "2ghz-b/g/n"})
@@ -612,13 +695,12 @@ def test_mixin_wlan_adds_wireless_attributes():
     assert "band" in attrs
 
 
-def test_mixin_other_type_adds_no_extra_attributes():
-    """Non-ether/wlan interfaces (e.g. bridge) produce no extra attributes."""
+def test_mixin_other_type_adds_no_type_specific_attributes():
+    """Non-ether/wlan interfaces (e.g. bridge) produce no type-specific attributes."""
     entity = _ConcreteEntity({"type": "bridge", "status": "active"})
     attrs = entity.extra_state_attributes
     assert "status" not in attrs
-    # Only the base attribution key is present
-    assert list(attrs.keys()) == ["attribution"]
+    assert "attribution" in attrs
 
 
 def test_mixin_missing_type_adds_no_extra_attributes():
@@ -626,7 +708,7 @@ def test_mixin_missing_type_adds_no_extra_attributes():
     entity = _ConcreteEntity({"status": "active"})
     attrs = entity.extra_state_attributes
     assert "status" not in attrs
-    assert list(attrs.keys()) == ["attribution"]
+    assert "attribution" in attrs
 
 
 def test_mixin_preserves_base_attributes():
@@ -666,6 +748,43 @@ def testcopy_attrs_empty_variables_list():
     data = {"status": "up"}
     copy_attrs(attributes, data, [])
     assert len(attributes) == 0
+
+
+def testcopy_attrs_skip_junk_filters_defaults():
+    """skip_junk=True omits 'unknown', 'none', 'N/A', and None values."""
+    attributes = {}
+    data = {
+        "real": "link-ok",
+        "junk1": "unknown",
+        "junk2": "none",
+        "junk3": "N/A",
+        "junk4": None,
+        "zero": 0,
+        "empty": "",
+    }
+    copy_attrs(
+        attributes,
+        data,
+        ["real", "junk1", "junk2", "junk3", "junk4", "zero", "empty"],
+        skip_junk=True,
+    )
+    assert attributes["real"] == "link-ok"
+    assert "junk1" not in attributes
+    assert "junk2" not in attributes
+    assert "junk3" not in attributes
+    assert "junk4" not in attributes
+    # 0 and "" are NOT filtered — they can be valid values
+    assert attributes["zero"] == 0
+    assert attributes["empty"] == ""
+
+
+def testcopy_attrs_without_skip_junk_includes_all():
+    """Default skip_junk=False preserves all values including junk defaults."""
+    attributes = {}
+    data = {"status": "unknown", "rate": None}
+    copy_attrs(attributes, data, ["status", "rate"])
+    assert attributes["status"] == "unknown"
+    assert attributes["rate"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Attribute cleanup** — Entity attributes now only show information relevant to each port type. SFP diagnostics on SFP ports only, PoE on PoE-capable ports only, wireless metrics on wireless clients only. See [ADR-009](docs/decisions/ADR-009-attribute-filtering-by-hardware.md).
- **Mangle fix** — Rules differing only by in/out-interface (e.g. MSS clamping) no longer silently removed as duplicates
- **SFP monitor fix** — SFP ports now show link rate and duplex; sfp-temperature default corrected for empty cages
- **Refactor** — Consolidated duplicated attribute logic via mixin inheritance; single-source attribute lists in `iface_attributes.py`
- **Docs** — ADR-009, architecture.md updated, sensor gap analysis added as public roadmap

## Test Plan
- [x] 473 tests pass, 5 skipped
- [x] Ruff lint + format clean
- [x] Beta tested on rb4011, hapax3, hapac2, csr310 — junk attributes verified eliminated
- [x] Mangle rules confirmed appearing as switches
- [x] ADR-009 documents attribute filtering decision and consequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)