### PR TITLE
feat: add DHCP server status and lease count sensors

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -665,7 +665,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         if self.api.connected() and self.support_wireless:
             await self.hass.async_add_executor_job(self.get_wireless_hosts)
 
-        for func in [self.get_bridge, self.get_arp, self.get_dhcp]:
+        for func in [self.get_bridge, self.get_arp, self.get_dhcp_server, self.get_dhcp]:
             await self._async_run_if_connected(func)
 
         if self.api.connected():
@@ -2165,6 +2165,14 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 else:
                     self.ds["dhcp"][uid]["interface"] = self.ds["arp"][uid]["interface"]
 
+        # Count active leases per DHCP server
+        for server_name in self.ds["dhcp-server"]:
+            self.ds["dhcp-server"][server_name]["lease-count"] = 0
+        for uid in self.ds["dhcp"]:
+            server = self.ds["dhcp"][uid]["server"]
+            if server in self.ds["dhcp-server"]:
+                self.ds["dhcp-server"][server]["lease-count"] += 1
+
     # ---------------------------
     #   get_dhcp_server
     # ---------------------------
@@ -2177,8 +2185,25 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             vals=[
                 {"name": "name"},
                 {"name": "interface", "default": "unknown"},
+                {"name": "address-pool", "default": "unknown"},
+                {
+                    "name": "enabled",
+                    "source": "disabled",
+                    "type": "bool",
+                    "reverse": True,
+                },
+                {"name": "comment", "default": ""},
+            ],
+            ensure_vals=[
+                {"name": "lease-count", "default": 0},
+                {"name": "status", "default": "unknown"},
             ],
         )
+
+        for uid in self.ds["dhcp-server"]:
+            self.ds["dhcp-server"][uid]["status"] = (
+                "running" if self.ds["dhcp-server"][uid]["enabled"] else "disabled"
+            )
 
     # ---------------------------
     #   get_dhcp_client

--- a/custom_components/mikrotik_router/sensor_types.py
+++ b/custom_components/mikrotik_router/sensor_types.py
@@ -53,6 +53,13 @@ DEVICE_ATTRIBUTES_DHCP_CLIENT = [
     "expires-after",
     "comment",
 ]
+DEVICE_ATTRIBUTES_DHCP_SERVER = [
+    "name",
+    "interface",
+    "address-pool",
+    "enabled",
+    "comment",
+]
 DEVICE_ATTRIBUTES_GPS = [
     "valid",
     "latitude",
@@ -857,6 +864,38 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
         data_uid="interface",
         data_reference="interface",
         data_attributes_list=DEVICE_ATTRIBUTES_DHCP_CLIENT,
+    ),
+    MikrotikSensorEntityDescription(
+        key="dhcp_server_status",
+        name="DHCP server",
+        icon="mdi:ip-network",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=None,
+        entity_category=None,
+        ha_group="System",
+        data_path="dhcp-server",
+        data_attribute="status",
+        data_name="name",
+        data_uid="name",
+        data_reference="name",
+        data_attributes_list=DEVICE_ATTRIBUTES_DHCP_SERVER,
+    ),
+    MikrotikSensorEntityDescription(
+        key="dhcp_server_lease_count",
+        name="DHCP server leases",
+        icon="mdi:ip-network-outline",
+        native_unit_of_measurement=None,
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=None,
+        ha_group="System",
+        data_path="dhcp-server",
+        data_attribute="lease-count",
+        data_name="name",
+        data_uid="name",
+        data_reference="name",
+        data_attributes_list=DEVICE_ATTRIBUTES_DHCP_SERVER,
     ),
 )
 


### PR DESCRIPTION
## Summary

- **Problem:** "DHCP status" and "DHCP address" sensors show "stopped"/"Unknown" on routers running DHCP servers for multiple VLANs, because they only monitor the router's own DHCP *client* config (`/ip/dhcp-client`), not the DHCP *server* instances
- **Fix:** Adds two new per-server sensors from `/ip/dhcp-server`:
  - **"DHCP server"** — shows "running" or "disabled" for each DHCP server instance
  - **"DHCP server leases"** — counts active leases per server
- Extends `get_dhcp_server()` to fetch `address-pool`, `enabled`, and `comment` fields
- Promotes `get_dhcp_server()` from lazy-loaded (only when unknown server encountered) to running every update cycle, so server status is always current

## Test plan

- [ ] Verify new "DHCP server" sensors appear per DHCP server instance (one per VLAN scope)
- [ ] Confirm each sensor shows "running" for active servers
- [ ] Confirm "DHCP server leases" counts match actual lease counts per server
- [ ] Verify existing "DHCP status"/"DHCP address" client sensors still work unchanged
- [ ] Check entity attributes include interface, address-pool, enabled, comment

https://claude.ai/code/session_011ywEx1T543iyxMkyq8uSfp