### PR TITLE
feat: faster startup, entity cleanup services, bug fixes (v2.3.12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,18 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
-## What's New — v2.3.11
+## What's New — v2.3.12
+
+**Faster startup** — The integration no longer blocks Home Assistant startup by sequentially pinging every tracked host. First-run host availability now uses the ARP table for instant results, with pings starting on the next 10-second tracker cycle. MAC vendor lookups are also parallelised instead of running one-by-one.
+
+**Bug fixes:**
+- Fixed chained comparison bug that could skip firmware v7+ client traffic processing
+- Fixed `voluptuous.Optional` incorrectly used as a type hint in API parser
+- All `datetime.now()` calls replaced with timezone-aware equivalents (HA coding standards)
+- `get_system_resource` now properly guarded against disconnected API
+
+<details>
+<summary>Previous: v2.3.11 — Attribute cleanup</summary>
 
 **Attribute cleanup** — Entity attributes now only show information relevant to each port type. Previously, all ethernet ports displayed SFP diagnostics, PoE status, and client tracking fields regardless of hardware capability. Now:
 
@@ -28,6 +39,8 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 | Wireless metrics | Shown on all tracked devices | Only wireless/CAPsMAN clients |
 
 **Mangle fix** — Rules differing only by `in-interface`/`out-interface` (e.g. MSS clamping for inbound vs outbound PPPoE) were silently removed as duplicates. Interface fields are now included in the rule unique ID.
+
+</details>
 
 <details>
 <summary>Previous: v2.3.10 — Device tracker fix</summary>

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 **Faster startup** — The integration no longer blocks Home Assistant startup by sequentially pinging every tracked host. First-run host availability now uses the ARP table for instant results, with pings starting on the next 10-second tracker cycle. MAC vendor lookups are also parallelised instead of running one-by-one.
 
+**Entity cleanup services** — Two new service actions available in Developer Tools > Services:
+- `mikrotik_router.cleanup_entities` — removes orphaned entities that no longer have backing router data (deleted interfaces, old firewall rules)
+- `mikrotik_router.cleanup_stale_hosts` — reports or removes stale device tracker entities for away hosts (dry_run mode by default)
+
 **Bug fixes:**
 - Fixed chained comparison bug that could skip firmware v7+ client traffic processing
 - Fixed `voluptuous.Optional` incorrectly used as a type hint in API parser

--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -87,34 +87,48 @@ async def async_cleanup_entities(
     entry_id = call.data["entry_id"]
 
     if entry_id not in hass.data.get(DOMAIN, {}):
-        raise vol.Invalid(f"Config entry '{entry_id}' not found for {DOMAIN}")
+        _LOGGER.error(
+            "Config entry '%s' not found. Available: %s",
+            entry_id,
+            list(hass.data.get(DOMAIN, {}).keys()),
+        )
+        return {"error": f"Config entry '{entry_id}' not found"}
 
-    mikrotik_data: MikrotikData = hass.data[DOMAIN][entry_id]
-    coordinator = mikrotik_data.data_coordinator
-    config_entry = coordinator.config_entry
-    inst = config_entry.data[CONF_NAME]
+    try:
+        mikrotik_data: MikrotikData = hass.data[DOMAIN][entry_id]
+        coordinator = mikrotik_data.data_coordinator
+        config_entry = coordinator.config_entry
+        inst = config_entry.data[CONF_NAME]
 
-    valid_ids = _build_valid_unique_ids(inst, coordinator.ds)
+        valid_ids = _build_valid_unique_ids(inst, coordinator.ds)
+        _LOGGER.debug("Built %d valid unique IDs for %s", len(valid_ids), inst)
 
-    entity_registry = er.async_get(hass)
-    removed: list[dict[str, str]] = []
+        entity_registry = er.async_get(hass)
+        removed: list[dict[str, str]] = []
 
-    for entity in list(entity_registry.entities.values()):
-        if entity.config_entry_id != entry_id:
-            continue
-        if entity.unique_id in valid_ids:
-            continue
+        for entity in list(entity_registry.entities.values()):
+            if entity.config_entry_id != entry_id:
+                continue
+            if entity.unique_id in valid_ids:
+                continue
+
+            _LOGGER.info(
+                "Removing orphaned entity %s (unique_id=%s)",
+                entity.entity_id,
+                entity.unique_id,
+            )
+            removed.append(
+                {"entity_id": entity.entity_id, "unique_id": entity.unique_id}
+            )
+            entity_registry.async_remove(entity.entity_id)
 
         _LOGGER.info(
-            "Removing orphaned entity %s (unique_id=%s)",
-            entity.entity_id,
-            entity.unique_id,
+            "Cleanup complete: removed %d orphaned entities", len(removed)
         )
-        removed.append({"entity_id": entity.entity_id, "unique_id": entity.unique_id})
-        entity_registry.async_remove(entity.entity_id)
-
-    _LOGGER.info("Cleanup complete: removed %d orphaned entities", len(removed))
-    return {"removed_count": len(removed), "removed_entities": removed}
+        return {"removed_count": len(removed), "removed_entities": removed}
+    except Exception as err:
+        _LOGGER.exception("cleanup_entities failed: %s", err)
+        return {"error": str(err)}
 
 
 SERVICE_CLEANUP_STALE_HOSTS = "cleanup_stale_hosts"
@@ -134,86 +148,98 @@ async def async_cleanup_stale_hosts(
     dry_run = call.data.get("dry_run", True)
 
     if entry_id not in hass.data.get(DOMAIN, {}):
-        raise vol.Invalid(f"Config entry '{entry_id}' not found for {DOMAIN}")
+        _LOGGER.error(
+            "Config entry '%s' not found. Available: %s",
+            entry_id,
+            list(hass.data.get(DOMAIN, {}).keys()),
+        )
+        return {"error": f"Config entry '{entry_id}' not found"}
 
-    mikrotik_data: MikrotikData = hass.data[DOMAIN][entry_id]
-    coordinator = mikrotik_data.data_coordinator
-    config_entry = coordinator.config_entry
-    inst = config_entry.data[CONF_NAME].lower()
+    try:
+        mikrotik_data: MikrotikData = hass.data[DOMAIN][entry_id]
+        coordinator = mikrotik_data.data_coordinator
+        config_entry = coordinator.config_entry
+        inst = config_entry.data[CONF_NAME].lower()
 
-    host_data = coordinator.ds.get("host", {})
-    entity_registry = er.async_get(hass)
+        host_data = coordinator.ds.get("host", {})
+        entity_registry = er.async_get(hass)
 
-    stale: list[dict[str, str]] = []
-    removed: list[dict[str, str]] = []
+        stale: list[dict[str, str]] = []
+        removed: list[dict[str, str]] = []
 
-    for entity in list(entity_registry.entities.values()):
-        if entity.config_entry_id != entry_id:
-            continue
-        if not entity.entity_id.startswith("device_tracker."):
-            continue
+        for entity in list(entity_registry.entities.values()):
+            if entity.config_entry_id != entry_id:
+                continue
+            if not entity.entity_id.startswith("device_tracker."):
+                continue
 
-        # Parse unique_id: {inst}-host-{mac_slug}
-        unique_id = entity.unique_id
-        prefix = f"{inst}-host-"
-        if not unique_id.startswith(prefix):
-            continue
+            # Parse unique_id: {inst}-host-{mac_slug}
+            unique_id = entity.unique_id
+            prefix = f"{inst}-host-"
+            if not unique_id.startswith(prefix):
+                continue
 
-        mac_slug = unique_id[len(prefix) :]
-        # Find matching host by slugified mac-address
-        host_entry = None
-        for uid, hdata in host_data.items():
-            mac = hdata.get("mac-address", "")
-            if slugify(str(mac).lower()) == mac_slug:
-                host_entry = hdata
-                break
+            mac_slug = unique_id[len(prefix) :]
+            # Find matching host by slugified mac-address
+            host_entry = None
+            for uid, hdata in host_data.items():
+                mac = hdata.get("mac-address", "")
+                if slugify(str(mac).lower()) == mac_slug:
+                    host_entry = hdata
+                    break
 
-        if host_entry is None:
-            # Host no longer in coordinator data at all
-            entry_info = {
-                "entity_id": entity.entity_id,
-                "unique_id": unique_id,
-                "source": "unknown",
-                "available": False,
-                "last_seen": "never",
-                "reason": "not_in_coordinator_data",
-            }
-            stale.append(entry_info)
-            if not dry_run:
-                entity_registry.async_remove(entity.entity_id)
-                removed.append(entry_info)
-            continue
+            if host_entry is None:
+                entry_info = {
+                    "entity_id": entity.entity_id,
+                    "unique_id": unique_id,
+                    "source": "unknown",
+                    "available": False,
+                    "last_seen": "never",
+                    "reason": "not_in_coordinator_data",
+                }
+                stale.append(entry_info)
+                if not dry_run:
+                    entity_registry.async_remove(entity.entity_id)
+                    removed.append(entry_info)
+                continue
 
-        is_available = host_entry.get("available", False)
-        source = host_entry.get("source", "unknown")
-        last_seen = host_entry.get("last-seen", "unknown")
+            is_available = host_entry.get("available", False)
+            source = host_entry.get("source", "unknown")
+            last_seen = host_entry.get("last-seen", "unknown")
 
-        if not is_available:
-            entry_info = {
-                "entity_id": entity.entity_id,
-                "unique_id": unique_id,
-                "source": source,
-                "available": False,
-                "last_seen": str(last_seen),
-                "host_name": host_entry.get("host-name", "unknown"),
-                "mac_address": host_entry.get("mac-address", "unknown"),
-                "reason": "host_unavailable",
-            }
-            stale.append(entry_info)
-            if not dry_run:
-                entity_registry.async_remove(entity.entity_id)
-                removed.append(entry_info)
+            if not is_available:
+                entry_info = {
+                    "entity_id": entity.entity_id,
+                    "unique_id": unique_id,
+                    "source": source,
+                    "available": False,
+                    "last_seen": str(last_seen),
+                    "host_name": host_entry.get("host-name", "unknown"),
+                    "mac_address": host_entry.get("mac-address", "unknown"),
+                    "reason": "host_unavailable",
+                }
+                stale.append(entry_info)
+                if not dry_run:
+                    entity_registry.async_remove(entity.entity_id)
+                    removed.append(entry_info)
 
-    if dry_run:
-        _LOGGER.info("Stale hosts dry run: found %d stale host entities", len(stale))
-        return {"stale_count": len(stale), "stale_hosts": stale}
+        if dry_run:
+            _LOGGER.info(
+                "Stale hosts dry run: found %d stale host entities", len(stale)
+            )
+            return {"stale_count": len(stale), "stale_hosts": stale}
 
-    _LOGGER.info("Stale hosts cleanup: removed %d host entities", len(removed))
-    return {
-        "stale_count": len(stale),
-        "removed_count": len(removed),
-        "removed_hosts": removed,
-    }
+        _LOGGER.info(
+            "Stale hosts cleanup: removed %d host entities", len(removed)
+        )
+        return {
+            "stale_count": len(stale),
+            "removed_count": len(removed),
+            "removed_hosts": removed,
+        }
+    except Exception as err:
+        _LOGGER.exception("cleanup_stale_hosts failed: %s", err)
+        return {"error": str(err)}
 
 
 # ---------------------------

--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -217,10 +217,13 @@ async def async_cleanup_stale_hosts(
 
 
 # ---------------------------
-#   async_setup
+#   _async_register_services
 # ---------------------------
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    """Set up the Mikrotik Router integration (register services)."""
+def _async_register_services(hass: HomeAssistant) -> None:
+    """Register integration services (idempotent — safe to call per entry)."""
+    if hass.services.has_service(DOMAIN, SERVICE_CLEANUP_ENTITIES):
+        return
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_CLEANUP_ENTITIES,
@@ -235,7 +238,6 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         schema=CLEANUP_STALE_HOSTS_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
-    return True
 
 
 # ---------------------------
@@ -243,6 +245,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 # ---------------------------
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up a config entry."""
+    _async_register_services(hass)
     coordinator = MikrotikCoordinator(hass, config_entry)
     await coordinator.async_config_entry_first_refresh()
     coordinator_tracker = MikrotikTrackerCoordinator(hass, config_entry, coordinator)

--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -111,6 +111,11 @@ async def async_cleanup_entities(call: ServiceCall) -> ServiceResponse:
     inst = config_entry.data[CONF_NAME]
 
     valid_ids = _build_valid_unique_ids(inst, coordinator.ds)
+    if not valid_ids:
+        raise HomeAssistantError(
+            "No valid entity IDs generated — aborting to prevent removing all "
+            "entities. This may indicate empty coordinator data or a bug."
+        )
     _LOGGER.debug("Built %d valid unique IDs for %s", len(valid_ids), inst)
 
     entity_registry = er.async_get(hass)

--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import voluptuous as vol
 import logging
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.util import slugify
 
-from homeassistant.const import CONF_VERIFY_SSL
+from homeassistant.const import CONF_NAME, CONF_VERIFY_SSL
 
 from .const import PLATFORMS, DOMAIN, DEFAULT_VERIFY_SSL
 from .coordinator import MikrotikData, MikrotikCoordinator, MikrotikTrackerCoordinator
@@ -20,6 +22,224 @@ SCRIPT_SCHEMA = vol.Schema(
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+SERVICE_CLEANUP_ENTITIES = "cleanup_entities"
+CLEANUP_SCHEMA = vol.Schema(
+    {vol.Required("entry_id"): cv.string}
+)
+
+
+def _collect_all_descriptions() -> list:
+    """Import and collect all entity descriptions from all platforms."""
+    from .sensor_types import SENSOR_TYPES
+    from .binary_sensor_types import SENSOR_TYPES as BINARY_SENSOR_TYPES
+    from .device_tracker_types import SENSOR_TYPES as DEVICE_TRACKER_TYPES
+    from .switch_types import SENSOR_TYPES as SWITCH_TYPES
+    from .button_types import SENSOR_TYPES as BUTTON_TYPES
+    from .update_types import SENSOR_TYPES as UPDATE_TYPES
+
+    descriptions = []
+    descriptions.extend(SENSOR_TYPES)
+    descriptions.extend(BINARY_SENSOR_TYPES)
+    descriptions.extend(DEVICE_TRACKER_TYPES)
+    descriptions.extend(SWITCH_TYPES)
+    descriptions.extend(BUTTON_TYPES)
+    descriptions.extend(UPDATE_TYPES)
+    return descriptions
+
+
+def _build_valid_unique_ids(inst: str, coordinator_data: dict) -> set[str]:
+    """Build the set of unique_ids that should currently exist."""
+    descriptions = _collect_all_descriptions()
+    valid_ids: set[str] = set()
+    inst_lower = inst.lower()
+
+    for desc in descriptions:
+        data_path = desc.data_path
+        if data_path not in coordinator_data:
+            continue
+
+        data = coordinator_data[data_path]
+
+        if not desc.data_reference:
+            # System-level entity (no per-device reference)
+            if data.get(desc.data_attribute) is not None:
+                valid_ids.add(f"{inst_lower}-{desc.key}")
+        else:
+            # Per-device/per-item entity
+            for uid in data:
+                ref_value = data[uid].get(desc.data_reference)
+                if ref_value is not None:
+                    valid_ids.add(
+                        f"{inst_lower}-{desc.key}-"
+                        f"{slugify(str(ref_value).lower())}"
+                    )
+
+    return valid_ids
+
+
+async def async_cleanup_entities(
+    hass: HomeAssistant, call: ServiceCall
+) -> ServiceResponse:
+    """Remove orphaned entities that no longer have backing data."""
+    entry_id = call.data["entry_id"]
+
+    if entry_id not in hass.data.get(DOMAIN, {}):
+        raise vol.Invalid(f"Config entry '{entry_id}' not found for {DOMAIN}")
+
+    mikrotik_data: MikrotikData = hass.data[DOMAIN][entry_id]
+    coordinator = mikrotik_data.data_coordinator
+    config_entry = coordinator.config_entry
+    inst = config_entry.data[CONF_NAME]
+
+    valid_ids = _build_valid_unique_ids(inst, coordinator.ds)
+
+    entity_registry = er.async_get(hass)
+    removed: list[dict[str, str]] = []
+
+    for entity in list(entity_registry.entities.values()):
+        if entity.config_entry_id != entry_id:
+            continue
+        if entity.unique_id in valid_ids:
+            continue
+
+        _LOGGER.info(
+            "Removing orphaned entity %s (unique_id=%s)",
+            entity.entity_id,
+            entity.unique_id,
+        )
+        removed.append(
+            {"entity_id": entity.entity_id, "unique_id": entity.unique_id}
+        )
+        entity_registry.async_remove(entity.entity_id)
+
+    _LOGGER.info("Cleanup complete: removed %d orphaned entities", len(removed))
+    return {"removed_count": len(removed), "removed_entities": removed}
+
+
+SERVICE_CLEANUP_STALE_HOSTS = "cleanup_stale_hosts"
+CLEANUP_STALE_HOSTS_SCHEMA = vol.Schema(
+    {
+        vol.Required("entry_id"): cv.string,
+        vol.Optional("dry_run", default=True): cv.boolean,
+    }
+)
+
+
+async def async_cleanup_stale_hosts(
+    hass: HomeAssistant, call: ServiceCall
+) -> ServiceResponse:
+    """Report or remove device tracker entities for away/stale hosts."""
+    entry_id = call.data["entry_id"]
+    dry_run = call.data.get("dry_run", True)
+
+    if entry_id not in hass.data.get(DOMAIN, {}):
+        raise vol.Invalid(f"Config entry '{entry_id}' not found for {DOMAIN}")
+
+    mikrotik_data: MikrotikData = hass.data[DOMAIN][entry_id]
+    coordinator = mikrotik_data.data_coordinator
+    config_entry = coordinator.config_entry
+    inst = config_entry.data[CONF_NAME].lower()
+
+    host_data = coordinator.ds.get("host", {})
+    entity_registry = er.async_get(hass)
+
+    stale: list[dict[str, str]] = []
+    removed: list[dict[str, str]] = []
+
+    for entity in list(entity_registry.entities.values()):
+        if entity.config_entry_id != entry_id:
+            continue
+        if not entity.entity_id.startswith("device_tracker."):
+            continue
+
+        # Parse unique_id: {inst}-host-{mac_slug}
+        unique_id = entity.unique_id
+        prefix = f"{inst}-host-"
+        if not unique_id.startswith(prefix):
+            continue
+
+        mac_slug = unique_id[len(prefix):]
+        # Find matching host by slugified mac-address
+        host_entry = None
+        for uid, hdata in host_data.items():
+            mac = hdata.get("mac-address", "")
+            if slugify(str(mac).lower()) == mac_slug:
+                host_entry = hdata
+                break
+
+        if host_entry is None:
+            # Host no longer in coordinator data at all
+            entry_info = {
+                "entity_id": entity.entity_id,
+                "unique_id": unique_id,
+                "source": "unknown",
+                "available": False,
+                "last_seen": "never",
+                "reason": "not_in_coordinator_data",
+            }
+            stale.append(entry_info)
+            if not dry_run:
+                entity_registry.async_remove(entity.entity_id)
+                removed.append(entry_info)
+            continue
+
+        is_available = host_entry.get("available", False)
+        source = host_entry.get("source", "unknown")
+        last_seen = host_entry.get("last-seen", "unknown")
+
+        if not is_available:
+            entry_info = {
+                "entity_id": entity.entity_id,
+                "unique_id": unique_id,
+                "source": source,
+                "available": False,
+                "last_seen": str(last_seen),
+                "host_name": host_entry.get("host-name", "unknown"),
+                "mac_address": host_entry.get("mac-address", "unknown"),
+                "reason": "host_unavailable",
+            }
+            stale.append(entry_info)
+            if not dry_run:
+                entity_registry.async_remove(entity.entity_id)
+                removed.append(entry_info)
+
+    if dry_run:
+        _LOGGER.info(
+            "Stale hosts dry run: found %d stale host entities", len(stale)
+        )
+        return {"stale_count": len(stale), "stale_hosts": stale}
+
+    _LOGGER.info(
+        "Stale hosts cleanup: removed %d host entities", len(removed)
+    )
+    return {
+        "stale_count": len(stale),
+        "removed_count": len(removed),
+        "removed_hosts": removed,
+    }
+
+
+# ---------------------------
+#   async_setup
+# ---------------------------
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the Mikrotik Router integration (register services)."""
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEANUP_ENTITIES,
+        async_cleanup_entities,
+        schema=CLEANUP_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEANUP_STALE_HOSTS,
+        async_cleanup_stale_hosts,
+        schema=CLEANUP_STALE_HOSTS_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+    return True
 
 
 # ---------------------------

--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -81,9 +81,7 @@ def _build_valid_unique_ids(inst: str, coordinator_data: dict) -> set[str]:
     return valid_ids
 
 
-def _get_mikrotik_data(
-    hass: HomeAssistant, entry_id: str
-) -> MikrotikData | None:
+def _get_mikrotik_data(hass: HomeAssistant, entry_id: str) -> MikrotikData | None:
     """Look up MikrotikData for a config entry, logging an error if missing."""
     domain_data = hass.data.get(DOMAIN, {})
     if entry_id in domain_data:
@@ -132,9 +130,7 @@ async def async_cleanup_entities(call: ServiceCall) -> ServiceResponse:
             entity.entity_id,
             entity.unique_id,
         )
-        removed.append(
-            {"entity_id": entity.entity_id, "unique_id": entity.unique_id}
-        )
+        removed.append({"entity_id": entity.entity_id, "unique_id": entity.unique_id})
         entity_registry.async_remove(entity.entity_id)
 
     _LOGGER.info("Cleanup complete: removed %d orphaned entities", len(removed))
@@ -159,9 +155,7 @@ def _find_host_by_mac_slug(host_data: dict, mac_slug: str) -> dict | None:
     return None
 
 
-def _classify_host_entity(
-    entity, host_data: dict, prefix: str
-) -> dict | None:
+def _classify_host_entity(entity, host_data: dict, prefix: str) -> dict | None:
     """Return a stale-host info dict if the entity is stale, else None."""
     unique_id = entity.unique_id
     if not unique_id.startswith(prefix):
@@ -230,9 +224,7 @@ async def async_cleanup_stale_hosts(call: ServiceCall) -> ServiceResponse:
             removed.append(entry_info)
 
     if dry_run:
-        _LOGGER.info(
-            "Stale hosts dry run: found %d stale host entities", len(stale)
-        )
+        _LOGGER.info("Stale hosts dry run: found %d stale host entities", len(stale))
         return {"stale_count": len(stale), "stale_hosts": stale}
 
     _LOGGER.info("Stale hosts cleanup: removed %d host entities", len(removed))

--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -80,10 +80,10 @@ def _build_valid_unique_ids(inst: str, coordinator_data: dict) -> set[str]:
     return valid_ids
 
 
-async def async_cleanup_entities(
-    hass: HomeAssistant, call: ServiceCall
+async def async_cleanup_entities(call: ServiceCall
 ) -> ServiceResponse:
     """Remove orphaned entities that no longer have backing data."""
+    hass = call.hass
     entry_id = call.data["entry_id"]
 
     if entry_id not in hass.data.get(DOMAIN, {}):
@@ -138,10 +138,10 @@ CLEANUP_STALE_HOSTS_SCHEMA = vol.Schema(
 )
 
 
-async def async_cleanup_stale_hosts(
-    hass: HomeAssistant, call: ServiceCall
+async def async_cleanup_stale_hosts(call: ServiceCall
 ) -> ServiceResponse:
     """Report or remove device tracker entities for away/stale hosts."""
+    hass = call.hass
     entry_id = call.data["entry_id"]
     dry_run = call.data.get("dry_run", True)
 

--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -122,9 +122,7 @@ async def async_cleanup_entities(
             )
             entity_registry.async_remove(entity.entity_id)
 
-        _LOGGER.info(
-            "Cleanup complete: removed %d orphaned entities", len(removed)
-        )
+        _LOGGER.info("Cleanup complete: removed %d orphaned entities", len(removed))
         return {"removed_count": len(removed), "removed_entities": removed}
     except Exception as err:
         _LOGGER.exception("cleanup_entities failed: %s", err)
@@ -229,9 +227,7 @@ async def async_cleanup_stale_hosts(
             )
             return {"stale_count": len(stale), "stale_hosts": stale}
 
-        _LOGGER.info(
-            "Stale hosts cleanup: removed %d host entities", len(removed)
-        )
+        _LOGGER.info("Stale hosts cleanup: removed %d host entities", len(removed))
         return {
             "stale_count": len(stale),
             "removed_count": len(removed),

--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -80,8 +80,7 @@ def _build_valid_unique_ids(inst: str, coordinator_data: dict) -> set[str]:
     return valid_ids
 
 
-async def async_cleanup_entities(call: ServiceCall
-) -> ServiceResponse:
+async def async_cleanup_entities(call: ServiceCall) -> ServiceResponse:
     """Remove orphaned entities that no longer have backing data."""
     hass = call.hass
     entry_id = call.data["entry_id"]
@@ -138,8 +137,7 @@ CLEANUP_STALE_HOSTS_SCHEMA = vol.Schema(
 )
 
 
-async def async_cleanup_stale_hosts(call: ServiceCall
-) -> ServiceResponse:
+async def async_cleanup_stale_hosts(call: ServiceCall) -> ServiceResponse:
     """Report or remove device tracker entities for away/stale hosts."""
     hass = call.hass
     entry_id = call.data["entry_id"]

--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import voluptuous as vol
 import logging
 
-from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry
 from homeassistant.helpers import entity_registry as er
@@ -24,9 +29,7 @@ SCRIPT_SCHEMA = vol.Schema(
 _LOGGER = logging.getLogger(__name__)
 
 SERVICE_CLEANUP_ENTITIES = "cleanup_entities"
-CLEANUP_SCHEMA = vol.Schema(
-    {vol.Required("entry_id"): cv.string}
-)
+CLEANUP_SCHEMA = vol.Schema({vol.Required("entry_id"): cv.string})
 
 
 def _collect_all_descriptions() -> list:
@@ -71,8 +74,7 @@ def _build_valid_unique_ids(inst: str, coordinator_data: dict) -> set[str]:
                 ref_value = data[uid].get(desc.data_reference)
                 if ref_value is not None:
                     valid_ids.add(
-                        f"{inst_lower}-{desc.key}-"
-                        f"{slugify(str(ref_value).lower())}"
+                        f"{inst_lower}-{desc.key}-{slugify(str(ref_value).lower())}"
                     )
 
     return valid_ids
@@ -108,9 +110,7 @@ async def async_cleanup_entities(
             entity.entity_id,
             entity.unique_id,
         )
-        removed.append(
-            {"entity_id": entity.entity_id, "unique_id": entity.unique_id}
-        )
+        removed.append({"entity_id": entity.entity_id, "unique_id": entity.unique_id})
         entity_registry.async_remove(entity.entity_id)
 
     _LOGGER.info("Cleanup complete: removed %d orphaned entities", len(removed))
@@ -159,7 +159,7 @@ async def async_cleanup_stale_hosts(
         if not unique_id.startswith(prefix):
             continue
 
-        mac_slug = unique_id[len(prefix):]
+        mac_slug = unique_id[len(prefix) :]
         # Find matching host by slugified mac-address
         host_entry = None
         for uid, hdata in host_data.items():
@@ -205,14 +205,10 @@ async def async_cleanup_stale_hosts(
                 removed.append(entry_info)
 
     if dry_run:
-        _LOGGER.info(
-            "Stale hosts dry run: found %d stale host entities", len(stale)
-        )
+        _LOGGER.info("Stale hosts dry run: found %d stale host entities", len(stale))
         return {"stale_count": len(stale), "stale_hosts": stale}
 
-    _LOGGER.info(
-        "Stale hosts cleanup: removed %d host entities", len(removed)
-    )
+    _LOGGER.info("Stale hosts cleanup: removed %d host entities", len(removed))
     return {
         "stale_count": len(stale),
         "removed_count": len(removed),

--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.util import slugify
 
 from homeassistant.const import CONF_NAME, CONF_VERIFY_SSL
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import PLATFORMS, DOMAIN, DEFAULT_VERIFY_SSL
 from .coordinator import MikrotikData, MikrotikCoordinator, MikrotikTrackerCoordinator
@@ -41,14 +42,14 @@ def _collect_all_descriptions() -> list:
     from .button_types import SENSOR_TYPES as BUTTON_TYPES
     from .update_types import SENSOR_TYPES as UPDATE_TYPES
 
-    descriptions = []
-    descriptions.extend(SENSOR_TYPES)
-    descriptions.extend(BINARY_SENSOR_TYPES)
-    descriptions.extend(DEVICE_TRACKER_TYPES)
-    descriptions.extend(SWITCH_TYPES)
-    descriptions.extend(BUTTON_TYPES)
-    descriptions.extend(UPDATE_TYPES)
-    return descriptions
+    return [
+        *SENSOR_TYPES,
+        *BINARY_SENSOR_TYPES,
+        *DEVICE_TRACKER_TYPES,
+        *SWITCH_TYPES,
+        *BUTTON_TYPES,
+        *UPDATE_TYPES,
+    ]
 
 
 def _build_valid_unique_ids(inst: str, coordinator_data: dict) -> set[str]:
@@ -80,52 +81,59 @@ def _build_valid_unique_ids(inst: str, coordinator_data: dict) -> set[str]:
     return valid_ids
 
 
+def _get_mikrotik_data(
+    hass: HomeAssistant, entry_id: str
+) -> MikrotikData | None:
+    """Look up MikrotikData for a config entry, logging an error if missing."""
+    domain_data = hass.data.get(DOMAIN, {})
+    if entry_id in domain_data:
+        return domain_data[entry_id]
+
+    _LOGGER.error(
+        "Config entry '%s' not found. Available: %s",
+        entry_id,
+        list(domain_data.keys()),
+    )
+    return None
+
+
 async def async_cleanup_entities(call: ServiceCall) -> ServiceResponse:
     """Remove orphaned entities that no longer have backing data."""
     hass = call.hass
     entry_id = call.data["entry_id"]
 
-    if entry_id not in hass.data.get(DOMAIN, {}):
-        _LOGGER.error(
-            "Config entry '%s' not found. Available: %s",
-            entry_id,
-            list(hass.data.get(DOMAIN, {}).keys()),
+    mikrotik_data = _get_mikrotik_data(hass, entry_id)
+    if mikrotik_data is None:
+        raise HomeAssistantError(f"Config entry '{entry_id}' not found")
+
+    coordinator = mikrotik_data.data_coordinator
+    config_entry = coordinator.config_entry
+    inst = config_entry.data[CONF_NAME]
+
+    valid_ids = _build_valid_unique_ids(inst, coordinator.ds)
+    _LOGGER.debug("Built %d valid unique IDs for %s", len(valid_ids), inst)
+
+    entity_registry = er.async_get(hass)
+    removed: list[dict[str, str]] = []
+
+    for entity in list(entity_registry.entities.values()):
+        if entity.config_entry_id != entry_id:
+            continue
+        if entity.unique_id in valid_ids:
+            continue
+
+        _LOGGER.info(
+            "Removing orphaned entity %s (unique_id=%s)",
+            entity.entity_id,
+            entity.unique_id,
         )
-        return {"error": f"Config entry '{entry_id}' not found"}
+        removed.append(
+            {"entity_id": entity.entity_id, "unique_id": entity.unique_id}
+        )
+        entity_registry.async_remove(entity.entity_id)
 
-    try:
-        mikrotik_data: MikrotikData = hass.data[DOMAIN][entry_id]
-        coordinator = mikrotik_data.data_coordinator
-        config_entry = coordinator.config_entry
-        inst = config_entry.data[CONF_NAME]
-
-        valid_ids = _build_valid_unique_ids(inst, coordinator.ds)
-        _LOGGER.debug("Built %d valid unique IDs for %s", len(valid_ids), inst)
-
-        entity_registry = er.async_get(hass)
-        removed: list[dict[str, str]] = []
-
-        for entity in list(entity_registry.entities.values()):
-            if entity.config_entry_id != entry_id:
-                continue
-            if entity.unique_id in valid_ids:
-                continue
-
-            _LOGGER.info(
-                "Removing orphaned entity %s (unique_id=%s)",
-                entity.entity_id,
-                entity.unique_id,
-            )
-            removed.append(
-                {"entity_id": entity.entity_id, "unique_id": entity.unique_id}
-            )
-            entity_registry.async_remove(entity.entity_id)
-
-        _LOGGER.info("Cleanup complete: removed %d orphaned entities", len(removed))
-        return {"removed_count": len(removed), "removed_entities": removed}
-    except Exception as err:
-        _LOGGER.exception("cleanup_entities failed: %s", err)
-        return {"error": str(err)}
+    _LOGGER.info("Cleanup complete: removed %d orphaned entities", len(removed))
+    return {"removed_count": len(removed), "removed_entities": removed}
 
 
 SERVICE_CLEANUP_STALE_HOSTS = "cleanup_stale_hosts"
@@ -137,103 +145,97 @@ CLEANUP_STALE_HOSTS_SCHEMA = vol.Schema(
 )
 
 
+def _find_host_by_mac_slug(host_data: dict, mac_slug: str) -> dict | None:
+    """Find a host entry by slugified MAC address."""
+    for uid, hdata in host_data.items():
+        mac = hdata.get("mac-address", "")
+        if slugify(str(mac).lower()) == mac_slug:
+            return hdata
+    return None
+
+
+def _classify_host_entity(
+    entity, host_data: dict, prefix: str
+) -> dict | None:
+    """Return a stale-host info dict if the entity is stale, else None."""
+    unique_id = entity.unique_id
+    if not unique_id.startswith(prefix):
+        return None
+
+    mac_slug = unique_id[len(prefix) :]
+    host_entry = _find_host_by_mac_slug(host_data, mac_slug)
+
+    if host_entry is None:
+        return {
+            "entity_id": entity.entity_id,
+            "unique_id": unique_id,
+            "source": "unknown",
+            "available": False,
+            "last_seen": "never",
+            "reason": "not_in_coordinator_data",
+        }
+
+    if not host_entry.get("available", False):
+        return {
+            "entity_id": entity.entity_id,
+            "unique_id": unique_id,
+            "source": host_entry.get("source", "unknown"),
+            "available": False,
+            "last_seen": str(host_entry.get("last-seen", "unknown")),
+            "host_name": host_entry.get("host-name", "unknown"),
+            "mac_address": host_entry.get("mac-address", "unknown"),
+            "reason": "host_unavailable",
+        }
+
+    return None
+
+
 async def async_cleanup_stale_hosts(call: ServiceCall) -> ServiceResponse:
     """Report or remove device tracker entities for away/stale hosts."""
     hass = call.hass
     entry_id = call.data["entry_id"]
     dry_run = call.data.get("dry_run", True)
 
-    if entry_id not in hass.data.get(DOMAIN, {}):
-        _LOGGER.error(
-            "Config entry '%s' not found. Available: %s",
-            entry_id,
-            list(hass.data.get(DOMAIN, {}).keys()),
+    mikrotik_data = _get_mikrotik_data(hass, entry_id)
+    if mikrotik_data is None:
+        raise HomeAssistantError(f"Config entry '{entry_id}' not found")
+
+    coordinator = mikrotik_data.data_coordinator
+    inst = coordinator.config_entry.data[CONF_NAME].lower()
+    host_data = coordinator.ds.get("host", {})
+    entity_registry = er.async_get(hass)
+    prefix = f"{inst}-host-"
+
+    stale: list[dict[str, str]] = []
+    removed: list[dict[str, str]] = []
+
+    for entity in list(entity_registry.entities.values()):
+        if entity.config_entry_id != entry_id:
+            continue
+        if not entity.entity_id.startswith("device_tracker."):
+            continue
+
+        entry_info = _classify_host_entity(entity, host_data, prefix)
+        if entry_info is None:
+            continue
+
+        stale.append(entry_info)
+        if not dry_run:
+            entity_registry.async_remove(entity.entity_id)
+            removed.append(entry_info)
+
+    if dry_run:
+        _LOGGER.info(
+            "Stale hosts dry run: found %d stale host entities", len(stale)
         )
-        return {"error": f"Config entry '{entry_id}' not found"}
+        return {"stale_count": len(stale), "stale_hosts": stale}
 
-    try:
-        mikrotik_data: MikrotikData = hass.data[DOMAIN][entry_id]
-        coordinator = mikrotik_data.data_coordinator
-        config_entry = coordinator.config_entry
-        inst = config_entry.data[CONF_NAME].lower()
-
-        host_data = coordinator.ds.get("host", {})
-        entity_registry = er.async_get(hass)
-
-        stale: list[dict[str, str]] = []
-        removed: list[dict[str, str]] = []
-
-        for entity in list(entity_registry.entities.values()):
-            if entity.config_entry_id != entry_id:
-                continue
-            if not entity.entity_id.startswith("device_tracker."):
-                continue
-
-            # Parse unique_id: {inst}-host-{mac_slug}
-            unique_id = entity.unique_id
-            prefix = f"{inst}-host-"
-            if not unique_id.startswith(prefix):
-                continue
-
-            mac_slug = unique_id[len(prefix) :]
-            # Find matching host by slugified mac-address
-            host_entry = None
-            for uid, hdata in host_data.items():
-                mac = hdata.get("mac-address", "")
-                if slugify(str(mac).lower()) == mac_slug:
-                    host_entry = hdata
-                    break
-
-            if host_entry is None:
-                entry_info = {
-                    "entity_id": entity.entity_id,
-                    "unique_id": unique_id,
-                    "source": "unknown",
-                    "available": False,
-                    "last_seen": "never",
-                    "reason": "not_in_coordinator_data",
-                }
-                stale.append(entry_info)
-                if not dry_run:
-                    entity_registry.async_remove(entity.entity_id)
-                    removed.append(entry_info)
-                continue
-
-            is_available = host_entry.get("available", False)
-            source = host_entry.get("source", "unknown")
-            last_seen = host_entry.get("last-seen", "unknown")
-
-            if not is_available:
-                entry_info = {
-                    "entity_id": entity.entity_id,
-                    "unique_id": unique_id,
-                    "source": source,
-                    "available": False,
-                    "last_seen": str(last_seen),
-                    "host_name": host_entry.get("host-name", "unknown"),
-                    "mac_address": host_entry.get("mac-address", "unknown"),
-                    "reason": "host_unavailable",
-                }
-                stale.append(entry_info)
-                if not dry_run:
-                    entity_registry.async_remove(entity.entity_id)
-                    removed.append(entry_info)
-
-        if dry_run:
-            _LOGGER.info(
-                "Stale hosts dry run: found %d stale host entities", len(stale)
-            )
-            return {"stale_count": len(stale), "stale_hosts": stale}
-
-        _LOGGER.info("Stale hosts cleanup: removed %d host entities", len(removed))
-        return {
-            "stale_count": len(stale),
-            "removed_count": len(removed),
-            "removed_hosts": removed,
-        }
-    except Exception as err:
-        _LOGGER.exception("cleanup_stale_hosts failed: %s", err)
-        return {"error": str(err)}
+    _LOGGER.info("Stale hosts cleanup: removed %d host entities", len(removed))
+    return {
+        "stale_count": len(stale),
+        "removed_count": len(removed),
+        "removed_hosts": removed,
+    }
 
 
 # ---------------------------
@@ -300,6 +302,10 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         config_entry, PLATFORMS
     ):
         hass.data[DOMAIN].pop(config_entry.entry_id)
+
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_CLEANUP_ENTITIES)
+            hass.services.async_remove(DOMAIN, SERVICE_CLEANUP_STALE_HOSTS)
 
     return unload_ok
 

--- a/custom_components/mikrotik_router/apiparser.py
+++ b/custom_components/mikrotik_router/apiparser.py
@@ -1,9 +1,9 @@
 """API parser for JSON APIs."""
 
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from logging import getLogger
-
-from voluptuous import Optional
 
 from homeassistant.components.diagnostics import async_redact_data
 
@@ -149,7 +149,7 @@ def parse_api(
 # ---------------------------
 #   get_uid
 # ---------------------------
-def get_uid(entry, key, key_secondary, key_search, keymap) -> Optional(str):
+def get_uid(entry, key, key_secondary, key_search, keymap) -> str | None:
     """Get UID for data list."""
     uid = None
     if not key_search:
@@ -178,7 +178,7 @@ def get_uid(entry, key, key_secondary, key_search, keymap) -> Optional(str):
 # ---------------------------
 #   generate_keymap
 # ---------------------------
-def generate_keymap(data, key_search) -> Optional(dict):
+def generate_keymap(data, key_search) -> dict | None:
     """Generate keymap."""
     return (
         {data[uid][key_search]: uid for uid in data if key_search in data[uid]}

--- a/custom_components/mikrotik_router/config_flow.py
+++ b/custom_components/mikrotik_router/config_flow.py
@@ -1,5 +1,7 @@
 """Config flow to configure Mikrotik Router."""
 
+from __future__ import annotations
+
 import logging
 
 import voluptuous as vol

--- a/custom_components/mikrotik_router/const.py
+++ b/custom_components/mikrotik_router/const.py
@@ -1,5 +1,7 @@
 """Constants used by the Mikrotik Router component and platforms."""
 
+from __future__ import annotations
+
 from homeassistant.const import Platform
 
 PLATFORMS = [

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -611,11 +611,11 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 self.ds["host_hass"][tmp[2].upper()] = entity.original_name
 
     # ---------------------------
-    #   _async_run_if_connected
+    #   _run_if_enabled
     # ---------------------------
-    async def _async_run_if_connected(self, func) -> None:
-        """Run a blocking function in the executor if the API is connected."""
-        if self.api.connected():
+    async def _run_if_enabled(self, func, *, requires: bool = True) -> None:
+        """Run a blocking API call in the executor if connected and enabled."""
+        if self.api.connected() and requires:
             await self.hass.async_add_executor_job(func)
 
     # ---------------------------
@@ -638,13 +638,14 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             self.get_capabilities,
             self.get_system_routerboard,
         ]:
-            await self._async_run_if_connected(func)
+            await self._run_if_enabled(func)
 
-        if self.api.connected() and self.option_sensor_scripts:
-            await self.hass.async_add_executor_job(self.get_script)
+        await self._run_if_enabled(
+            self.get_script, requires=self.option_sensor_scripts
+        )
 
         for func in [self.get_dhcp_network, self.get_dns]:
-            await self._async_run_if_connected(func)
+            await self._run_if_enabled(func)
 
         if not self.api.connected():
             raise UpdateFailed("Mikrotik Disconnected")
@@ -664,72 +665,74 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         if not hwinfo_ran:
             await self.hass.async_add_executor_job(self.get_system_resource)
 
+        # Core data — always fetched
         for func in [self.get_system_health, self.get_dhcp_client, self.get_interface]:
-            await self._async_run_if_connected(func)
+            await self._run_if_enabled(func)
 
         if self.api.connected() and not self.ds["host_hass"]:
             await self.async_get_host_hass()
 
-        if self.api.connected() and self.support_capsman:
-            await self.hass.async_add_executor_job(self.get_capsman_hosts)
+        # Wireless / CAPsMAN host discovery
+        await self._run_if_enabled(
+            self.get_capsman_hosts, requires=self.support_capsman
+        )
+        await self._run_if_enabled(self.get_wireless, requires=self.support_wireless)
+        await self._run_if_enabled(
+            self.get_wireless_hosts, requires=self.support_wireless
+        )
 
-        if self.api.connected() and self.support_wireless:
-            await self.hass.async_add_executor_job(self.get_wireless)
-
-        if self.api.connected() and self.support_wireless:
-            await self.hass.async_add_executor_job(self.get_wireless_hosts)
-
+        # Host processing pipeline
         for func in [self.get_bridge, self.get_arp, self.get_dhcp]:
-            await self._async_run_if_connected(func)
+            await self._run_if_enabled(func)
 
         if self.api.connected():
             await self.async_process_host()
 
-        await self._async_run_if_connected(self.process_interface_client)
+        await self._run_if_enabled(self.process_interface_client)
 
-        # Optional sensors — each guarded by its config option
-        optional_sensors = [
-            (self.option_sensor_nat, self.get_nat),
-            (self.option_sensor_kidcontrol, self.get_kidcontrol),
-            (self.option_sensor_mangle, self.get_mangle),
-            (self.option_sensor_filter, self.get_filter),
-            (self.option_sensor_raw, self.get_raw),
-            (self.option_sensor_netwatch, self.get_netwatch),
-        ]
-        for enabled, func in optional_sensors:
-            if self.api.connected() and enabled:
-                await self.hass.async_add_executor_job(func)
+        # Optional sensors
+        await self._run_if_enabled(self.get_nat, requires=self.option_sensor_nat)
+        await self._run_if_enabled(
+            self.get_kidcontrol, requires=self.option_sensor_kidcontrol
+        )
+        await self._run_if_enabled(
+            self.get_mangle, requires=self.option_sensor_mangle
+        )
+        await self._run_if_enabled(
+            self.get_filter, requires=self.option_sensor_filter
+        )
+        await self._run_if_enabled(self.get_raw, requires=self.option_sensor_raw)
+        await self._run_if_enabled(
+            self.get_netwatch, requires=self.option_sensor_netwatch
+        )
+        await self._run_if_enabled(
+            self.get_ppp, requires=self.support_ppp and self.option_sensor_ppp
+        )
 
-        if self.api.connected() and self.support_ppp and self.option_sensor_ppp:
-            await self.hass.async_add_executor_job(self.get_ppp)
-
+        # Client traffic — version-dependent
         if self.api.connected() and self.option_sensor_client_traffic:
             if 0 < self.major_fw_version < 7:
                 await self.hass.async_add_executor_job(self.process_accounting)
-            elif 0 < self.major_fw_version >= 7:
-                await self.hass.async_add_executor_job(self.process_kid_control_devices)
+            elif self.major_fw_version >= 7:
+                await self.hass.async_add_executor_job(
+                    self.process_kid_control_devices
+                )
 
-        optional_sensors_post = [
-            (self.option_sensor_client_captive, self.get_captive),
-            (self.option_sensor_simple_queues, self.get_queue),
-            (self.option_sensor_environment, self.get_environment),
-        ]
-        for enabled, func in optional_sensors_post:
-            if self.api.connected() and enabled:
-                await self.hass.async_add_executor_job(func)
-
-        if self.api.connected() and self.support_ups:
-            await self.hass.async_add_executor_job(self.get_ups)
-
-        if self.api.connected() and self.support_gps:
-            await self.hass.async_add_executor_job(self.get_gps)
-
-        if (
-            self.api.connected()
-            and self.support_container
-            and self.option_sensor_container
-        ):
-            await self.hass.async_add_executor_job(self.get_container)
+        await self._run_if_enabled(
+            self.get_captive, requires=self.option_sensor_client_captive
+        )
+        await self._run_if_enabled(
+            self.get_queue, requires=self.option_sensor_simple_queues
+        )
+        await self._run_if_enabled(
+            self.get_environment, requires=self.option_sensor_environment
+        )
+        await self._run_if_enabled(self.get_ups, requires=self.support_ups)
+        await self._run_if_enabled(self.get_gps, requires=self.support_gps)
+        await self._run_if_enabled(
+            self.get_container,
+            requires=self.support_container and self.option_sensor_container,
+        )
 
         if not self.api.connected():
             raise UpdateFailed("Mikrotik Disconnected")

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -15,7 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util.dt import utcnow
+from homeassistant.util.dt import now as dt_now, utcnow
 
 
 from homeassistant.const import (
@@ -626,7 +626,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
         Returns True if the refresh ran (so callers can skip duplicate work).
         """
-        delta = datetime.now().replace(microsecond=0) - self.last_hwinfo_update
+        delta = dt_now().replace(microsecond=0) - self.last_hwinfo_update
         if not self.api.has_reconnected() and delta.total_seconds() <= 60 * 60 * 4:
             return False
 
@@ -640,9 +640,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         ]:
             await self._run_if_enabled(func)
 
-        await self._run_if_enabled(
-            self.get_script, requires=self.option_sensor_scripts
-        )
+        await self._run_if_enabled(self.get_script, requires=self.option_sensor_scripts)
 
         for func in [self.get_dhcp_network, self.get_dns]:
             await self._run_if_enabled(func)
@@ -650,7 +648,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         if not self.api.connected():
             raise UpdateFailed("Mikrotik Disconnected")
 
-        self.last_hwinfo_update = datetime.now().replace(microsecond=0)
+        self.last_hwinfo_update = dt_now().replace(microsecond=0)
         return True
 
     # ---------------------------
@@ -702,9 +700,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             if 0 < self.major_fw_version < 7:
                 await self.hass.async_add_executor_job(self.process_accounting)
             elif self.major_fw_version >= 7:
-                await self.hass.async_add_executor_job(
-                    self.process_kid_control_devices
-                )
+                await self.hass.async_add_executor_job(self.process_kid_control_devices)
 
         for func, enabled in [
             (self.get_captive, self.option_sensor_client_captive),
@@ -712,7 +708,10 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             (self.get_environment, self.option_sensor_environment),
             (self.get_ups, self.support_ups),
             (self.get_gps, self.support_gps),
-            (self.get_container, self.support_container and self.option_sensor_container),
+            (
+                self.get_container,
+                self.support_container and self.option_sensor_container,
+            ),
         ]:
             await self._run_if_enabled(func, requires=enabled)
 
@@ -1722,7 +1721,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         tmp_uptime = _parse_uptime_to_seconds(self.ds["resource"]["uptime_str"])
 
         self.ds["resource"]["uptime_epoch"] = tmp_uptime
-        now = datetime.now().replace(microsecond=0)
+        now = dt_now().replace(microsecond=0)
         uptime_tm = datetime.timestamp(now - timedelta(seconds=tmp_uptime))
         update_uptime = False
         if not self.ds["resource"]["uptime"]:
@@ -2600,15 +2599,13 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
     async def _resolve_manufacturer(self, uid: str, mac: str) -> None:
         """Resolve a single MAC address to a manufacturer name."""
         try:
-            self.ds["host"][uid]["manufacturer"] = (
-                await self.async_mac_lookup.lookup(mac)
+            self.ds["host"][uid]["manufacturer"] = await self.async_mac_lookup.lookup(
+                mac
             )
         except asyncio.CancelledError:
             raise
         except Exception as err:
-            _LOGGER.debug(
-                "MAC vendor lookup failed for %s: %s", mac, err
-            )
+            _LOGGER.debug("MAC vendor lookup failed for %s: %s", mac, err)
             self.ds["host"][uid]["manufacturer"] = ""
 
     async def async_process_host(self) -> None:
@@ -2624,32 +2621,31 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         self.ds["resource"]["clients_wired"] = 0
         self.ds["resource"]["clients_wireless"] = 0
         mac_tasks: list[asyncio.Task] = []
-        try:
-            for uid, vals in self.ds["host"].items():
-                self._update_captive_portal(uid)
-                self._update_host_availability(
-                    uid, vals, capsman_detected, wireless_detected, arp_detected
-                )
-                self._update_host_address(uid, vals)
-                self._resolve_hostname(uid, vals)
+        for uid, vals in self.ds["host"].items():
+            self._update_captive_portal(uid)
+            self._update_host_availability(
+                uid, vals, capsman_detected, wireless_detected, arp_detected
+            )
+            self._update_host_address(uid, vals)
+            self._resolve_hostname(uid, vals)
 
-                if vals["manufacturer"] == "detect" and vals["mac-address"] != "unknown":
-                    mac_tasks.append(
-                        asyncio.create_task(
-                            self._resolve_manufacturer(uid, vals["mac-address"])
-                        )
+            if vals["manufacturer"] == "detect" and vals["mac-address"] != "unknown":
+                mac_tasks.append(
+                    asyncio.create_task(
+                        self._resolve_manufacturer(uid, vals["mac-address"])
                     )
-                elif vals["manufacturer"] == "detect":
-                    self.ds["host"][uid]["manufacturer"] = ""
+                )
+            elif vals["manufacturer"] == "detect":
+                self.ds["host"][uid]["manufacturer"] = ""
 
-                if self.ds["host"][uid]["available"]:
-                    if vals["source"] in ["capsman", "wireless"]:
-                        self.ds["resource"]["clients_wireless"] += 1
-                    else:
-                        self.ds["resource"]["clients_wired"] += 1
-        finally:
-            if mac_tasks:
-                await asyncio.gather(*mac_tasks, return_exceptions=True)
+            if self.ds["host"][uid]["available"]:
+                if vals["source"] in ["capsman", "wireless"]:
+                    self.ds["resource"]["clients_wireless"] += 1
+                else:
+                    self.ds["resource"]["clients_wired"] += 1
+
+        if mac_tasks:
+            await asyncio.gather(*mac_tasks)
 
     # ---------------------------
     #   process_accounting

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -665,14 +665,12 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         if not hwinfo_ran:
             await self.hass.async_add_executor_job(self.get_system_resource)
 
-        # Core data — always fetched
         for func in [self.get_system_health, self.get_dhcp_client, self.get_interface]:
             await self._run_if_enabled(func)
 
         if self.api.connected() and not self.ds["host_hass"]:
             await self.async_get_host_hass()
 
-        # Wireless / CAPsMAN host discovery
         await self._run_if_enabled(
             self.get_capsman_hosts, requires=self.support_capsman
         )
@@ -681,7 +679,6 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             self.get_wireless_hosts, requires=self.support_wireless
         )
 
-        # Host processing pipeline
         for func in [self.get_bridge, self.get_arp, self.get_dhcp]:
             await self._run_if_enabled(func)
 
@@ -690,26 +687,17 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
         await self._run_if_enabled(self.process_interface_client)
 
-        # Optional sensors
-        await self._run_if_enabled(self.get_nat, requires=self.option_sensor_nat)
-        await self._run_if_enabled(
-            self.get_kidcontrol, requires=self.option_sensor_kidcontrol
-        )
-        await self._run_if_enabled(
-            self.get_mangle, requires=self.option_sensor_mangle
-        )
-        await self._run_if_enabled(
-            self.get_filter, requires=self.option_sensor_filter
-        )
-        await self._run_if_enabled(self.get_raw, requires=self.option_sensor_raw)
-        await self._run_if_enabled(
-            self.get_netwatch, requires=self.option_sensor_netwatch
-        )
-        await self._run_if_enabled(
-            self.get_ppp, requires=self.support_ppp and self.option_sensor_ppp
-        )
+        for func, enabled in [
+            (self.get_nat, self.option_sensor_nat),
+            (self.get_kidcontrol, self.option_sensor_kidcontrol),
+            (self.get_mangle, self.option_sensor_mangle),
+            (self.get_filter, self.option_sensor_filter),
+            (self.get_raw, self.option_sensor_raw),
+            (self.get_netwatch, self.option_sensor_netwatch),
+            (self.get_ppp, self.support_ppp and self.option_sensor_ppp),
+        ]:
+            await self._run_if_enabled(func, requires=enabled)
 
-        # Client traffic — version-dependent
         if self.api.connected() and self.option_sensor_client_traffic:
             if 0 < self.major_fw_version < 7:
                 await self.hass.async_add_executor_job(self.process_accounting)
@@ -718,21 +706,15 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     self.process_kid_control_devices
                 )
 
-        await self._run_if_enabled(
-            self.get_captive, requires=self.option_sensor_client_captive
-        )
-        await self._run_if_enabled(
-            self.get_queue, requires=self.option_sensor_simple_queues
-        )
-        await self._run_if_enabled(
-            self.get_environment, requires=self.option_sensor_environment
-        )
-        await self._run_if_enabled(self.get_ups, requires=self.support_ups)
-        await self._run_if_enabled(self.get_gps, requires=self.support_gps)
-        await self._run_if_enabled(
-            self.get_container,
-            requires=self.support_container and self.option_sensor_container,
-        )
+        for func, enabled in [
+            (self.get_captive, self.option_sensor_client_captive),
+            (self.get_queue, self.option_sensor_simple_queues),
+            (self.get_environment, self.option_sensor_environment),
+            (self.get_ups, self.support_ups),
+            (self.get_gps, self.support_gps),
+            (self.get_container, self.support_container and self.option_sensor_container),
+        ]:
+            await self._run_if_enabled(func, requires=enabled)
 
         if not self.api.connected():
             raise UpdateFailed("Mikrotik Disconnected")
@@ -2642,34 +2624,32 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         self.ds["resource"]["clients_wired"] = 0
         self.ds["resource"]["clients_wireless"] = 0
         mac_tasks: list[asyncio.Task] = []
-        for uid, vals in self.ds["host"].items():
-            self._update_captive_portal(uid)
-            self._update_host_availability(
-                uid, vals, capsman_detected, wireless_detected, arp_detected
-            )
-            self._update_host_address(uid, vals)
-            self._resolve_hostname(uid, vals)
-
-            # Queue manufacturer lookups to run concurrently
-            if vals["manufacturer"] == "detect" and vals["mac-address"] != "unknown":
-                mac_tasks.append(
-                    asyncio.create_task(
-                        self._resolve_manufacturer(uid, vals["mac-address"])
-                    )
+        try:
+            for uid, vals in self.ds["host"].items():
+                self._update_captive_portal(uid)
+                self._update_host_availability(
+                    uid, vals, capsman_detected, wireless_detected, arp_detected
                 )
-            elif vals["manufacturer"] == "detect":
-                self.ds["host"][uid]["manufacturer"] = ""
+                self._update_host_address(uid, vals)
+                self._resolve_hostname(uid, vals)
 
-            # Count hosts
-            if self.ds["host"][uid]["available"]:
-                if vals["source"] in ["capsman", "wireless"]:
-                    self.ds["resource"]["clients_wireless"] += 1
-                else:
-                    self.ds["resource"]["clients_wired"] += 1
+                if vals["manufacturer"] == "detect" and vals["mac-address"] != "unknown":
+                    mac_tasks.append(
+                        asyncio.create_task(
+                            self._resolve_manufacturer(uid, vals["mac-address"])
+                        )
+                    )
+                elif vals["manufacturer"] == "detect":
+                    self.ds["host"][uid]["manufacturer"] = ""
 
-        # Resolve all MAC vendor lookups concurrently
-        if mac_tasks:
-            await asyncio.gather(*mac_tasks)
+                if self.ds["host"][uid]["available"]:
+                    if vals["source"] in ["capsman", "wireless"]:
+                        self.ds["resource"]["clients_wireless"] += 1
+                    else:
+                        self.ds["resource"]["clients_wired"] += 1
+        finally:
+            if mac_tasks:
+                await asyncio.gather(*mac_tasks, return_exceptions=True)
 
     # ---------------------------
     #   process_accounting

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -329,7 +329,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         self.async_mac_lookup = AsyncMacLookup()
         self.accessrights_reported = False
 
-        self.last_hwinfo_update = datetime(1970, 1, 1)
+        self.last_hwinfo_update = datetime(1970, 1, 1, tzinfo=timezone.utc)
         self.rebootcheck = 0
 
     # ---------------------------

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -170,8 +170,10 @@ class MikrotikTrackerCoordinator(DataUpdateCoordinator[None]):
         if "test" not in self.coordinator.ds["access"]:
             return
 
+        first_run = not self.coordinator.host_tracking_initialized
+
         for uid in list(self.coordinator.ds["host"]):
-            if not self.coordinator.host_tracking_initialized:
+            if first_run:
                 # Add missing default values
                 for key, default in zip(
                     [
@@ -187,8 +189,13 @@ class MikrotikTrackerCoordinator(DataUpdateCoordinator[None]):
                     if key not in self.coordinator.ds["host"][uid]:
                         self.coordinator.ds["host"][uid][key] = default
 
-            # Check host availability
-            if (
+            # On first run, use ARP data instead of pinging every host
+            # sequentially.  Pings will run on subsequent 10s updates.
+            if first_run:
+                self.coordinator.ds["host"][uid]["available"] = (
+                    uid in self.coordinator.ds["arp"]
+                )
+            elif (
                 self.coordinator.ds["host"][uid]["source"]
                 not in ["capsman", "wireless"]
                 and self.coordinator.ds["host"][uid]["address"] not in ["unknown", ""]
@@ -614,11 +621,14 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
     # ---------------------------
     #   _async_update_hwinfo
     # ---------------------------
-    async def _async_update_hwinfo(self) -> None:
-        """Refresh hardware info (runs every 4 hours or on reconnect)."""
+    async def _async_update_hwinfo(self) -> bool:
+        """Refresh hardware info (runs every 4 hours or on reconnect).
+
+        Returns True if the refresh ran (so callers can skip duplicate work).
+        """
         delta = datetime.now().replace(microsecond=0) - self.last_hwinfo_update
         if not self.api.has_reconnected() and delta.total_seconds() <= 60 * 60 * 4:
-            return
+            return False
 
         await self.hass.async_add_executor_job(self.get_access)
 
@@ -640,15 +650,19 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             raise UpdateFailed("Mikrotik Disconnected")
 
         self.last_hwinfo_update = datetime.now().replace(microsecond=0)
+        return True
 
     # ---------------------------
     #   _async_update_data
     # ---------------------------
     async def _async_update_data(self):
         """Update Mikrotik data"""
-        await self._async_update_hwinfo()
+        hwinfo_ran = await self._async_update_hwinfo()
 
-        await self.hass.async_add_executor_job(self.get_system_resource)
+        # get_system_resource already ran inside _async_update_hwinfo;
+        # only call it again on normal polling cycles where hwinfo was skipped.
+        if not hwinfo_ran:
+            await self.hass.async_add_executor_job(self.get_system_resource)
 
         for func in [self.get_system_health, self.get_dhcp_client, self.get_interface]:
             await self._async_run_if_connected(func)
@@ -2598,6 +2612,20 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
     # ---------------------------
     #   async_process_host
     # ---------------------------
+    async def _resolve_manufacturer(self, uid: str, mac: str) -> None:
+        """Resolve a single MAC address to a manufacturer name."""
+        try:
+            self.ds["host"][uid]["manufacturer"] = (
+                await self.async_mac_lookup.lookup(mac)
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.debug(
+                "MAC vendor lookup failed for %s: %s", mac, err
+            )
+            self.ds["host"][uid]["manufacturer"] = ""
+
     async def async_process_host(self) -> None:
         """Get host tracking data"""
         capsman_detected = self._merge_capsman_hosts()
@@ -2610,6 +2638,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         # Process hosts
         self.ds["resource"]["clients_wired"] = 0
         self.ds["resource"]["clients_wireless"] = 0
+        mac_tasks: list[asyncio.Task] = []
         for uid, vals in self.ds["host"].items():
             self._update_captive_portal(uid)
             self._update_host_availability(
@@ -2618,23 +2647,14 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             self._update_host_address(uid, vals)
             self._resolve_hostname(uid, vals)
 
-            # Resolve manufacturer
+            # Queue manufacturer lookups to run concurrently
             if vals["manufacturer"] == "detect" and vals["mac-address"] != "unknown":
-                try:
-                    self.ds["host"][uid][
-                        "manufacturer"
-                    ] = await self.async_mac_lookup.lookup(vals["mac-address"])
-                except asyncio.CancelledError:
-                    raise
-                except Exception as err:
-                    _LOGGER.debug(
-                        "MAC vendor lookup failed for %s: %s",
-                        vals["mac-address"],
-                        err,
+                mac_tasks.append(
+                    asyncio.create_task(
+                        self._resolve_manufacturer(uid, vals["mac-address"])
                     )
-                    self.ds["host"][uid]["manufacturer"] = ""
-
-            if vals["manufacturer"] == "detect":
+                )
+            elif vals["manufacturer"] == "detect":
                 self.ds["host"][uid]["manufacturer"] = ""
 
             # Count hosts
@@ -2643,6 +2663,10 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     self.ds["resource"]["clients_wireless"] += 1
                 else:
                     self.ds["resource"]["clients_wired"] += 1
+
+        # Resolve all MAC vendor lookups concurrently
+        if mac_tasks:
+            await asyncio.gather(*mac_tasks)
 
     # ---------------------------
     #   process_accounting

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -192,9 +192,13 @@ class MikrotikTrackerCoordinator(DataUpdateCoordinator[None]):
             # On first run, use ARP data instead of pinging every host
             # sequentially.  Pings will run on subsequent 10s updates.
             if first_run:
-                self.coordinator.ds["host"][uid]["available"] = (
-                    uid in self.coordinator.ds["arp"]
-                )
+                in_arp = uid in self.coordinator.ds["arp"]
+                self.coordinator.ds["host"][uid]["available"] = in_arp
+                if not in_arp:
+                    _LOGGER.debug(
+                        "Host %s not in ARP on first run; will ping next cycle",
+                        uid,
+                    )
             elif (
                 self.coordinator.ds["host"][uid]["source"]
                 not in ["capsman", "wireless"]
@@ -661,7 +665,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         # get_system_resource already ran inside _async_update_hwinfo;
         # only call it again on normal polling cycles where hwinfo was skipped.
         if not hwinfo_ran:
-            await self.hass.async_add_executor_job(self.get_system_resource)
+            await self._run_if_enabled(self.get_system_resource)
 
         for func in [self.get_system_health, self.get_dhcp_client, self.get_interface]:
             await self._run_if_enabled(func)
@@ -2594,7 +2598,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             del self.ds["host"][uid]["bypassed"]
 
     # ---------------------------
-    #   async_process_host
+    #   _resolve_manufacturer
     # ---------------------------
     async def _resolve_manufacturer(self, uid: str, mac: str) -> None:
         """Resolve a single MAC address to a manufacturer name."""
@@ -2602,12 +2606,13 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             self.ds["host"][uid]["manufacturer"] = await self.async_mac_lookup.lookup(
                 mac
             )
-        except asyncio.CancelledError:
-            raise
         except Exception as err:
             _LOGGER.debug("MAC vendor lookup failed for %s: %s", mac, err)
             self.ds["host"][uid]["manufacturer"] = ""
 
+    # ---------------------------
+    #   async_process_host
+    # ---------------------------
     async def async_process_host(self) -> None:
         """Get host tracking data"""
         capsman_detected = self._merge_capsman_hosts()

--- a/custom_components/mikrotik_router/exceptions.py
+++ b/custom_components/mikrotik_router/exceptions.py
@@ -1,5 +1,7 @@
 """Exceptions for Mikrotik Router."""
 
+from __future__ import annotations
+
 
 class ApiEntryNotFound(Exception):
     """Api entry not found."""

--- a/custom_components/mikrotik_router/helper.py
+++ b/custom_components/mikrotik_router/helper.py
@@ -1,5 +1,7 @@
 """Helper functions for Mikrotik Router."""
 
+from __future__ import annotations
+
 
 # ---------------------------
 #   format_attribute

--- a/custom_components/mikrotik_router/iface_attributes.py
+++ b/custom_components/mikrotik_router/iface_attributes.py
@@ -1,5 +1,7 @@
 """Shared interface attribute lists used by sensor and binary sensor types."""
 
+from __future__ import annotations
+
 DEVICE_ATTRIBUTES_IFACE = [
     "running",
     "enabled",

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.11"
+    "version": "2.3.12-beta.1"
 }

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.12-beta.1"
+    "version": "2.3.12"
 }

--- a/custom_components/mikrotik_router/services.yaml
+++ b/custom_components/mikrotik_router/services.yaml
@@ -1,1 +1,41 @@
 ---
+cleanup_entities:
+  name: Cleanup orphaned entities
+  description: >-
+    Remove entities from the Home Assistant entity registry that no longer have
+    backing data on the Mikrotik router (e.g. removed interfaces, deleted
+    firewall rules, old hosts).
+  fields:
+    entry_id:
+      name: Config entry ID
+      description: The config entry ID of the Mikrotik Router integration instance.
+      required: true
+      example: "abcdef1234567890abcdef1234567890"
+      selector:
+        text:
+
+cleanup_stale_hosts:
+  name: Cleanup stale tracked hosts
+  description: >-
+    List or remove device tracker entities for hosts that are currently away
+    and were discovered via DHCP, ARP, or other transient sources.
+    Use dry_run to preview which hosts would be removed before actually
+    cleaning them up.
+  fields:
+    entry_id:
+      name: Config entry ID
+      description: The config entry ID of the Mikrotik Router integration instance.
+      required: true
+      example: "abcdef1234567890abcdef1234567890"
+      selector:
+        text:
+    dry_run:
+      name: Dry run
+      description: >-
+        When true, only report stale hosts without removing them.
+        When false, remove the stale host entities.
+      required: false
+      default: true
+      example: true
+      selector:
+        boolean:

--- a/custom_components/mikrotik_router/strings.json
+++ b/custom_components/mikrotik_router/strings.json
@@ -1,4 +1,30 @@
 {
+    "services": {
+        "cleanup_entities": {
+            "name": "Cleanup orphaned entities",
+            "description": "Remove entities from the entity registry that no longer have backing data on the Mikrotik router.",
+            "fields": {
+                "entry_id": {
+                    "name": "Config entry ID",
+                    "description": "The config entry ID of the Mikrotik Router integration instance."
+                }
+            }
+        },
+        "cleanup_stale_hosts": {
+            "name": "Cleanup stale tracked hosts",
+            "description": "List or remove device tracker entities for hosts that are currently away and were discovered via DHCP, ARP, or other transient sources.",
+            "fields": {
+                "entry_id": {
+                    "name": "Config entry ID",
+                    "description": "The config entry ID of the Mikrotik Router integration instance."
+                },
+                "dry_run": {
+                    "name": "Dry run",
+                    "description": "When true, only report stale hosts without removing them. When false, remove the stale host entities."
+                }
+            }
+        }
+    },
     "config": {
         "step": {
             "user": {

--- a/custom_components/mikrotik_router/translations/en.json
+++ b/custom_components/mikrotik_router/translations/en.json
@@ -1,4 +1,30 @@
 {
+    "services": {
+        "cleanup_entities": {
+            "name": "Cleanup orphaned entities",
+            "description": "Remove entities from the entity registry that no longer have backing data on the Mikrotik router.",
+            "fields": {
+                "entry_id": {
+                    "name": "Config entry ID",
+                    "description": "The config entry ID of the Mikrotik Router integration instance."
+                }
+            }
+        },
+        "cleanup_stale_hosts": {
+            "name": "Cleanup stale tracked hosts",
+            "description": "List or remove device tracker entities for hosts that are currently away and were discovered via DHCP, ARP, or other transient sources.",
+            "fields": {
+                "entry_id": {
+                    "name": "Config entry ID",
+                    "description": "The config entry ID of the Mikrotik Router integration instance."
+                },
+                "dry_run": {
+                    "name": "Dry run",
+                    "description": "When true, only report stale hosts without removing them. When false, remove the stale host entities."
+                }
+            }
+        }
+    },
     "config": {
         "step": {
             "user": {

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -8,7 +8,7 @@ Changes listed in reverse chronological order.
 
 **Date:** 2026-03-26
 **Branch:** `claude/fix-homeassistant-slow-load-EzXf3`
-**Status:** Pre-release (v2.3.12-beta.1)
+**Status:** Released (v2.3.12)
 
 ### What Changed
 

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -22,8 +22,13 @@ Changes listed in reverse chronological order.
 | `coordinator.py` | Fixed chained comparison bug: `elif 0 < self.major_fw_version >= 7` → `elif self.major_fw_version >= 7` |
 | `coordinator.py` | `get_system_resource` now uses `_run_if_enabled` guard (caught by silent-failure audit) |
 | `apiparser.py` | Fixed `voluptuous.Optional(str)` misused as type hint → `str \| None` (PEP 604) |
+| `__init__.py` | New `cleanup_entities` service: removes orphaned entities with no backing router data |
+| `__init__.py` | New `cleanup_stale_hosts` service: reports/removes stale device tracker entities (dry_run default) |
+| `__init__.py` | Services registered in `async_setup_entry` (not `async_setup` which is skipped for config-flow integrations) |
+| `services.yaml` | Service descriptions for cleanup_entities and cleanup_stale_hosts |
+| `strings.json`, `translations/en.json` | Service translation strings |
 | `*.py` (6 files) | Added `from __future__ import annotations` per HA coding standards |
-| `tests/` | `mac_lookup.lookup` mock changed from `MagicMock` to `AsyncMock` to match async gather usage |
+| `tests/` | 4 new `_resolve_manufacturer` tests (error, concurrent failure, parallel success, unknown MAC skip); `AsyncMock` for mac_lookup |
 
 ### Why
 
@@ -31,15 +36,18 @@ ISS-260326-slow-load: The integration was blocking HA startup by sequentially pi
 
 ISS-260320-deprecated-datetime: All remaining naive `datetime.now()` calls replaced with timezone-aware equivalents per HA coding standards.
 
+Entity cleanup services address long-standing user pain point: orphaned entities from removed interfaces, deleted firewall rules, or stale DHCP hosts that accumulate over time and require manual registry editing to remove.
+
 ### Quality Gate Results
 
 | Metric | Value | Gate |
 |--------|-------|------|
 | Ruff lint | 0 errors | ✅ |
 | Ruff format | 0 reformats needed | ✅ |
-| Tests | 461 passed, 5 skipped | ✅ |
+| Tests | 465 passed, 5 skipped | ✅ |
 | Code review | No bugs found | ✅ |
 | Silent-failure audit | 2 fixes applied (resource guard, ARP logging) | ✅ |
+| HA live test | Services working, zero errors in logs | ✅ |
 
 ---
 

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -177,7 +177,7 @@ ISS-260320-test-coverage Phase 4: entity-level tests cover all 6 platform entity
 | Area | Change |
 |------|--------|
 | `coordinator.py` | Extracted 11 helpers from `async_process_host()` (136→~10 each): `_merge_capsman_hosts`, `_merge_wireless_hosts`, `_merge_dhcp_hosts`, `_merge_arp_hosts`, `_recover_hass_hosts`, `_ensure_host_defaults`, `_update_host_availability`, `_update_host_address`, `_resolve_hostname`, `_dhcp_comment_for_host`, `_update_captive_portal` |
-| `coordinator.py` | Extracted `_async_update_hwinfo` and `_async_run_if_connected` from `_async_update_data()` (65→~15), plus optional sensor loop tables |
+| `coordinator.py` | Extracted `_async_update_hwinfo` and `_run_if_enabled` from `_async_update_data()` (65→~15), plus optional sensor loop tables |
 | `coordinator.py` | Extracted `_init_accounting_hosts`, `_classify_accounting_traffic`, `_check_accounting_threshold`, `_apply_accounting_throughput` from `process_accounting()` (48→~10 each) |
 | `coordinator.py` | Extracted `_monitor_ethernet_port` with SFP/copper/PoE monitor val constants from `get_interface()` (27→~10) |
 | `entity.py` | Split `_skip_sensor()` into `_skip_interface_traffic`, `_skip_binary_sensor`, `_skip_device_tracker`, `_skip_poe_sensor` (23→~5 each) |

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,45 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260326-fix-slow-load — Eliminate startup bottlenecks that block HA loading
+
+**Date:** 2026-03-26
+**Branch:** `claude/fix-homeassistant-slow-load-EzXf3`
+**Status:** Pre-release (v2.3.12-beta.1)
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `coordinator.py` | First-run host tracking uses ARP table instead of sequential pings — eliminates O(n) blocking startup delay |
+| `coordinator.py` | MAC vendor lookups parallelised via `asyncio.gather` + `_resolve_manufacturer` helper |
+| `coordinator.py` | `_async_update_hwinfo` returns `bool` to skip duplicate `get_system_resource` call on hwinfo cycles |
+| `coordinator.py` | `_async_run_if_connected` → `_run_if_enabled` with `requires` kwarg, reducing boilerplate |
+| `coordinator.py` | All `datetime.now()` replaced with HA's `dt_now()` (timezone-aware); `last_hwinfo_update` initialised with `tzinfo=timezone.utc` |
+| `coordinator.py` | Fixed chained comparison bug: `elif 0 < self.major_fw_version >= 7` → `elif self.major_fw_version >= 7` |
+| `coordinator.py` | `get_system_resource` now uses `_run_if_enabled` guard (caught by silent-failure audit) |
+| `apiparser.py` | Fixed `voluptuous.Optional(str)` misused as type hint → `str \| None` (PEP 604) |
+| `*.py` (6 files) | Added `from __future__ import annotations` per HA coding standards |
+| `tests/` | `mac_lookup.lookup` mock changed from `MagicMock` to `AsyncMock` to match async gather usage |
+
+### Why
+
+ISS-260326-slow-load: The integration was blocking HA startup by sequentially pinging every tracked host on first load. With many hosts, this added 10+ seconds to HA boot time. ARP-based first-run detection provides immediate availability data, with pings starting on the next 10s tracker cycle.
+
+ISS-260320-deprecated-datetime: All remaining naive `datetime.now()` calls replaced with timezone-aware equivalents per HA coding standards.
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint | 0 errors | ✅ |
+| Ruff format | 0 reformats needed | ✅ |
+| Tests | 461 passed, 5 skipped | ✅ |
+| Code review | No bugs found | ✅ |
+| Silent-failure audit | 2 fixes applied (resource guard, ARP logging) | ✅ |
+
+---
+
 ## CR-260325-attribute-cleanup — Remove junk attributes from interface and tracker entities
 
 **Date:** 2026-03-25

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -68,7 +68,7 @@ SonarCloud reports 14 functions exceeding cognitive complexity threshold of 15. 
 
 **Done (PR #30 — feature/complexity-reduction):**
 - ✅ `async_process_host()` (136→~10 per helper): extracted `_merge_capsman_hosts`, `_merge_wireless_hosts`, `_merge_dhcp_hosts`, `_merge_arp_hosts`, `_recover_hass_hosts`, `_ensure_host_defaults`, `_update_host_availability`, `_update_host_address`, `_resolve_hostname`, `_dhcp_comment_for_host`, `_update_captive_portal`
-- ✅ `_async_update_data()` (65→~15): extracted `_async_update_hwinfo`, `_async_run_if_connected`, optional sensor loop tables
+- ✅ `_async_update_data()` (65→~15): extracted `_async_update_hwinfo`, `_run_if_enabled`, optional sensor loop tables
 - ✅ `process_accounting()` (48→~10 per helper): extracted `_init_accounting_hosts`, `_classify_accounting_traffic`, `_check_accounting_threshold`, `_apply_accounting_throughput`
 - ✅ `get_interface()` (27→~10): extracted `_monitor_ethernet_port` with `_SFP_MONITOR_VALS`, `_COPPER_MONITOR_VALS`, `_POE_MONITOR_VALS` class constants
 - ✅ `_skip_sensor()` (23→~5 per helper): extracted `_skip_interface_traffic`, `_skip_binary_sensor`, `_skip_device_tracker`, `_skip_poe_sensor`

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -4,7 +4,7 @@
 
 1. ISS-260320-test-coverage — Increase test coverage to ≥80%
 2. ISS-260320-new-device-discovery — New devices require HA restart to appear
-3. ISS-260320-deprecated-datetime — Remaining naive datetime.now() calls
+3. ISS-260321-cognitive-complexity — Reduce cognitive complexity to ≤15 per function
 
 ---
 
@@ -29,7 +29,7 @@
 - Full HA integration tests: async_setup_entry, async_unload_entry (requires full HA platform machinery)
 - Full coverage measurement and gap analysis
 
-**Reference:** 473 tests passing (303 PR #29, 58 PR #30, 80 PR #31, 20 upstream FR port, 12 attribute cleanup), target ≥80% for SonarCloud Grade A
+**Reference:** 461 tests passing (303 PR #29, 58 PR #30, 80 PR #31, 20 upstream FR port), target ≥80% for SonarCloud Grade A
 
 ---
 
@@ -103,19 +103,6 @@ The `update_sensors` dispatcher was re-enabled in v2.3.6 to fix new devices not 
 
 ---
 
-### ISS-260320-deprecated-datetime — Remaining naive datetime.now() calls
-**Type:** Bug
-**Priority:** Medium
-**Created:** 2026-03-20
-**Status:** 🟡 Backlog
-**Source:** coordinator.py lines 577, 606, 1547
-
-**Remaining:**
-- Replace `datetime.now()` with `homeassistant.util.dt.now()`
-- Audit all datetime usage in coordinator.py
-
----
-
 ### ISS-260320-refactor-dedup — Refactor duplicated patterns
 **Type:** Refactoring
 **Priority:** Medium
@@ -159,6 +146,14 @@ Silent-failure audit (pr-review-toolkit:silent-failure-hunter) found 12 issues. 
 ---
 
 ## Completed
+
+### ISS-260326-slow-load — Startup bottlenecks blocking HA loading
+**Type:** Bug/Performance | **Priority:** High | **Created:** 2026-03-26
+**Status:** 🔴 Closed — fixed in v2.3.12 (claude/fix-homeassistant-slow-load)
+
+### ISS-260320-deprecated-datetime — Remaining naive datetime.now() calls
+**Type:** Bug | **Priority:** Medium | **Created:** 2026-03-20
+**Status:** 🔴 Closed — fixed in v2.3.12 (claude/fix-homeassistant-slow-load)
 
 ### ISS-260325-attribute-bloat — ~1300 junk attributes on interface and tracker entities
 **Type:** Bug/Quality | **Priority:** High | **Created:** 2026-03-25

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ Large coordinator methods have been decomposed into focused helpers. Each helper
 
 **Update cycle** (`_async_update_data` orchestrates):
 - `_async_update_hwinfo()` — 4-hourly hardware info refresh
-- `_async_run_if_connected()` — guarded executor dispatch
+- `_run_if_enabled()` — guarded executor dispatch
 
 **Accounting** (`process_accounting` orchestrates):
 - `_init_accounting_hosts()`, `_classify_accounting_traffic()`, `_check_accounting_threshold()`, `_apply_accounting_throughput()`

--- a/docs/decisions/ADR-006-naive-datetime-removal.md
+++ b/docs/decisions/ADR-006-naive-datetime-removal.md
@@ -1,7 +1,7 @@
 # ADR-006: Replace naive datetime.now() with HA utility
 
 **Date:** 2026-03-21
-**Status:** Proposed
+**Status:** Accepted — implemented in v2.3.12
 
 ## Context
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -11,7 +11,7 @@ Lightweight records of key design decisions for mikrotik_router HACS integration
 | [ADR-003](ADR-003-ruff-migration.md) | Ruff Replaces Black+flake8 | Accepted |
 | [ADR-004](ADR-004-blocking-io-wrapping.md) | Blocking I/O Wrapped with async_add_executor_job | Accepted |
 | [ADR-005](ADR-005-lock-context-managers.md) | Lock Context Managers Replace Manual acquire/release | Accepted |
-| [ADR-006](ADR-006-naive-datetime-removal.md) | Replace naive datetime.now() with HA utility | Proposed |
+| [ADR-006](ADR-006-naive-datetime-removal.md) | Replace naive datetime.now() with HA utility | Accepted |
 | [ADR-007](ADR-007-complexity-reduction-extraction.md) | Cognitive Complexity Reduction via Helper Extraction | Accepted |
 | [ADR-008](ADR-008-upstream-feature-port.md) | Port Upstream Feature Requests (#310, #321, #334, #298) | Accepted |
 | [ADR-009](ADR-009-attribute-filtering-by-hardware.md) | Entity Attribute Filtering by Hardware Capability | Accepted |

--- a/info.md
+++ b/info.md
@@ -4,7 +4,12 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
-### What's new in v2.3.11
+### What's new in v2.3.12
+- **Faster startup** — No longer blocks HA startup by pinging every tracked host sequentially; uses ARP table for instant first-run availability
+- **Parallel MAC lookups** — Vendor resolution now runs concurrently instead of one-by-one
+- **Bug fixes** — Firmware v7+ client traffic comparison fix, timezone-aware datetimes, API parser type hint fix
+
+### v2.3.11
 - **Attribute cleanup** — Entity attributes now only show information relevant to each port type (SFP diagnostics on SFP ports only, PoE on PoE-capable ports only, wireless metrics on wireless clients only)
 - **Mangle fix** — Rules differing only by interface were silently dropped as duplicates
 

--- a/info.md
+++ b/info.md
@@ -7,6 +7,7 @@ Monitor and control your MikroTik router from Home Assistant.
 ### What's new in v2.3.12
 - **Faster startup** — No longer blocks HA startup by pinging every tracked host sequentially; uses ARP table for instant first-run availability
 - **Parallel MAC lookups** — Vendor resolution now runs concurrently instead of one-by-one
+- **Entity cleanup services** — `cleanup_entities` removes orphaned entities; `cleanup_stale_hosts` reports/removes stale device trackers
 - **Bug fixes** — Firmware v7+ client traffic comparison fix, timezone-aware datetimes, API parser type hint fix
 
 ### v2.3.11

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -774,6 +774,107 @@ async def test_mac_lookup_cancelled_error_propagates():
         await coordinator.async_process_host()
 
 
+def _host_entry(mac, address="192.168.1.10", manufacturer="detect"):
+    """Build a minimal host entry for manufacturer resolution tests."""
+    return {
+        "mac-address": mac,
+        "address": address,
+        "interface": "ether1",
+        "host-name": "test",
+        "source": "arp",
+        "manufacturer": manufacturer,
+        "last-seen": False,
+        "available": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_manufacturer_error_sets_empty_string():
+    """When mac_lookup.lookup raises, manufacturer is set to '' not left as 'detect'."""
+    mac = "AA:BB:CC:DD:EE:FF"
+    coordinator = make_coordinator_for_host(
+        arp_entries={mac: {"mac-address": mac, "address": "192.168.1.10", "interface": "ether1"}},
+        host_entries={mac: _host_entry(mac)},
+    )
+
+    coordinator.async_mac_lookup.lookup = AsyncMock(
+        side_effect=OSError("lookup DB unavailable")
+    )
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["host"][mac]["manufacturer"] == ""
+
+
+@pytest.mark.asyncio
+async def test_resolve_manufacturer_concurrent_partial_failure():
+    """One MAC lookup failure does not affect other concurrent lookups."""
+    mac1, mac2 = "AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac1: {"mac-address": mac1, "address": "192.168.1.10", "interface": "ether1"},
+            mac2: {"mac-address": mac2, "address": "192.168.1.11", "interface": "ether1"},
+        },
+        host_entries={
+            mac1: _host_entry(mac1, "192.168.1.10"),
+            mac2: _host_entry(mac2, "192.168.1.11"),
+        },
+    )
+
+    async def selective_lookup(mac):
+        if mac == mac1:
+            raise OSError("lookup failed")
+        return "GoodVendor"
+
+    coordinator.async_mac_lookup.lookup = selective_lookup
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["host"][mac1]["manufacturer"] == ""
+    assert coordinator.ds["host"][mac2]["manufacturer"] == "GoodVendor"
+
+
+@pytest.mark.asyncio
+async def test_resolve_manufacturer_parallel_success():
+    """Multiple MAC lookups resolve concurrently via asyncio.gather."""
+    mac1, mac2 = "AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac1: {"mac-address": mac1, "address": "192.168.1.10", "interface": "ether1"},
+            mac2: {"mac-address": mac2, "address": "192.168.1.11", "interface": "ether1"},
+        },
+        host_entries={
+            mac1: _host_entry(mac1, "192.168.1.10"),
+            mac2: _host_entry(mac2, "192.168.1.11"),
+        },
+    )
+
+    async def vendor_by_mac(mac):
+        return {mac1: "VendorA", mac2: "VendorB"}[mac]
+
+    coordinator.async_mac_lookup.lookup = vendor_by_mac
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["host"][mac1]["manufacturer"] == "VendorA"
+    assert coordinator.ds["host"][mac2]["manufacturer"] == "VendorB"
+
+
+@pytest.mark.asyncio
+async def test_resolve_manufacturer_unknown_mac_skips_lookup():
+    """Hosts with mac-address='unknown' skip lookup and get manufacturer=''."""
+    coordinator = make_coordinator_for_host(
+        host_entries={
+            "AA:BB:CC:DD:EE:FF": _host_entry("unknown"),
+        },
+    )
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["host"]["AA:BB:CC:DD:EE:FF"]["manufacturer"] == ""
+    coordinator.async_mac_lookup.lookup.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # utc_from_timestamp and as_local tests
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -793,7 +793,9 @@ async def test_resolve_manufacturer_error_sets_empty_string():
     """When mac_lookup.lookup raises, manufacturer is set to '' not left as 'detect'."""
     mac = "AA:BB:CC:DD:EE:FF"
     coordinator = make_coordinator_for_host(
-        arp_entries={mac: {"mac-address": mac, "address": "192.168.1.10", "interface": "ether1"}},
+        arp_entries={
+            mac: {"mac-address": mac, "address": "192.168.1.10", "interface": "ether1"}
+        },
         host_entries={mac: _host_entry(mac)},
     )
 
@@ -812,8 +814,16 @@ async def test_resolve_manufacturer_concurrent_partial_failure():
     mac1, mac2 = "AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"
     coordinator = make_coordinator_for_host(
         arp_entries={
-            mac1: {"mac-address": mac1, "address": "192.168.1.10", "interface": "ether1"},
-            mac2: {"mac-address": mac2, "address": "192.168.1.11", "interface": "ether1"},
+            mac1: {
+                "mac-address": mac1,
+                "address": "192.168.1.10",
+                "interface": "ether1",
+            },
+            mac2: {
+                "mac-address": mac2,
+                "address": "192.168.1.11",
+                "interface": "ether1",
+            },
         },
         host_entries={
             mac1: _host_entry(mac1, "192.168.1.10"),
@@ -840,8 +850,16 @@ async def test_resolve_manufacturer_parallel_success():
     mac1, mac2 = "AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"
     coordinator = make_coordinator_for_host(
         arp_entries={
-            mac1: {"mac-address": mac1, "address": "192.168.1.10", "interface": "ether1"},
-            mac2: {"mac-address": mac2, "address": "192.168.1.11", "interface": "ether1"},
+            mac1: {
+                "mac-address": mac1,
+                "address": "192.168.1.10",
+                "interface": "ether1",
+            },
+            mac2: {
+                "mac-address": mac2,
+                "address": "192.168.1.11",
+                "interface": "ether1",
+            },
         },
         host_entries={
             mac1: _host_entry(mac1, "192.168.1.10"),

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,7 +1,7 @@
 """Unit tests for Mikrotik Router coordinator and apiparser logic."""
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -404,7 +404,7 @@ def make_coordinator_for_host(arp_entries=None, dhcp_entries=None, host_entries=
     coordinator.host_hass_recovered = True  # skip HA registry recovery
 
     mac_lookup = MagicMock()
-    mac_lookup.lookup = MagicMock(return_value="Vendor")
+    mac_lookup.lookup = AsyncMock(return_value="Vendor")
     coordinator.async_mac_lookup = mac_lookup
 
     coordinator.ds["arp"] = arp_entries or {}


### PR DESCRIPTION
## Summary
- **Faster startup** — First-run host tracking uses ARP table instead of sequential pings, eliminating O(n) blocking delay. MAC vendor lookups parallelised via asyncio.gather
- **Entity cleanup services** — Two new HA service actions: `cleanup_entities` (removes orphaned entities) and `cleanup_stale_hosts` (reports/removes stale device trackers with dry_run default)
- **Bug fixes** — Chained comparison fix for fw v7+ client traffic, `voluptuous.Optional` type hint fix, timezone-aware datetimes (ADR-006), `get_system_resource` connection guard
- **Code quality** — `_run_if_enabled` replaces `_async_run_if_connected`, `HomeAssistantError` for service failures, empty valid_ids safety guard, service unregistration on last entry unload
- **Tests** — 465 passing (4 new for `_resolve_manufacturer` error/concurrent/parallel paths)

## Post-Deploy Actions
- Delete v2.3.12-beta.1 pre-release after stable release is created
- Create v2.3.12 release with zip asset

## Test Plan
- [x] 465 tests passing, 5 skipped
- [x] Code review (pr-review-toolkit:code-reviewer) — no bugs found
- [x] Simplify (pr-review-toolkit:code-simplifier) — clean
- [x] Security audit (pr-review-toolkit:silent-failure-hunter) — all findings addressed
- [x] HA live test — services working, zero errors in logs
- [x] HA coding standards — datetime, type hints, annotations, service patterns
- [x] Entity data validated against live HA states (4 routers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)