### PR TITLE
fix: change SonarCloud trigger from dev to master

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,9 +2,9 @@ name: SonarCloud
 
 on:
   push:
-    branches: [dev]
+    branches: [master, dev]
   pull_request:
-    branches: [dev]
+    branches: [master, dev]
 
 permissions: {}
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,9 +2,9 @@ name: SonarCloud
 
 on:
   push:
-    branches: [master, dev]
+    branches: [master]
   pull_request:
-    branches: [master, dev]
+    branches: [master]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- SonarCloud hasn't been scanning because the workflow targeted `dev`, but PRs now merge to `master`
- Changes trigger branch from `dev` to `master` for both `push` and `pull_request` events

## Post-merge
- Update default branch in SonarCloud project settings (Administration > General Settings) from `dev` to `master`

https://claude.ai/code/session_01MMuFMmXxUPNcXtnY6FyCSj