### PR TITLE
fix: detect wireless clients via bridge table for hAP ac2

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -2598,7 +2598,9 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
     # ---------------------------
     #   _is_wireless_host
     # ---------------------------
-    def _is_wireless_host(self, uid: str, vals: dict) -> bool:
+    def _is_wireless_host(
+        self, uid: str, vals: dict, wireless_interfaces: set | None = None
+    ) -> bool:
         """Check if a host is connected via a wireless interface.
 
         Uses source, bridge host table, and wireless interface list to
@@ -2608,7 +2610,8 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         if vals["source"] in ["capsman", "wireless"]:
             return True
 
-        wireless_interfaces = set(self.ds.get("wireless", {}))
+        if wireless_interfaces is None:
+            wireless_interfaces = set(self.ds.get("wireless", {}))
         if not wireless_interfaces:
             return False
 
@@ -2634,6 +2637,9 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         arp_detected = self._merge_arp_hosts()
         self._recover_hass_hosts()
         self._ensure_host_defaults()
+
+        # Build wireless interface set once for the entire loop
+        wireless_ifaces = set(self.ds.get("wireless", {}))
 
         # Process hosts
         self.ds["resource"]["clients_wired"] = 0
@@ -2667,7 +2673,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
             # Count hosts
             if self.ds["host"][uid]["available"]:
-                if self._is_wireless_host(uid, vals):
+                if self._is_wireless_host(uid, vals, wireless_ifaces):
                     self.ds["resource"]["clients_wireless"] += 1
                 else:
                     self.ds["resource"]["clients_wired"] += 1

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -2596,6 +2596,34 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             del self.ds["host"][uid]["bypassed"]
 
     # ---------------------------
+    #   _is_wireless_host
+    # ---------------------------
+    def _is_wireless_host(self, uid: str, vals: dict) -> bool:
+        """Check if a host is connected via a wireless interface.
+
+        Uses source, bridge host table, and wireless interface list to
+        determine if a client is wireless — even when the registration
+        table is empty (e.g. hAP ac2 with the new WiFi package).
+        """
+        if vals["source"] in ["capsman", "wireless"]:
+            return True
+
+        wireless_interfaces = set(self.ds.get("wireless", {}))
+        if not wireless_interfaces:
+            return False
+
+        # Check if the host's interface is directly a wireless interface
+        if vals.get("interface") in wireless_interfaces:
+            return True
+
+        # Check the bridge host table for the physical interface
+        bridge_entry = self.ds.get("bridge_host", {}).get(uid)
+        if bridge_entry and bridge_entry.get("interface") in wireless_interfaces:
+            return True
+
+        return False
+
+    # ---------------------------
     #   async_process_host
     # ---------------------------
     async def async_process_host(self) -> None:
@@ -2639,7 +2667,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
             # Count hosts
             if self.ds["host"][uid]["available"]:
-                if vals["source"] in ["capsman", "wireless"]:
+                if self._is_wireless_host(uid, vals):
                     self.ds["resource"]["clients_wireless"] += 1
                 else:
                     self.ds["resource"]["clients_wired"] += 1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4109,3 +4109,98 @@ def test_container_defaults():
     assert c["status"] == "stopped"
     assert c["running"] is False
     assert c["comment"] == ""
+
+
+# =====================================================================
+# _is_wireless_host — bridge/interface-based wireless detection
+# =====================================================================
+
+
+def test_is_wireless_host_source_wireless():
+    """Host with source 'wireless' is always wireless."""
+    coordinator = make_coordinator_for_host()
+    vals = {"source": "wireless", "interface": "ether1"}
+    assert coordinator._is_wireless_host("AA:BB:CC:DD:EE:01", vals) is True
+
+
+def test_is_wireless_host_source_capsman():
+    """Host with source 'capsman' is always wireless."""
+    coordinator = make_coordinator_for_host()
+    vals = {"source": "capsman", "interface": "ether1"}
+    assert coordinator._is_wireless_host("AA:BB:CC:DD:EE:01", vals) is True
+
+
+def test_is_wireless_host_direct_interface():
+    """ARP host on a wireless interface is detected as wireless."""
+    coordinator = make_coordinator_for_host()
+    coordinator.ds["wireless"] = {"wlan1": {"name": "wlan1"}}
+    vals = {"source": "arp", "interface": "wlan1"}
+    assert coordinator._is_wireless_host("AA:BB:CC:DD:EE:01", vals) is True
+
+
+def test_is_wireless_host_bridge_lookup():
+    """ARP host on a bridge is detected as wireless via bridge host table."""
+    mac = "AA:BB:CC:DD:EE:01"
+    coordinator = make_coordinator_for_host()
+    coordinator.ds["wireless"] = {"wlan1": {"name": "wlan1"}}
+    coordinator.ds["bridge_host"] = {
+        mac: {"interface": "wlan1", "bridge": "bridge1", "enabled": True}
+    }
+    vals = {"source": "arp", "interface": "bridge1"}
+    assert coordinator._is_wireless_host(mac, vals) is True
+
+
+def test_is_wireless_host_wired():
+    """ARP host on a wired interface is not wireless."""
+    coordinator = make_coordinator_for_host()
+    coordinator.ds["wireless"] = {"wlan1": {"name": "wlan1"}}
+    coordinator.ds["bridge_host"] = {}
+    vals = {"source": "arp", "interface": "ether1"}
+    assert coordinator._is_wireless_host("AA:BB:CC:DD:EE:01", vals) is False
+
+
+def test_is_wireless_host_no_wireless_interfaces():
+    """Host is not wireless when no wireless interfaces exist."""
+    coordinator = make_coordinator_for_host()
+    coordinator.ds["wireless"] = {}
+    vals = {"source": "arp", "interface": "ether1"}
+    assert coordinator._is_wireless_host("AA:BB:CC:DD:EE:01", vals) is False
+
+
+@pytest.mark.asyncio
+async def test_hapac2_wireless_count_via_bridge():
+    """hAP ac2 scenario: empty registration table, clients detected via bridge.
+
+    When the WiFi package registration table returns no entries (hAP ac2),
+    clients discovered via ARP/DHCP should still be counted as wireless
+    if the bridge host table shows them on a wireless interface.
+    """
+    mac_wifi = "AA:BB:CC:DD:EE:W1"
+    mac_wired = "AA:BB:CC:DD:EE:E1"
+    coordinator = make_coordinator_for_host(
+        arp_entries={
+            mac_wifi: {
+                "mac-address": mac_wifi,
+                "address": "192.168.1.10",
+                "interface": "bridge1",
+            },
+            mac_wired: {
+                "mac-address": mac_wired,
+                "address": "192.168.1.11",
+                "interface": "bridge1",
+            },
+        }
+    )
+    # WiFi interfaces exist but registration table is empty (hAP ac2 issue)
+    coordinator.support_wireless = True
+    coordinator.ds["wireless_hosts"] = {}
+    coordinator.ds["wireless"] = {"wlan1": {"name": "wlan1"}, "wlan2": {"name": "wlan2"}}
+    coordinator.ds["bridge_host"] = {
+        mac_wifi: {"interface": "wlan1", "bridge": "bridge1", "enabled": True},
+        mac_wired: {"interface": "ether2", "bridge": "bridge1", "enabled": True},
+    }
+
+    await coordinator.async_process_host()
+
+    assert coordinator.ds["resource"]["clients_wireless"] == 1
+    assert coordinator.ds["resource"]["clients_wired"] == 1


### PR DESCRIPTION
## Summary

- On hAP ac2 and similar devices with the new WiFi package, `/interface/wifi/registration-table` may return empty results, causing all clients to be counted as wired
- Adds `_is_wireless_host()` method that cross-references the bridge host table (`/interface/bridge/host`) with known wireless interfaces (`ds["wireless"]`) to correctly classify clients
- No extra API calls — uses data already fetched each polling cycle
- Eliminates the need for the Kid Control workaround for accurate wireless client counts

## Test plan

- [x] Added unit tests for `_is_wireless_host()` covering all paths (source-based, direct interface, bridge lookup, wired, no wireless)
- [x] Added integration test simulating the hAP ac2 scenario (empty registration table, clients via bridge)
- [x] Ruff passes with zero errors
- [ ] Verify on hAP ac2 hardware that wireless client count is correct without Kid Control enabled

https://claude.ai/code/session_01AgGDWdZuLQN7Yi8QUNzV4Q