### PR TITLE
refactor: SonarCloud remediation, complexity reduction, and legacy modernisation

### DIFF
--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -59,26 +59,26 @@ def _build_valid_unique_ids(inst: str, coordinator_data: dict) -> set[str]:
     inst_lower = inst.lower()
 
     for desc in descriptions:
-        data_path = desc.data_path
-        if data_path not in coordinator_data:
+        if desc.data_path not in coordinator_data:
             continue
-
-        data = coordinator_data[data_path]
-
-        if not desc.data_reference:
-            # System-level entity (no per-device reference)
-            if data.get(desc.data_attribute) is not None:
-                valid_ids.add(f"{inst_lower}-{desc.key}")
-        else:
-            # Per-device/per-item entity
-            for uid in data:
-                ref_value = data[uid].get(desc.data_reference)
-                if ref_value is not None:
-                    valid_ids.add(
-                        f"{inst_lower}-{desc.key}-{slugify(str(ref_value).lower())}"
-                    )
+        _collect_ids_for_desc(
+            desc, coordinator_data[desc.data_path], inst_lower, valid_ids
+        )
 
     return valid_ids
+
+
+def _collect_ids_for_desc(desc, data: dict, inst_lower: str, valid_ids: set) -> None:
+    """Add unique IDs for a single entity description."""
+    if not desc.data_reference:
+        if data.get(desc.data_attribute) is not None:
+            valid_ids.add(f"{inst_lower}-{desc.key}")
+        return
+
+    for uid in data:
+        ref_value = data[uid].get(desc.data_reference)
+        if ref_value is not None:
+            valid_ids.add(f"{inst_lower}-{desc.key}-{slugify(str(ref_value).lower())}")
 
 
 def _get_mikrotik_data(hass: HomeAssistant, entry_id: str) -> MikrotikData | None:
@@ -119,7 +119,9 @@ async def async_cleanup_entities(call: ServiceCall) -> ServiceResponse:
     entity_registry = er.async_get(hass)
     removed: list[dict[str, str]] = []
 
-    for entity in list(entity_registry.entities.values()):
+    for entity in list(
+        entity_registry.entities.values()
+    ):  # NOSONAR S7504 - list() needed: registry mutated in loop
         if entity.config_entry_id != entry_id:
             continue
         if entity.unique_id in valid_ids:
@@ -208,7 +210,9 @@ async def async_cleanup_stale_hosts(call: ServiceCall) -> ServiceResponse:
     stale: list[dict[str, str]] = []
     removed: list[dict[str, str]] = []
 
-    for entity in list(entity_registry.entities.values()):
+    for entity in list(
+        entity_registry.entities.values()
+    ):  # NOSONAR S7504 - list() needed: registry mutated in loop
         if entity.config_entry_id != entry_id:
             continue
         if not entity.entity_id.startswith("device_tracker."):
@@ -311,7 +315,9 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 #   async_remove_config_entry_device
 # ---------------------------
 async def async_remove_config_entry_device(
-    hass, config_entry: ConfigEntry, device_entry: device_registry.DeviceEntry
+    _hass: HomeAssistant,
+    _config_entry: ConfigEntry,
+    _device_entry: device_registry.DeviceEntry,
 ) -> bool:
     """Remove a config entry from a device."""
     return True

--- a/custom_components/mikrotik_router/apiparser.py
+++ b/custom_components/mikrotik_router/apiparser.py
@@ -303,7 +303,7 @@ def _process_val_sub(val_sub, _data) -> tuple[str | None, str | None]:
         if "action" in val:
             action = val["action"]
             continue
-        if not name or not action:
+        if not name or not action:  # need both before processing value entries
             break
 
         if action == "combine":

--- a/custom_components/mikrotik_router/apiparser.py
+++ b/custom_components/mikrotik_router/apiparser.py
@@ -12,17 +12,11 @@ from .const import TO_REDACT
 _LOGGER = getLogger(__name__)
 
 
-# ---------------------------
-#   utc_from_timestamp
-# ---------------------------
 def utc_from_timestamp(timestamp: float) -> datetime:
     """Return a UTC time from a timestamp."""
     return datetime.fromtimestamp(timestamp, tz=timezone.utc)
 
 
-# ---------------------------
-#   from_entry
-# ---------------------------
 _NOT_FOUND = object()
 
 
@@ -43,25 +37,17 @@ def _traverse_entry(entry, param):
 
 
 def from_entry(entry, param, default="") -> str:
-    """Validate and return str value an API dict."""
+    """Validate and return str value from an API dict."""
     ret = _traverse_entry(entry, param)
     if ret is _NOT_FOUND:
         return default
 
-    if default != "":
-        if isinstance(ret, str):
-            ret = str(ret)
-        elif isinstance(ret, int):
-            ret = int(ret)
-        elif isinstance(ret, float):
-            ret = round(float(ret), 2)
+    if default != "" and isinstance(ret, float):
+        ret = round(ret, 2)
 
     return ret[:255] if isinstance(ret, str) and len(ret) > 255 else ret
 
 
-# ---------------------------
-#   from_entry_bool
-# ---------------------------
 _TRUTHY_STRINGS = frozenset({"on", "yes", "up"})
 _FALSY_STRINGS = frozenset({"off", "no", "down"})
 
@@ -70,7 +56,7 @@ def from_entry_bool(entry, param, default=False, reverse=False) -> bool:
     """Validate and return a bool value from an API dict."""
     ret = _traverse_entry(entry, param)
     if ret is _NOT_FOUND:
-        return default
+        return not default if reverse else default
 
     if isinstance(ret, str):
         lowered = ret.lower()
@@ -85,9 +71,19 @@ def from_entry_bool(entry, param, default=False, reverse=False) -> bool:
     return not ret if reverse else ret
 
 
-# ---------------------------
-#   parse_api
-# ---------------------------
+def _set_data(data, uid, name, value):
+    """Set a value in data dict, handling uid-keyed or flat dicts."""
+    if uid:
+        data[uid][name] = value
+    else:
+        data[name] = value
+
+
+def _get_data(data, uid, name):
+    """Get a value from data dict, handling uid-keyed or flat dicts."""
+    return data[uid][name] if uid else data[name]
+
+
 def parse_api(
     data=None,
     source=None,
@@ -101,83 +97,84 @@ def parse_api(
     skip=None,
 ) -> dict:
     """Get data from API."""
-    debug = _LOGGER.getEffectiveLevel() == 10
     if isinstance(source, dict):
-        tmp = source
-        source = [tmp]
+        source = [source]
 
     if not source:
         if not key and not key_search:
             data = fill_defaults(data, vals)
         return data
 
+    debug = _LOGGER.getEffectiveLevel() == 10
     if debug:
         _LOGGER.debug("Processing source %s", async_redact_data(source, TO_REDACT))
 
     keymap = generate_keymap(data, key_search)
     for entry in source:
-        if only and not matches_only(entry, only):
+        uid = _process_source_entry(
+            data, entry, key, key_secondary, key_search, keymap, only, skip, debug
+        )
+        if uid is _NOT_FOUND:
             continue
-
-        if skip and can_skip(entry, skip):
-            continue
-
-        uid = None
-        if key or key_search:
-            uid = get_uid(entry, key, key_secondary, key_search, keymap)
-            if not uid:
-                continue
-
-            if uid not in data:
-                data[uid] = {}
-
-        if debug:
-            _LOGGER.debug("Processing entry %s", async_redact_data(entry, TO_REDACT))
 
         if vals:
-            data = fill_vals(data, entry, uid, vals)
+            fill_vals(data, entry, uid, vals)
 
         if ensure_vals:
-            data = fill_ensure_vals(data, uid, ensure_vals)
+            fill_ensure_vals(data, uid, ensure_vals)
 
         if val_proc:
-            data = fill_vals_proc(data, uid, val_proc)
+            fill_vals_proc(data, uid, val_proc)
 
     return data
 
 
-# ---------------------------
-#   get_uid
-# ---------------------------
+def _process_source_entry(
+    data, entry, key, key_secondary, key_search, keymap, only, skip, debug
+):
+    """Process a single source entry. Returns uid (or None for flat) or _NOT_FOUND to skip."""
+    if only and not matches_only(entry, only):
+        return _NOT_FOUND
+
+    if skip and can_skip(entry, skip):
+        return _NOT_FOUND
+
+    uid = None
+    if key or key_search:
+        uid = get_uid(entry, key, key_secondary, key_search, keymap)
+        if not uid:
+            return _NOT_FOUND
+        if uid not in data:
+            data[uid] = {}
+
+    if debug:
+        _LOGGER.debug("Processing entry %s", async_redact_data(entry, TO_REDACT))
+
+    return uid
+
+
 def get_uid(entry, key, key_secondary, key_search, keymap) -> str | None:
     """Get UID for data list."""
-    uid = None
     if not key_search:
-        key_primary_found = key in entry
-        if key_primary_found and key not in entry and not entry[key]:
-            return None
+        return _get_uid_from_keys(entry, key, key_secondary)
 
-        if key_primary_found:
-            uid = entry[key]
-        elif key_secondary:
-            if key_secondary not in entry:
-                return None
+    if keymap and key_search in entry and entry[key_search] in keymap:
+        return keymap[entry[key_search]]
 
-            if not entry[key_secondary]:
-                return None
-
-            uid = entry[key_secondary]
-    elif keymap and key_search in entry and entry[key_search] in keymap:
-        uid = keymap[entry[key_search]]
-    else:
-        return None
-
-    return uid or None
+    return None
 
 
-# ---------------------------
-#   generate_keymap
-# ---------------------------
+def _get_uid_from_keys(entry, key, key_secondary) -> str | None:
+    """Resolve UID from primary or secondary key."""
+    if key in entry:
+        return entry[key] or None
+
+    if key_secondary and key_secondary in entry:
+        return entry[key_secondary] or None
+
+    return None
+
+
 def generate_keymap(data, key_search) -> dict | None:
     """Generate keymap."""
     return (
@@ -187,172 +184,153 @@ def generate_keymap(data, key_search) -> dict | None:
     )
 
 
-# ---------------------------
-#   matches_only
-# ---------------------------
 def matches_only(entry, only) -> bool:
     """Return True if all variables are matched."""
-    ret = False
-    for val in only:
-        if val["key"] in entry and entry[val["key"]] == val["value"]:
-            ret = True
-        else:
-            ret = False
-            break
-
-    return ret
+    return all(
+        val["key"] in entry and entry[val["key"]] == val["value"] for val in only
+    )
 
 
-# ---------------------------
-#   can_skip
-# ---------------------------
 def can_skip(entry, skip) -> bool:
     """Return True if at least one variable matches."""
-    ret = False
     for val in skip:
         if val["name"] in entry and entry[val["name"]] == val["value"]:
-            ret = True
-            break
-
+            return True
         if val["value"] == "" and val["name"] not in entry:
-            ret = True
-            break
-
-    return ret
+            return True
+    return False
 
 
-# ---------------------------
-#   fill_defaults
-# ---------------------------
+def _resolve_str_default(val) -> str:
+    """Get string default from a val descriptor."""
+    default = val.get("default", "")
+    if "default_val" in val and val["default_val"] in val:
+        default = val[val["default_val"]]
+    return default
+
+
 def fill_defaults(data, vals) -> dict:
     """Fill defaults if source is not present."""
     for val in vals:
-        _name = val["name"]
-        _type = val["type"] if "type" in val else "str"
-        _source = val["source"] if "source" in val else _name
+        name = val["name"]
+        if name in data:
+            continue
 
-        if _type == "str":
-            _default = val["default"] if "default" in val else ""
-            if "default_val" in val and val["default_val"] in val:
-                _default = val[val["default_val"]]
-
-            if _name not in data:
-                data[_name] = from_entry([], _source, default=_default)
-
-        elif _type == "bool":
-            _default = val["default"] if "default" in val else False
-            _reverse = val["reverse"] if "reverse" in val else False
-            if _name not in data:
-                data[_name] = from_entry_bool(
-                    [], _source, default=_default, reverse=_reverse
-                )
+        vtype = val.get("type", "str")
+        if vtype == "str":
+            data[name] = from_entry(
+                [], val.get("source", name), default=_resolve_str_default(val)
+            )
+        elif vtype == "bool":
+            data[name] = from_entry_bool(
+                [],
+                val.get("source", name),
+                default=val.get("default", False),
+                reverse=val.get("reverse", False),
+            )
 
     return data
 
 
-# ---------------------------
-#   fill_vals
-# ---------------------------
+def _fill_val_str(data, entry, uid, val) -> None:
+    """Fill a single string-typed value."""
+    source = val.get("source", val["name"])
+    default = _resolve_str_default(val)
+    _set_data(data, uid, val["name"], from_entry(entry, source, default=default))
+
+
+def _fill_val_bool(data, entry, uid, val) -> None:
+    """Fill a single bool-typed value."""
+    source = val.get("source", val["name"])
+    _set_data(
+        data,
+        uid,
+        val["name"],
+        from_entry_bool(
+            entry,
+            source,
+            default=val.get("default", False),
+            reverse=val.get("reverse", False),
+        ),
+    )
+
+
+def _convert_timestamp(data, uid, name) -> None:
+    """Convert an integer value to UTC datetime if applicable."""
+    value = _get_data(data, uid, name)
+    if not isinstance(value, int) or value <= 0:
+        return
+    if value > 100000000000:
+        value = value / 1000
+    _set_data(data, uid, name, utc_from_timestamp(value))
+
+
 def fill_vals(data, entry, uid, vals) -> dict:
-    """Fill all data."""
+    """Fill all data from a source entry."""
     for val in vals:
-        _name = val["name"]
-        _type = val["type"] if "type" in val else "str"
-        _source = val["source"] if "source" in val else _name
-        _convert = val["convert"] if "convert" in val else None
+        vtype = val.get("type", "str")
+        if vtype == "str":
+            _fill_val_str(data, entry, uid, val)
+        elif vtype == "bool":
+            _fill_val_bool(data, entry, uid, val)
 
-        if _type == "str":
-            _default = val["default"] if "default" in val else ""
-            if "default_val" in val and val["default_val"] in val:
-                _default = val[val["default_val"]]
-
-            if uid:
-                data[uid][_name] = from_entry(entry, _source, default=_default)
-            else:
-                data[_name] = from_entry(entry, _source, default=_default)
-
-        elif _type == "bool":
-            _default = val["default"] if "default" in val else False
-            _reverse = val["reverse"] if "reverse" in val else False
-
-            if uid:
-                data[uid][_name] = from_entry_bool(
-                    entry, _source, default=_default, reverse=_reverse
-                )
-            else:
-                data[_name] = from_entry_bool(
-                    entry, _source, default=_default, reverse=_reverse
-                )
-
-        if _convert == "utc_from_timestamp":
-            if uid:
-                if isinstance(data[uid][_name], int) and data[uid][_name] > 0:
-                    if data[uid][_name] > 100000000000:
-                        data[uid][_name] = data[uid][_name] / 1000
-
-                    data[uid][_name] = utc_from_timestamp(data[uid][_name])
-            elif isinstance(data[_name], int) and data[_name] > 0:
-                if data[_name] > 100000000000:
-                    data[_name] = data[_name] / 1000
-
-                data[_name] = utc_from_timestamp(data[_name])
+        if val.get("convert") == "utc_from_timestamp":
+            _convert_timestamp(data, uid, val["name"])
 
     return data
 
 
-# ---------------------------
-#   fill_ensure_vals
-# ---------------------------
 def fill_ensure_vals(data, uid, ensure_vals) -> dict:
     """Add required keys which are not available in data."""
     for val in ensure_vals:
-        if uid:
-            if val["name"] not in data[uid]:
-                _default = val["default"] if "default" in val else ""
-                data[uid][val["name"]] = _default
-
-        elif val["name"] not in data:
-            _default = val["default"] if "default" in val else ""
-            data[val["name"]] = _default
+        target = data[uid] if uid else data
+        if val["name"] not in target:
+            target[val["name"]] = val.get("default", "")
 
     return data
 
 
-# ---------------------------
-#   fill_vals_proc
-# ---------------------------
+def _process_val_sub(val_sub, _data) -> tuple[str | None, str | None]:
+    """Process a single val_proc sub-entry and return (name, computed_value)."""
+    name = None
+    action = None
+    value = None
+
+    for val in val_sub:
+        if "name" in val:
+            name = val["name"]
+            continue
+        if "action" in val:
+            action = val["action"]
+            continue
+        if not name or not action:
+            break
+
+        if action == "combine":
+            value = _apply_combine(val, _data, value)
+
+    return name, value
+
+
+def _apply_combine(val, _data, current_value) -> str | None:
+    """Apply a combine action step to build a string value."""
+    if "key" in val:
+        tmp = _data.get(val["key"], "unknown")
+        return f"{current_value}{tmp}" if current_value else tmp
+
+    if "text" in val:
+        tmp = val["text"]
+        return f"{current_value}{tmp}" if current_value else tmp
+
+    return current_value
+
+
 def fill_vals_proc(data, uid, vals_proc) -> dict:
-    """Add custom keys."""
+    """Add custom keys built from val_proc descriptors."""
     _data = data[uid] if uid else data
     for val_sub in vals_proc:
-        _name = None
-        _action = None
-        _value = None
-        for val in val_sub:
-            if "name" in val:
-                _name = val["name"]
-                continue
-
-            if "action" in val:
-                _action = val["action"]
-                continue
-
-            if not _name and not _action:
-                break
-
-            if _action == "combine":
-                if "key" in val:
-                    tmp = _data[val["key"]] if val["key"] in _data else "unknown"
-                    _value = f"{_value}{tmp}" if _value else tmp
-
-                if "text" in val:
-                    tmp = val["text"]
-                    _value = f"{_value}{tmp}" if _value else tmp
-
-        if _name and _value:
-            if uid:
-                data[uid][_name] = _value
-            else:
-                data[_name] = _value
+        name, value = _process_val_sub(val_sub, _data)
+        if name and value:
+            _set_data(data, uid, name, value)
 
     return data

--- a/custom_components/mikrotik_router/config_flow.py
+++ b/custom_components/mikrotik_router/config_flow.py
@@ -82,9 +82,9 @@ _LOGGER = logging.getLogger(__name__)
 @callback
 def configured_instances(hass):
     """Return a set of configured instances."""
-    return set(
+    return {
         entry.data[CONF_NAME] for entry in hass.config_entries.async_entries(DOMAIN)
-    )
+    }
 
 
 # ---------------------------

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -178,7 +178,7 @@ class MikrotikTrackerCoordinator(DataUpdateCoordinator[None]):
 
         first_run = not self.coordinator.host_tracking_initialized
 
-        for uid in self.coordinator.ds["host"]:
+        for uid in list(self.coordinator.ds["host"]):
             host = self.coordinator.ds["host"][uid]
             if first_run:
                 self._ensure_host_defaults(host)
@@ -1067,6 +1067,38 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         else:
             iface["client-ip-address"] = "none"
 
+    def _dedup_firewall_rules(self, ds_key: str, removed_log: dict) -> None:
+        """Remove duplicate firewall rules (by uniq-id) and coerce comments to str.
+
+        Shared by get_nat, get_mangle, get_filter, and get_raw.  When two
+        entries share the same uniq-id both are removed to prevent entity
+        registration crashes.  The first occurrence is logged as an error.
+        """
+        data = self.ds[ds_key]
+        seen: dict[str, str] = {}
+        duplicates: dict[str, int] = {}
+
+        for uid in data:
+            data[uid]["comment"] = str(data[uid]["comment"])
+            uniq = data[uid]["uniq-id"]
+            if uniq not in seen:
+                seen[uniq] = uid
+            else:
+                duplicates[uid] = 1
+                duplicates[seen[uniq]] = 1
+
+        for uid in duplicates:
+            uniq = data[uid]["uniq-id"]
+            if uniq not in removed_log:
+                removed_log[uniq] = 1
+                _LOGGER.error(
+                    "Mikrotik %s duplicate %s rule %s, entity will be unavailable.",
+                    self.host,
+                    ds_key,
+                    data[uid]["name"],
+                )
+            del data[uid]
+
     # ---------------------------
     #   get_nat
     # ---------------------------
@@ -1125,29 +1157,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             only=[{"key": "action", "value": "dst-nat"}],
         )
 
-        # Remove duplicate NAT entries to prevent crash
-        nat_uniq = {}
-        nat_del = {}
-        for uid in self.ds["nat"]:
-            self.ds["nat"][uid]["comment"] = str(self.ds["nat"][uid]["comment"])
-
-            tmp_name = self.ds["nat"][uid]["uniq-id"]
-            if tmp_name not in nat_uniq:
-                nat_uniq[tmp_name] = uid
-            else:
-                nat_del[uid] = 1
-                nat_del[nat_uniq[tmp_name]] = 1
-
-        for uid in nat_del:
-            if self.ds["nat"][uid]["uniq-id"] not in self.nat_removed:
-                self.nat_removed[self.ds["nat"][uid]["uniq-id"]] = 1
-                _LOGGER.error(
-                    "Mikrotik %s duplicate NAT rule %s, entity will be unavailable.",
-                    self.host,
-                    self.ds["nat"][uid]["name"],
-                )
-
-            del self.ds["nat"][uid]
+        self._dedup_firewall_rules("nat", self.nat_removed)
 
     # ---------------------------
     #   get_mangle
@@ -1223,29 +1233,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             ],
         )
 
-        # Remove duplicate Mangle entries to prevent crash
-        mangle_uniq = {}
-        mangle_del = {}
-        for uid in self.ds["mangle"]:
-            self.ds["mangle"][uid]["comment"] = str(self.ds["mangle"][uid]["comment"])
-
-            tmp_name = self.ds["mangle"][uid]["uniq-id"]
-            if tmp_name not in mangle_uniq:
-                mangle_uniq[tmp_name] = uid
-            else:
-                mangle_del[uid] = 1
-                mangle_del[mangle_uniq[tmp_name]] = 1
-
-        for uid in mangle_del:
-            if self.ds["mangle"][uid]["uniq-id"] not in self.mangle_removed:
-                self.mangle_removed[self.ds["mangle"][uid]["uniq-id"]] = 1
-                _LOGGER.error(
-                    "Mikrotik %s duplicate Mangle rule %s, entity will be unavailable.",
-                    self.host,
-                    self.ds["mangle"][uid]["name"],
-                )
-
-            del self.ds["mangle"][uid]
+        self._dedup_firewall_rules("mangle", self.mangle_removed)
 
     # ---------------------------
     #   get_filter
@@ -1331,30 +1319,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             ],
         )
 
-        # Remove duplicate filter entries to prevent crash
-        filter_uniq = {}
-        filter_del = {}
-        for uid in self.ds["filter"]:
-            self.ds["filter"][uid]["comment"] = str(self.ds["filter"][uid]["comment"])
-
-            tmp_name = self.ds["filter"][uid]["uniq-id"]
-            if tmp_name not in filter_uniq:
-                filter_uniq[tmp_name] = uid
-            else:
-                filter_del[uid] = 1
-                filter_del[filter_uniq[tmp_name]] = 1
-
-        for uid in filter_del:
-            if self.ds["filter"][uid]["uniq-id"] not in self.filter_removed:
-                self.filter_removed[self.ds["filter"][uid]["uniq-id"]] = 1
-                _LOGGER.error(
-                    "Mikrotik %s duplicate Filter rule %s (ID %s), entity will be unavailable.",
-                    self.host,
-                    self.ds["filter"][uid]["name"],
-                    self.ds["filter"][uid][".id"],
-                )
-
-            del self.ds["filter"][uid]
+        self._dedup_firewall_rules("filter", self.filter_removed)
 
     # ---------------------------
     #   get_raw
@@ -1434,30 +1399,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             ],
         )
 
-        # Remove duplicate raw entries to prevent crash
-        raw_uniq = {}
-        raw_del = {}
-        for uid in self.ds["raw"]:
-            self.ds["raw"][uid]["comment"] = str(self.ds["raw"][uid]["comment"])
-
-            tmp_name = self.ds["raw"][uid]["uniq-id"]
-            if tmp_name not in raw_uniq:
-                raw_uniq[tmp_name] = uid
-            else:
-                raw_del[uid] = 1
-                raw_del[raw_uniq[tmp_name]] = 1
-
-        for uid in raw_del:
-            if self.ds["raw"][uid]["uniq-id"] not in self.raw_removed:
-                self.raw_removed[self.ds["raw"][uid]["uniq-id"]] = 1
-                _LOGGER.error(
-                    "Mikrotik %s duplicate RAW rule %s (ID %s), entity will be unavailable.",
-                    self.host,
-                    self.ds["raw"][uid]["name"],
-                    self.ds["raw"][uid][".id"],
-                )
-
-            del self.ds["raw"][uid]
+        self._dedup_firewall_rules("raw", self.raw_removed)
 
     # ---------------------------
     #   get_container

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -214,9 +214,9 @@ class MikrotikTrackerCoordinator(DataUpdateCoordinator[None]):
     def _should_ping_host(host: dict) -> bool:
         """Check if a host should be pinged (non-wireless with valid address/interface)."""
         return (
-            host["source"] not in ("capsman", "wireless")
-            and host["address"] not in ("unknown", "")
-            and host["interface"] not in ("unknown", "")
+            host.get("source", "") not in ("capsman", "wireless")
+            and host.get("address", "unknown") not in ("unknown", "")
+            and host.get("interface", "unknown") not in ("unknown", "")
         )
 
     async def _ping_host(self, uid: str, host: dict) -> None:
@@ -224,7 +224,7 @@ class MikrotikTrackerCoordinator(DataUpdateCoordinator[None]):
         interface = host["interface"]
         if (
             uid in self.coordinator.ds["arp"]
-            and self.coordinator.ds["arp"][uid]["bridge"] != ""
+            and self.coordinator.ds["arp"][uid].get("bridge", "") != ""
         ):
             interface = self.coordinator.ds["arp"][uid]["bridge"]
 
@@ -1827,12 +1827,13 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     self.minor_fw_version,
                     full_version,
                 )
-            except Exception:
+            except (ValueError, IndexError) as e:
                 _LOGGER.warning(
-                    "Mikrotik %s unable to determine FW version from '%s';"
+                    "Mikrotik %s unable to determine FW version from '%s' (%s);"
                     " some features may be disabled until next successful parse",
                     self.host,
                     full_version,
+                    e,
                 )
 
     # ---------------------------
@@ -2004,8 +2005,12 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             self.ds["queue"][uid]["comment"] = str(self.ds["queue"][uid]["comment"])
             try:
                 self._parse_queue_values(uid, vals)
-            except (ValueError, IndexError):
-                _LOGGER.warning("Queue %s has unexpected value format, skipping", uid)
+            except (ValueError, IndexError) as e:
+                _LOGGER.warning(
+                    "Queue %s has unexpected value format (%s), skipping",
+                    uid,
+                    e,
+                )
 
     @staticmethod
     def _parse_queue_pair(raw: str) -> tuple[str, str]:

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1531,11 +1531,10 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     "encoding"
                 ]
             else:
-                _PPP_NOT_CONNECTED = "not connected"
                 self.ds["ppp_secret"][uid]["connected"] = False
-                self.ds["ppp_secret"][uid]["caller-id"] = _PPP_NOT_CONNECTED
-                self.ds["ppp_secret"][uid]["address"] = _PPP_NOT_CONNECTED
-                self.ds["ppp_secret"][uid]["encoding"] = _PPP_NOT_CONNECTED
+                self.ds["ppp_secret"][uid]["caller-id"] = "not connected"
+                self.ds["ppp_secret"][uid]["address"] = "not connected"
+                self.ds["ppp_secret"][uid]["encoding"] = "not connected"
 
     # ---------------------------
     #   get_netwatch

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -159,11 +159,17 @@ class MikrotikTrackerCoordinator(DataUpdateCoordinator[None]):
         """Config entry option zones."""
         return self.config_entry.options.get(CONF_ZONE, STATE_HOME)
 
-    # ---------------------------
-    #   _async_update_data
-    # ---------------------------
+    _HOST_DEFAULTS = {
+        "address": "unknown",
+        "mac-address": "unknown",
+        "interface": "unknown",
+        "host-name": "unknown",
+        "last-seen": False,
+        "available": False,
+    }
+
     async def _async_update_data(self):
-        """Trigger update by timer"""
+        """Trigger update by timer."""
         if not self.coordinator.option_track_network_hosts:
             return
 
@@ -172,61 +178,16 @@ class MikrotikTrackerCoordinator(DataUpdateCoordinator[None]):
 
         first_run = not self.coordinator.host_tracking_initialized
 
-        for uid in list(self.coordinator.ds["host"]):
+        for uid in self.coordinator.ds["host"]:
+            host = self.coordinator.ds["host"][uid]
             if first_run:
-                # Add missing default values
-                for key, default in zip(
-                    [
-                        "address",
-                        "mac-address",
-                        "interface",
-                        "host-name",
-                        "last-seen",
-                        "available",
-                    ],
-                    ["unknown", "unknown", "unknown", "unknown", False, False],
-                ):
-                    if key not in self.coordinator.ds["host"][uid]:
-                        self.coordinator.ds["host"][uid][key] = default
+                self._ensure_host_defaults(host)
+                self._first_run_availability(uid, host)
+            elif self._should_ping_host(host):
+                await self._ping_host(uid, host)
 
-            # On first run, use ARP data instead of pinging every host
-            # sequentially.  Pings will run on subsequent 10s updates.
-            if first_run:
-                in_arp = uid in self.coordinator.ds["arp"]
-                self.coordinator.ds["host"][uid]["available"] = in_arp
-                if not in_arp:
-                    _LOGGER.debug(
-                        "Host %s not in ARP on first run; will ping next cycle",
-                        uid,
-                    )
-            elif (
-                self.coordinator.ds["host"][uid]["source"]
-                not in ["capsman", "wireless"]
-                and self.coordinator.ds["host"][uid]["address"] not in ["unknown", ""]
-                and self.coordinator.ds["host"][uid]["interface"] not in ["unknown", ""]
-            ):
-                tmp_interface = self.coordinator.ds["host"][uid]["interface"]
-                if (
-                    uid in self.coordinator.ds["arp"]
-                    and self.coordinator.ds["arp"][uid]["bridge"] != ""
-                ):
-                    tmp_interface = self.coordinator.ds["arp"][uid]["bridge"]
-
-                _LOGGER.debug(
-                    "Ping host: %s", self.coordinator.ds["host"][uid]["address"]
-                )
-
-                self.coordinator.ds["host"][uid][
-                    "available"
-                ] = await self.hass.async_add_executor_job(
-                    self.api.arp_ping,
-                    self.coordinator.ds["host"][uid]["address"],
-                    tmp_interface,
-                )
-
-            # Update last seen
-            if self.coordinator.ds["host"][uid]["available"]:
-                self.coordinator.ds["host"][uid]["last-seen"] = utcnow()
+            if host["available"]:
+                host["last-seen"] = utcnow()
 
         self.coordinator.host_tracking_initialized = True
 
@@ -236,10 +197,43 @@ class MikrotikTrackerCoordinator(DataUpdateCoordinator[None]):
             "routerboard": self.coordinator.ds["routerboard"],
         }
 
+    def _ensure_host_defaults(self, host: dict) -> None:
+        """Add missing default values to a host entry."""
+        for key, default in self._HOST_DEFAULTS.items():
+            if key not in host:
+                host[key] = default
 
-# ---------------------------
-#   MikrotikControllerData
-# ---------------------------
+    def _first_run_availability(self, uid: str, host: dict) -> None:
+        """Set availability from ARP on first run (no pinging)."""
+        in_arp = uid in self.coordinator.ds["arp"]
+        host["available"] = in_arp
+        if not in_arp:
+            _LOGGER.debug("Host %s not in ARP on first run; will ping next cycle", uid)
+
+    @staticmethod
+    def _should_ping_host(host: dict) -> bool:
+        """Check if a host should be pinged (non-wireless with valid address/interface)."""
+        return (
+            host["source"] not in ("capsman", "wireless")
+            and host["address"] not in ("unknown", "")
+            and host["interface"] not in ("unknown", "")
+        )
+
+    async def _ping_host(self, uid: str, host: dict) -> None:
+        """Ping a host and update availability."""
+        interface = host["interface"]
+        if (
+            uid in self.coordinator.ds["arp"]
+            and self.coordinator.ds["arp"][uid]["bridge"] != ""
+        ):
+            interface = self.coordinator.ds["arp"][uid]["bridge"]
+
+        _LOGGER.debug("Ping host: %s", host["address"])
+        host["available"] = await self.hass.async_add_executor_job(
+            self.api.arp_ping, host["address"], interface
+        )
+
+
 class MikrotikCoordinator(DataUpdateCoordinator[None]):
     """MikrotikCoordinator Class"""
 
@@ -545,55 +539,57 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         )
 
         if 0 < self.major_fw_version < 7:
-            if "ppp" in packages:
-                self.support_ppp = packages["ppp"]["enabled"]
+            self._detect_capabilities_v6(packages)
+        elif self.major_fw_version >= 7:
+            self._detect_capabilities_v7(packages)
 
-            if "wireless" in packages:
-                self.support_capsman = packages["wireless"]["enabled"]
-                self.support_wireless = packages["wireless"]["enabled"]
-            else:
-                self.support_capsman = False
-                self.support_wireless = False
+        for pkg, attr in [
+            ("ups", "support_ups"),
+            ("gps", "support_gps"),
+            ("container", "support_container"),
+        ]:
+            if pkg in packages and packages[pkg]["enabled"]:
+                setattr(self, attr, True)
 
-        elif 0 < self.major_fw_version >= 7:
-            self.support_ppp = True
-            self.support_wireless = True
-            if "wifiwave2" in packages and packages["wifiwave2"]["enabled"]:
-                self.support_capsman = False
-                self._wifimodule = "wifiwave2"
+    def _detect_capabilities_v6(self, packages: dict) -> None:
+        """Detect wireless/PPP capabilities for RouterOS v6."""
+        if "ppp" in packages:
+            self.support_ppp = packages["ppp"]["enabled"]
+        if "wireless" in packages:
+            self.support_capsman = packages["wireless"]["enabled"]
+            self.support_wireless = packages["wireless"]["enabled"]
+        else:
+            self.support_capsman = False
+            self.support_wireless = False
 
-            elif any(
-                pkg in packages and packages[pkg]["enabled"]
-                for pkg in ("wifi", "wifi-qcom", "wifi-qcom-ac")
-            ) or (
-                (self.major_fw_version == 7 and self.minor_fw_version >= 13)
-                or self.major_fw_version > 7
-            ):
-                self.support_capsman = False
-                self._wifimodule = "wifi"
+    def _detect_capabilities_v7(self, packages: dict) -> None:
+        """Detect wireless/PPP/wifi module capabilities for RouterOS v7+."""
+        self.support_ppp = True
+        self.support_wireless = True
 
-            else:
-                self.support_capsman = True
-                self.support_wireless = bool(self.minor_fw_version < 13)
+        if "wifiwave2" in packages and packages["wifiwave2"]["enabled"]:
+            self.support_capsman = False
+            self._wifimodule = "wifiwave2"
+        elif self._has_wifi_package(packages):
+            self.support_capsman = False
+            self._wifimodule = "wifi"
+        else:
+            self.support_capsman = True
+            self.support_wireless = bool(self.minor_fw_version < 13)
 
-            _LOGGER.debug(
-                "Mikrotik %s wifi module=%s",
-                self.host,
-                self._wifimodule,
-            )
+        _LOGGER.debug("Mikrotik %s wifi module=%s", self.host, self._wifimodule)
 
-        if "ups" in packages and packages["ups"]["enabled"]:
-            self.support_ups = True
+    def _has_wifi_package(self, packages: dict) -> bool:
+        """Check if a wifi package is enabled or version implies wifi module."""
+        if any(
+            pkg in packages and packages[pkg]["enabled"]
+            for pkg in ("wifi", "wifi-qcom", "wifi-qcom-ac")
+        ):
+            return True
+        return (
+            self.major_fw_version == 7 and self.minor_fw_version >= 13
+        ) or self.major_fw_version > 7
 
-        if "gps" in packages and packages["gps"]["enabled"]:
-            self.support_gps = True
-
-        if "container" in packages and packages["container"]["enabled"]:
-            self.support_container = True
-
-    # ---------------------------
-    #   async_get_host_hass
-    # ---------------------------
     async def async_get_host_hass(self):
         """Get host data from HA entity registry"""
         registry = entity_registry.async_get(self.hass)
@@ -706,11 +702,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         ]:
             await self._run_if_enabled(func, requires=enabled)
 
-        if self.api.connected() and self.option_sensor_client_traffic:
-            if 0 < self.major_fw_version < 7:
-                await self.hass.async_add_executor_job(self.process_accounting)
-            elif self.major_fw_version >= 7:
-                await self.hass.async_add_executor_job(self.process_kid_control_devices)
+        await self._async_update_client_traffic()
 
         for func, enabled in [
             (self.get_captive, self.option_sensor_client_captive),
@@ -735,9 +727,15 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         # async_dispatcher_send(self.hass, "update_sensors", self)
         return self.ds
 
-    # ---------------------------
-    #   get_access
-    # ---------------------------
+    async def _async_update_client_traffic(self) -> None:
+        """Run accounting or kid-control traffic collection if enabled."""
+        if not self.api.connected() or not self.option_sensor_client_traffic:
+            return
+        if 0 < self.major_fw_version < 7:
+            await self.hass.async_add_executor_job(self.process_accounting)
+        elif self.major_fw_version >= 7:
+            await self.hass.async_add_executor_job(self.process_kid_control_devices)
+
     def get_access(self) -> None:
         """Get access rights from Mikrotik"""
         tmp_user = parse_api(
@@ -862,9 +860,18 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 vals=self._POE_MONITOR_VALS,
             )
 
-    # ---------------------------
-    #   get_interface
-    # ---------------------------
+    def _calculate_interface_traffic(self) -> None:
+        """Calculate per-interface TX/RX throughput from byte counters."""
+        interval = self.option_scan_interval.seconds
+        for uid, vals in self.ds["interface"].items():
+            iface = self.ds["interface"][uid]
+            for direction in ("tx", "rx"):
+                current = vals[f"{direction}-current"]
+                previous = vals[f"{direction}-previous"] or current
+                iface[direction] = round(max(0, current - previous) / interval)
+                iface[f"{direction}-previous"] = current
+                iface[f"{direction}-total"] = current
+
     def get_interface(self) -> None:
         """Get all interfaces data from Mikrotik"""
         self.ds["interface"] = parse_api(
@@ -917,27 +924,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         )
 
         if self.option_sensor_port_traffic:
-            for uid, vals in self.ds["interface"].items():
-                current_tx = vals["tx-current"]
-                previous_tx = vals["tx-previous"] or current_tx
-
-                delta_tx = max(0, current_tx - previous_tx)
-                self.ds["interface"][uid]["tx"] = round(
-                    delta_tx / self.option_scan_interval.seconds
-                )
-                self.ds["interface"][uid]["tx-previous"] = current_tx
-
-                current_rx = vals["rx-current"]
-                previous_rx = vals["rx-previous"] or current_rx
-
-                delta_rx = max(0, current_rx - previous_rx)
-                self.ds["interface"][uid]["rx"] = round(
-                    delta_rx / self.option_scan_interval.seconds
-                )
-                self.ds["interface"][uid]["rx-previous"] = current_rx
-
-                self.ds["interface"][uid]["tx-total"] = current_tx
-                self.ds["interface"][uid]["rx-total"] = current_rx
+            self._calculate_interface_traffic()
 
         self.ds["interface"] = parse_api(
             data=self.ds["interface"],
@@ -962,46 +949,47 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         )
 
         # Update virtual interfaces
-        bonding = False
-        for uid, vals in self.ds["interface"].items():
-            if self.ds["interface"][uid]["type"] == "bond":
-                bonding = True
+        self._process_interface_metadata()
 
-            self.ds["interface"][uid]["comment"] = str(
-                self.ds["interface"][uid]["comment"]
-            )
+    def _process_interface_metadata(self) -> None:
+        """Post-process interfaces: comments, virtual names, ethernet monitoring, bonding."""
+        has_bonding = False
+        for uid, vals in self.ds["interface"].items():
+            iface = self.ds["interface"][uid]
+            if iface["type"] == "bond":
+                has_bonding = True
+
+            iface["comment"] = str(iface["comment"])
 
             if vals["default-name"] == "":
-                self.ds["interface"][uid]["default-name"] = vals["name"]
-                self.ds["interface"][uid]["port-mac-address"] = (
-                    f"{vals['port-mac-address']}-{vals['name']}"
-                )
+                iface["default-name"] = vals["name"]
+                iface["port-mac-address"] = f"{vals['port-mac-address']}-{vals['name']}"
 
-            if self.ds["interface"][uid]["type"] == "ether":
+            if iface["type"] == "ether":
                 self._monitor_ethernet_port(vals)
 
-        if bonding:
-            self.ds["bonding"] = parse_api(
-                data={},
-                source=self.api.query("/interface/bonding"),
-                key="name",
-                vals=[
-                    {"name": "name"},
-                    {"name": "mac-address"},
-                    {"name": "slaves"},
-                    {"name": "mode"},
-                ],
-            )
+        if has_bonding:
+            self._process_bonding()
 
-            self.ds["bonding_slaves"] = {}
-            for uid, vals in self.ds["bonding"].items():
-                for tmp in vals["slaves"].split(","):
-                    self.ds["bonding_slaves"][tmp] = vals
-                    self.ds["bonding_slaves"][tmp]["master"] = uid
+    def _process_bonding(self) -> None:
+        """Fetch bonding config and build slave→master mapping."""
+        self.ds["bonding"] = parse_api(
+            data={},
+            source=self.api.query("/interface/bonding"),
+            key="name",
+            vals=[
+                {"name": "name"},
+                {"name": "mac-address"},
+                {"name": "slaves"},
+                {"name": "mode"},
+            ],
+        )
+        self.ds["bonding_slaves"] = {}
+        for uid, vals in self.ds["bonding"].items():
+            for tmp in vals["slaves"].split(","):
+                self.ds["bonding_slaves"][tmp] = vals
+                self.ds["bonding_slaves"][tmp]["master"] = uid
 
-    # ---------------------------
-    #   get_bridge
-    # ---------------------------
     def get_bridge(self) -> None:
         """Get system resources data from Mikrotik"""
         self.ds["bridge_host"] = parse_api(
@@ -1025,11 +1013,8 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         for uid, vals in self.ds["bridge_host"].items():
             self.ds["bridge"][vals["bridge"]] = True
 
-    # ---------------------------
-    #   process_interface_client
-    # ---------------------------
     def process_interface_client(self) -> None:
-        # Remove data if disabled
+        """Resolve client IP/MAC for each interface from ARP and DHCP data."""
         if not self.option_track_iface_clients:
             for uid in self.ds["interface"]:
                 self.ds["interface"][uid]["client-ip-address"] = "disabled"
@@ -1039,36 +1024,48 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         for uid, vals in self.ds["interface"].items():
             self.ds["interface"][uid]["client-ip-address"] = ""
             self.ds["interface"][uid]["client-mac-address"] = ""
-            for arp_uid, arp_vals in self.ds["arp"].items():
-                if arp_vals["interface"] != vals["name"] and not (
-                    vals["name"] in self.ds["bonding_slaves"]
-                    and self.ds["bonding_slaves"][vals["name"]]["master"]
-                    == arp_vals["interface"]
-                ):
-                    continue
-
-                if self.ds["interface"][uid]["client-ip-address"] == "":
-                    self.ds["interface"][uid]["client-ip-address"] = arp_vals["address"]
-                else:
-                    self.ds["interface"][uid]["client-ip-address"] = "multiple"
-
-                if self.ds["interface"][uid]["client-mac-address"] == "":
-                    self.ds["interface"][uid]["client-mac-address"] = arp_vals[
-                        "mac-address"
-                    ]
-                else:
-                    self.ds["interface"][uid]["client-mac-address"] = "multiple"
-
-            if self.ds["interface"][uid]["client-ip-address"] == "":
-                if self.ds["interface"][uid]["name"] in self.ds["dhcp-client"]:
-                    self.ds["interface"][uid]["client-ip-address"] = self.ds[
-                        "dhcp-client"
-                    ][self.ds["interface"][uid]["name"]]["address"]
-                else:
-                    self.ds["interface"][uid]["client-ip-address"] = "none"
-
+            self._match_arp_clients(uid, vals)
+            self._fallback_client_ip(uid)
             if self.ds["interface"][uid]["client-mac-address"] == "":
                 self.ds["interface"][uid]["client-mac-address"] = "none"
+
+    def _arp_matches_interface(self, arp_vals: dict, iface_name: str) -> bool:
+        """Check if an ARP entry belongs to an interface (direct or via bonding)."""
+        if arp_vals["interface"] == iface_name:
+            return True
+        if iface_name in self.ds["bonding_slaves"]:
+            return (
+                self.ds["bonding_slaves"][iface_name]["master"] == arp_vals["interface"]
+            )
+        return False
+
+    def _match_arp_clients(self, uid: str, vals: dict) -> None:
+        """Match ARP entries to an interface, setting client-ip/mac or 'multiple'."""
+        iface = self.ds["interface"][uid]
+        for arp_vals in self.ds["arp"].values():
+            if not self._arp_matches_interface(arp_vals, vals["name"]):
+                continue
+
+            if iface["client-ip-address"] == "":
+                iface["client-ip-address"] = arp_vals["address"]
+            else:
+                iface["client-ip-address"] = "multiple"
+
+            if iface["client-mac-address"] == "":
+                iface["client-mac-address"] = arp_vals["mac-address"]
+            else:
+                iface["client-mac-address"] = "multiple"
+
+    def _fallback_client_ip(self, uid: str) -> None:
+        """Fall back to DHCP client address if no ARP match found."""
+        iface = self.ds["interface"][uid]
+        if iface["client-ip-address"] != "":
+            return
+        name = iface["name"]
+        if name in self.ds["dhcp-client"]:
+            iface["client-ip-address"] = self.ds["dhcp-client"][name]["address"]
+        else:
+            iface["client-ip-address"] = "none"
 
     # ---------------------------
     #   get_nat
@@ -1284,7 +1281,6 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     "source": "disabled",
                     "type": "bool",
                     "reverse": True,
-                    "default": True,
                 },
             ],
             val_proc=[
@@ -1390,7 +1386,6 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     "source": "disabled",
                     "type": "bool",
                     "reverse": True,
-                    "default": True,
                 },
             ],
             val_proc=[
@@ -1833,8 +1828,9 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     full_version,
                 )
             except Exception:
-                _LOGGER.error(
-                    "Mikrotik %s unable to determine major FW version (%s).",
+                _LOGGER.warning(
+                    "Mikrotik %s unable to determine FW version from '%s';"
+                    " some features may be disabled until next successful parse",
                     self.host,
                     full_version,
                 )
@@ -2006,50 +2002,32 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
         for uid, vals in self.ds["queue"].items():
             self.ds["queue"][uid]["comment"] = str(self.ds["queue"][uid]["comment"])
+            try:
+                self._parse_queue_values(uid, vals)
+            except (ValueError, IndexError):
+                _LOGGER.warning("Queue %s has unexpected value format, skipping", uid)
 
-            upload_max_limit_bps, download_max_limit_bps = [
-                int(x) for x in vals["max-limit"].split("/")
-            ]
-            self.ds["queue"][uid]["upload-max-limit"] = f"{upload_max_limit_bps} bps"
-            self.ds["queue"][uid]["download-max-limit"] = (
-                f"{download_max_limit_bps} bps"
-            )
+    @staticmethod
+    def _parse_queue_pair(raw: str) -> tuple[str, str]:
+        """Split an 'upload/download' value and format as bps strings."""
+        up, down = (int(x) for x in raw.split("/"))
+        return f"{up} bps", f"{down} bps"
 
-            upload_rate_bps, download_rate_bps = [
-                int(x) for x in vals["rate"].split("/")
-            ]
-            self.ds["queue"][uid]["upload-rate"] = f"{upload_rate_bps} bps"
-            self.ds["queue"][uid]["download-rate"] = f"{download_rate_bps} bps"
+    def _parse_queue_values(self, uid: str, vals: dict) -> None:
+        """Parse all queue rate/limit fields for a single entry."""
+        q = self.ds["queue"][uid]
+        for field, up_key, down_key in [
+            ("max-limit", "upload-max-limit", "download-max-limit"),
+            ("rate", "upload-rate", "download-rate"),
+            ("limit-at", "upload-limit-at", "download-limit-at"),
+            ("burst-limit", "upload-burst-limit", "download-burst-limit"),
+            ("burst-threshold", "upload-burst-threshold", "download-burst-threshold"),
+        ]:
+            q[up_key], q[down_key] = self._parse_queue_pair(vals[field])
 
-            upload_limit_at_bps, download_limit_at_bps = [
-                int(x) for x in vals["limit-at"].split("/")
-            ]
-            self.ds["queue"][uid]["upload-limit-at"] = f"{upload_limit_at_bps} bps"
-            self.ds["queue"][uid]["download-limit-at"] = f"{download_limit_at_bps} bps"
-
-            upload_burst_limit_bps, download_burst_limit_bps = [
-                int(x) for x in vals["burst-limit"].split("/")
-            ]
-            self.ds["queue"][uid]["upload-burst-limit"] = (
-                f"{upload_burst_limit_bps} bps"
-            )
-            self.ds["queue"][uid]["download-burst-limit"] = (
-                f"{download_burst_limit_bps} bps"
-            )
-
-            upload_burst_threshold_bps, download_burst_threshold_bps = [
-                int(x) for x in vals["burst-threshold"].split("/")
-            ]
-            self.ds["queue"][uid]["upload-burst-threshold"] = (
-                f"{upload_burst_threshold_bps} bps"
-            )
-            self.ds["queue"][uid]["download-burst-threshold"] = (
-                f"{download_burst_threshold_bps} bps"
-            )
-
-            upload_burst_time, download_burst_time = vals["burst-time"].split("/")
-            self.ds["queue"][uid]["upload-burst-time"] = upload_burst_time
-            self.ds["queue"][uid]["download-burst-time"] = download_burst_time
+        upload_burst_time, download_burst_time = vals["burst-time"].split("/")
+        q["upload-burst-time"] = upload_burst_time
+        q["download-burst-time"] = download_burst_time
 
     # ---------------------------
     #   get_arp
@@ -2133,48 +2111,46 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         dhcpserver_query = False
         for uid in self.ds["dhcp"]:
             self.ds["dhcp"][uid]["comment"] = str(self.ds["dhcp"][uid]["comment"])
+            self._normalize_dhcp_lease(uid)
+            dhcpserver_query = self._resolve_dhcp_interface(uid, dhcpserver_query)
 
-            # is_valid_ip
-            if self.ds["dhcp"][uid]["address"] != "unknown":
-                if not is_valid_ip(self.ds["dhcp"][uid]["address"]):
-                    self.ds["dhcp"][uid]["address"] = "unknown"
+        self._count_leases_per_server()
 
-                if self.ds["dhcp"][uid]["active-address"] not in [
-                    self.ds["dhcp"][uid]["address"],
-                    "unknown",
-                ]:
-                    self.ds["dhcp"][uid]["address"] = self.ds["dhcp"][uid][
-                        "active-address"
-                    ]
+    def _normalize_dhcp_lease(self, uid: str) -> None:
+        """Validate and normalize address/MAC for a single DHCP lease."""
+        lease = self.ds["dhcp"][uid]
+        if lease["address"] == "unknown":
+            return
 
-                if (
-                    self.ds["dhcp"][uid]["mac-address"]
-                    != self.ds["dhcp"][uid]["active-mac-address"]
-                    != "unknown"
-                ):
-                    self.ds["dhcp"][uid]["mac-address"] = self.ds["dhcp"][uid][
-                        "active-mac-address"
-                    ]
+        if not is_valid_ip(lease["address"]):
+            lease["address"] = "unknown"
+            return
 
-            # Safety net: re-query if a server appeared after the upfront call
-            if (
-                not dhcpserver_query
-                and self.ds["dhcp"][uid]["server"] not in self.ds["dhcp-server"]
-            ):
-                self.get_dhcp_server()
-                dhcpserver_query = True
+        if lease["active-address"] not in (lease["address"], "unknown"):
+            lease["address"] = lease["active-address"]
 
-            if self.ds["dhcp"][uid]["server"] in self.ds["dhcp-server"]:
-                self.ds["dhcp"][uid]["interface"] = self.ds["dhcp-server"][
-                    self.ds["dhcp"][uid]["server"]
-                ]["interface"]
-            elif uid in self.ds["arp"]:
-                if self.ds["arp"][uid]["bridge"] != "unknown":
-                    self.ds["dhcp"][uid]["interface"] = self.ds["arp"][uid]["bridge"]
-                else:
-                    self.ds["dhcp"][uid]["interface"] = self.ds["arp"][uid]["interface"]
+        if lease["mac-address"] != lease["active-mac-address"] != "unknown":
+            lease["mac-address"] = lease["active-mac-address"]
 
-        # Count leases per DHCP server
+    def _resolve_dhcp_interface(self, uid: str, dhcpserver_queried: bool) -> bool:
+        """Resolve interface for a DHCP lease from server or ARP data."""
+        lease = self.ds["dhcp"][uid]
+        if not dhcpserver_queried and lease["server"] not in self.ds["dhcp-server"]:
+            self.get_dhcp_server()
+            dhcpserver_queried = True
+
+        if lease["server"] in self.ds["dhcp-server"]:
+            lease["interface"] = self.ds["dhcp-server"][lease["server"]]["interface"]
+        elif uid in self.ds["arp"]:
+            arp = self.ds["arp"][uid]
+            lease["interface"] = (
+                arp["bridge"] if arp["bridge"] != "unknown" else arp["interface"]
+            )
+
+        return dhcpserver_queried
+
+    def _count_leases_per_server(self) -> None:
+        """Count active leases per DHCP server."""
         for server_name in self.ds["dhcp-server"]:
             self.ds["dhcp-server"][server_name]["lease-count"] = 0
         for uid in self.ds["dhcp"]:
@@ -2841,16 +2817,19 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
         if entry_count == threshold:
             _LOGGER.warning(
-                f"Accounting entries count reached the threshold of {threshold}!"
+                "Accounting entries count reached the threshold of %s!"
                 " Some entries were not saved by Mikrotik so accounting calculation won't be correct."
                 " Consider shortening update interval or"
-                " increasing the accounting threshold value in Mikrotik."
+                " increasing the accounting threshold value in Mikrotik.",
+                threshold,
             )
         elif entry_count > threshold * 0.9:
             _LOGGER.info(
-                f"Accounting entries count ({entry_count} reached 90% of the threshold,"
-                f" currently set to {threshold}! Consider shortening update interval or"
-                " increasing the accounting threshold value in Mikrotik."
+                "Accounting entries count (%s) reached 90%% of the threshold,"
+                " currently set to %s! Consider shortening update interval or"
+                " increasing the accounting threshold value in Mikrotik.",
+                entry_count,
+                threshold,
             )
 
     # ---------------------------

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -305,6 +305,11 @@ class MikrotikEntity(CoordinatorEntity[_MikrotikCoordinatorT], Entity):
             if self._uid:
                 self._data = self._data[self._uid]
         except KeyError:
+            _LOGGER.debug(
+                "Data path %s uid=%s not found, skipping update",
+                self.entity_description.data_path,
+                self._uid,
+            )
             return
         super()._handle_coordinator_update()
 

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -300,11 +300,12 @@ class MikrotikEntity(CoordinatorEntity[_MikrotikCoordinatorT], Entity):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        self._data = self.coordinator.data[self.entity_description.data_path]
-        if self._uid:
-            self._data = self.coordinator.data[self.entity_description.data_path][
-                self._uid
-            ]
+        try:
+            self._data = self.coordinator.data[self.entity_description.data_path]
+            if self._uid:
+                self._data = self._data[self._uid]
+        except KeyError:
+            return
         super()._handle_coordinator_update()
 
     @property

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -341,8 +341,7 @@ class MikrotikEntity(CoordinatorEntity[_MikrotikCoordinatorT], Entity):
         """Return a unique id for this entity"""
         if self._uid:
             return f"{self._inst.lower()}-{self.entity_description.key}-{slugify(str(self._data[self.entity_description.data_reference]).lower())}"
-        else:
-            return f"{self._inst.lower()}-{self.entity_description.key}"
+        return f"{self._inst.lower()}-{self.entity_description.key}"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/mikrotik_router/mikrotikapi.py
+++ b/custom_components/mikrotik_router/mikrotikapi.py
@@ -17,23 +17,20 @@ import librouteros
 _LOGGER = logging.getLogger(__name__)
 
 
-# ---------------------------
-#   MikrotikAPI
-# ---------------------------
 class MikrotikAPI:
     """Handle all communication with the Mikrotik API."""
 
     def __init__(
         self,
-        host,
-        username,
-        password,
-        port=0,
-        use_ssl=True,
-        ssl_verify=True,
-        login_method=DEFAULT_LOGIN_METHOD,
-        encoding=DEFAULT_ENCODING,
-    ):
+        host: str,
+        username: str,
+        password: str,
+        port: int = 0,
+        use_ssl: bool = True,
+        ssl_verify: bool = True,
+        login_method: str = DEFAULT_LOGIN_METHOD,
+        encoding: str = DEFAULT_ENCODING,
+    ) -> None:
         """Initialize the Mikrotik Client."""
         self._host = host
         self._use_ssl = use_ssl
@@ -49,46 +46,33 @@ class MikrotikAPI:
         self._connection = None
         self._connected = False
         self._reconnected = True
-        self._connection_epoch = 0
+        self._connection_epoch: float = 0
         self._connection_retry_sec = 58
-        self.error = None
+        self.error: str = ""
         self.connection_error_reported = False
-        self.client_traffic_last_run = None
+        self.client_traffic_last_run: int | None = None
         self.disable_health = False
 
-        # Default ports
         if not self._port:
             self._port = 8729 if self._use_ssl else 8728
 
-    # ---------------------------
-    #   has_reconnected
-    # ---------------------------
     def has_reconnected(self) -> bool:
-        """Check if mikrotik has reconnected"""
+        """Check if mikrotik has reconnected."""
         if self._reconnected:
             self._reconnected = False
             return True
-
         return False
 
-    # ---------------------------
-    #   connection_check
-    # ---------------------------
     def connection_check(self) -> bool:
-        """Check if mikrotik is connected"""
+        """Check if mikrotik is connected."""
         if not self._connected or not self._connection:
             if self._connection_epoch > time() - self._connection_retry_sec:
                 return False
-
             if not self.connect():
                 return False
-
         return True
 
-    # ---------------------------
-    #   disconnect
-    # ---------------------------
-    def disconnect(self, location="unknown", error=None):
+    def disconnect(self, location: str = "unknown", error: object = None) -> None:
         """Disconnect from Mikrotik device."""
         if not error:
             error = "unknown"
@@ -100,7 +84,6 @@ class MikrotikAPI:
                 _LOGGER.error(
                     "Mikrotik %s error while %s : %s", self._host, location, error
                 )
-
             self.connection_error_reported = True
 
         self._reconnected = False
@@ -108,9 +91,6 @@ class MikrotikAPI:
         self._connection = None
         self._connection_epoch = 0
 
-    # ---------------------------
-    #   connect
-    # ---------------------------
     def connect(self) -> bool:
         """Connect to Mikrotik device."""
         self.error = ""
@@ -126,15 +106,7 @@ class MikrotikAPI:
         with self.lock:
             try:
                 if self._use_ssl:
-                    if self._ssl_wrapper is None:
-                        ssl_context = ssl.create_default_context()
-                        ssl_context.check_hostname = False
-                        if self._ssl_verify:
-                            ssl_context.verify_mode = ssl.CERT_REQUIRED
-                            ssl_context.verify_flags &= ~ssl.VERIFY_X509_STRICT
-                        else:
-                            ssl_context.verify_mode = ssl.CERT_NONE
-                        self._ssl_wrapper = ssl_context.wrap_socket
+                    self._ensure_ssl_wrapper()
                     kwargs["ssl_wrapper"] = self._ssl_wrapper
                 self._connection = librouteros.connect(
                     self._host, self._username, self._password, **kwargs
@@ -145,7 +117,6 @@ class MikrotikAPI:
                         "Mikrotik %s error while connecting: %s", self._host, e
                     )
                     self.connection_error_reported = True
-
                 self.error_to_strings(f"{e}")
                 self._connection = None
                 return False
@@ -155,42 +126,46 @@ class MikrotikAPI:
                     self.connection_error_reported = False
                 else:
                     _LOGGER.debug("Mikrotik Connected to %s", self._host)
-
                 self._connected = True
                 self._reconnected = True
 
         return self._connected
 
-    # ---------------------------
-    #   error_to_strings
-    # ---------------------------
-    def error_to_strings(self, error):
+    def _ensure_ssl_wrapper(self) -> None:
+        """Create SSL wrapper if not already initialised."""
+        if self._ssl_wrapper is not None:
+            return
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        if self._ssl_verify:
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            ssl_context.verify_flags &= ~ssl.VERIFY_X509_STRICT
+        else:
+            ssl_context.verify_mode = ssl.CERT_NONE
+        self._ssl_wrapper = ssl_context.wrap_socket
+
+    def error_to_strings(self, error: str) -> None:
         """Translate error output to error string."""
         self.error = "cannot_connect"
         if error == "invalid user name or password (6)":
             self.error = "wrong_login"
-
         if "ALERT_HANDSHAKE_FAILURE" in error:
             self.error = "ssl_handshake_failure"
-
         if "CERTIFICATE_VERIFY_FAILED" in error:
             self.error = "ssl_verify_failure"
 
-    # ---------------------------
-    #   connected
-    # ---------------------------
     def connected(self) -> bool:
         """Return connected boolean."""
         return self._connected
 
-    # ---------------------------
-    #   query
-    # ---------------------------
-    def query(self, path, command=None, args=None, return_list=True) -> list | None:
-        """Retrieve data from Mikrotik API.
-
-        Returns list, unless return_list passed as False (returns generator).
-        """
+    def query(
+        self,
+        path: str,
+        command: str | None = None,
+        args: dict | None = None,
+        return_list: bool = True,
+    ) -> list | None:
+        """Retrieve data from Mikrotik API."""
         if path == "/system/health" and self.disable_health:
             return None
 
@@ -208,34 +183,52 @@ class MikrotikAPI:
                 self.disconnect("path", e)
                 return None
 
-            if response and return_list and not command:
-                try:
-                    response = list(response)
-                except Exception as e:
-                    if path == "/system/health" and "no such command prefix" in str(e):
-                        self.disable_health = True
-                        return None
-
-                    self.disconnect(f"building list for path {path}", e)
-                    return None
-
-            elif response and command:
-                _LOGGER.debug("API query: %s, %s, %s", path, command, args)
-                try:
-                    response = list(response(command, **args))
-                except Exception as e:
-                    self.disconnect("path", e)
-                    return None
+            if command:
+                return self._query_command(response, path, command, args)
+            if return_list:
+                return self._query_list(response, path)
 
         return response or None
 
-    # ---------------------------
-    #   set_value
-    # ---------------------------
-    def set_value(self, path, param, value, mod_param, mod_value) -> bool:
-        """Modify a parameter"""
-        entry_found = None
+    def _query_list(self, response, path: str) -> list | None:
+        """Build list from API response. Must be called inside self.lock."""
+        try:
+            return list(response) or None
+        except Exception as e:
+            if path == "/system/health" and "no such command prefix" in str(e):
+                self.disable_health = True
+                return None
+            self.disconnect(f"building list for path {path}", e)
+            return None
 
+    def _query_command(
+        self, response, path: str, command: str, args: dict
+    ) -> list | None:
+        """Execute command on API path. Must be called inside self.lock."""
+        _LOGGER.debug("API query: %s, %s, %s", path, command, args)
+        try:
+            return list(response(command, **args)) or None
+        except Exception as e:
+            self.disconnect("path", e)
+            return None
+
+    @staticmethod
+    def _find_entry(response, param: str, value: str) -> str | None:
+        """Find .id of entry matching param=value in an API response."""
+        for item in response:
+            if item.get(param) == value:
+                return item.get(".id")
+        return None
+
+    def set_value(
+        self,
+        path: str,
+        param: str,
+        value: str,
+        mod_param: str,
+        mod_value: object,
+    ) -> bool:
+        """Modify a parameter."""
         if not self.connection_check():
             return False
 
@@ -243,15 +236,7 @@ class MikrotikAPI:
         if response is None:
             return False
 
-        for tmp in response:
-            if param not in tmp:
-                continue
-
-            if tmp[param] != value:
-                continue
-
-            entry_found = tmp[".id"]
-
+        entry_found = self._find_entry(response, param, value)
         if not entry_found:
             _LOGGER.error(
                 "Mikrotik %s set_value parameter %s with value %s not found",
@@ -259,7 +244,7 @@ class MikrotikAPI:
                 param,
                 value,
             )
-            return True
+            return False
 
         params = {".id": entry_found, mod_param: mod_value}
         with self.lock:
@@ -271,14 +256,15 @@ class MikrotikAPI:
 
         return True
 
-    # ---------------------------
-    #   execute
-    # ---------------------------
-    def execute(self, path, command, param, value, attributes=None) -> bool:
-        """Execute a command"""
-        entry_found = None
-        params = {}
-
+    def execute(
+        self,
+        path: str,
+        command: str,
+        param: str,
+        value: str,
+        attributes: dict | None = None,
+    ) -> bool:
+        """Execute a command."""
         if not self.connection_check():
             return False
 
@@ -286,16 +272,9 @@ class MikrotikAPI:
         if response is None:
             return False
 
+        params: dict = {}
         if param:
-            for tmp in response:
-                if param not in tmp:
-                    continue
-
-                if tmp[param] != value:
-                    continue
-
-                entry_found = tmp[".id"]
-
+            entry_found = self._find_entry(response, param, value)
             if not entry_found:
                 _LOGGER.error(
                     "Mikrotik %s Execute %s parameter %s with value %s not found",
@@ -304,9 +283,8 @@ class MikrotikAPI:
                     param,
                     value,
                 )
-                return True
-
-            params = {".id": entry_found}
+                return False
+            params[".id"] = entry_found
 
         if attributes:
             params.update(attributes)
@@ -320,12 +298,8 @@ class MikrotikAPI:
 
         return True
 
-    # ---------------------------
-    #   run_script
-    # ---------------------------
-    def run_script(self, name) -> bool:
-        """Run script"""
-        entry_found = None
+    def run_script(self, name: str) -> bool:
+        """Run script."""
         if not self.connection_check():
             return False
 
@@ -334,18 +308,10 @@ class MikrotikAPI:
             return False
 
         with self.lock:
-            for tmp in response:
-                if "name" not in tmp:
-                    continue
-
-                if tmp["name"] != name:
-                    continue
-
-                entry_found = tmp[".id"]
-
+            entry_found = self._find_entry(response, "name", name)
             if not entry_found:
                 _LOGGER.error("Mikrotik %s Script %s not found", self._host, name)
-                return True
+                return False
 
             try:
                 run = response("run", **{".id": entry_found})
@@ -356,11 +322,8 @@ class MikrotikAPI:
 
         return True
 
-    # ---------------------------
-    #   arp_ping
-    # ---------------------------
-    def arp_ping(self, address, interface) -> bool:
-        """Check arp ping response traffic stats"""
+    def arp_ping(self, address: str, interface: str) -> bool:
+        """Check arp ping response traffic stats."""
         if not self.connection_check():
             return False
 
@@ -397,7 +360,7 @@ class MikrotikAPI:
         return False
 
     @staticmethod
-    def _current_milliseconds():
+    def _current_milliseconds() -> int:
         return int(round(time() * 1000))
 
     def is_accounting_and_local_traffic_enabled(self) -> tuple[bool, bool]:
@@ -423,12 +386,8 @@ class MikrotikAPI:
 
         return True, True
 
-    # ---------------------------
-    #   take_client_traffic_snapshot
-    #   Returns float -> period in seconds between last and current run
-    # ---------------------------
-    def take_client_traffic_snapshot(self, use_accounting) -> float:
-        """Take accounting snapshot and return time diff"""
+    def take_client_traffic_snapshot(self, use_accounting: bool) -> float:
+        """Take accounting snapshot and return time diff."""
         if not self.connection_check():
             return 0
 
@@ -448,13 +407,10 @@ class MikrotikAPI:
                     self.disconnect("accounting_snapshot", e)
                     return 0
 
-        # First request will be discarded because we cannot know when the last data was retrieved
-        # prevents spikes in data
         if not self.client_traffic_last_run:
             self.client_traffic_last_run = self._current_milliseconds()
             return 0
 
-        # Calculate time difference in seconds and return
         time_diff = self._current_milliseconds() - self.client_traffic_last_run
         self.client_traffic_last_run = self._current_milliseconds()
         return time_diff / 1000

--- a/custom_components/mikrotik_router/sensor_types.py
+++ b/custom_components/mikrotik_router/sensor_types.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
 
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import EntityCategory
@@ -97,7 +96,7 @@ class MikrotikSensorEntityDescription(SensorEntityDescription):
     data_name_comment: bool = False
     data_uid: str | None = None
     data_reference: str | None = None
-    data_attributes_list: List = field(default_factory=lambda: [])
+    data_attributes_list: list = field(default_factory=list)
     func: str = "MikrotikSensor"
 
 

--- a/custom_components/mikrotik_router/sensor_types.py
+++ b/custom_components/mikrotik_router/sensor_types.py
@@ -28,6 +28,13 @@ from .iface_attributes import (
     DEVICE_ATTRIBUTES_IFACE,
 )
 
+# Icon constants (SonarCloud S1192 — avoid duplicated literals)
+ICON_THERMOMETER = "mdi:thermometer"
+ICON_LIGHTNING = "mdi:lightning-bolt"
+ICON_FAN = "mdi:fan"
+ICON_UPLOAD = "mdi:upload-network"
+ICON_DOWNLOAD = "mdi:download-network"
+
 DEVICE_ATTRIBUTES_IFACE_POE = [
     "default-name",
     "poe-out",
@@ -98,7 +105,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_temperature",
         name="Temperature",
-        icon="mdi:thermometer",
+        icon=ICON_THERMOMETER,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_display_precision=0,
@@ -115,7 +122,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_voltage",
         name="Voltage",
-        icon="mdi:lightning-bolt",
+        icon=ICON_LIGHTNING,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
         suggested_display_precision=1,
@@ -132,7 +139,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_cpu-temperature",
         name="CPU temperature",
-        icon="mdi:thermometer",
+        icon=ICON_THERMOMETER,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_display_precision=0,
@@ -149,7 +156,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_switch-temperature",
         name="Switch temperature",
-        icon="mdi:thermometer",
+        icon=ICON_THERMOMETER,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_display_precision=0,
@@ -166,7 +173,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_board-temperature1",
         name="Board temperature",
-        icon="mdi:thermometer",
+        icon=ICON_THERMOMETER,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_display_precision=0,
@@ -183,7 +190,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_phy-temperature",
         name="PHY temperature",
-        icon="mdi:thermometer",
+        icon=ICON_THERMOMETER,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_unit_of_measurement=UnitOfTemperature.CELSIUS,
         suggested_display_precision=0,
@@ -234,7 +241,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_poe_in_voltage",
         name="PoE in voltage",
-        icon="mdi:lightning-bolt",
+        icon=ICON_LIGHTNING,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
         suggested_display_precision=1,
@@ -286,7 +293,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="poe_out_voltage",
         name="PoE out voltage",
-        icon="mdi:lightning-bolt",
+        icon=ICON_LIGHTNING,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
         suggested_display_precision=1,
@@ -346,7 +353,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_fan1-speed",
         name="Fan1 speed",
-        icon="mdi:fan",
+        icon=ICON_FAN,
         native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
@@ -361,7 +368,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_fan2-speed",
         name="Fan2 speed",
-        icon="mdi:fan",
+        icon=ICON_FAN,
         native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
@@ -376,7 +383,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_fan3-speed",
         name="Fan3 speed",
-        icon="mdi:fan",
+        icon=ICON_FAN,
         native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
@@ -391,7 +398,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_fan4-speed",
         name="Fan4 speed",
-        icon="mdi:fan",
+        icon=ICON_FAN,
         native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
         device_class=None,
         state_class=SensorStateClass.MEASUREMENT,
@@ -423,7 +430,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_psu1_voltage",
         name="PSU 1 Voltage",
-        icon="mdi:lightning-bolt",
+        icon=ICON_LIGHTNING,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
         suggested_display_precision=1,
@@ -457,7 +464,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="system_psu2_voltage",
         name="PSU 2 Voltage",
-        icon="mdi:lightning-bolt",
+        icon=ICON_LIGHTNING,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
         suggested_display_precision=1,
@@ -653,7 +660,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="tx-total",
         name="TX total",
-        icon="mdi:upload-network",
+        icon=ICON_UPLOAD,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
         suggested_display_precision=1,
@@ -674,7 +681,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="rx-total",
         name="RX total",
-        icon="mdi:download-network",
+        icon=ICON_DOWNLOAD,
         native_unit_of_measurement=UnitOfInformation.BYTES,
         suggested_unit_of_measurement=UnitOfInformation.GIGABYTES,
         suggested_display_precision=1,
@@ -695,7 +702,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="client_traffic_lan_tx",
         name="LAN TX",
-        icon="mdi:upload-network",
+        icon=ICON_UPLOAD,
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
         suggested_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
         suggested_display_precision=1,
@@ -716,7 +723,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="client_traffic_lan_rx",
         name="LAN RX",
-        icon="mdi:download-network",
+        icon=ICON_DOWNLOAD,
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
         suggested_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
         suggested_display_precision=1,
@@ -737,7 +744,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="client_traffic_wan_tx",
         name="WAN TX",
-        icon="mdi:upload-network",
+        icon=ICON_UPLOAD,
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
         suggested_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
         suggested_display_precision=1,
@@ -758,7 +765,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="client_traffic_wan_rx",
         name="WAN RX",
-        icon="mdi:download-network",
+        icon=ICON_DOWNLOAD,
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
         suggested_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
         suggested_display_precision=1,
@@ -779,7 +786,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="client_traffic_tx",
         name="TX",
-        icon="mdi:upload-network",
+        icon=ICON_UPLOAD,
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
         suggested_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
         suggested_display_precision=1,
@@ -800,7 +807,7 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
     MikrotikSensorEntityDescription(
         key="client_traffic_rx",
         name="RX",
-        icon="mdi:download-network",
+        icon=ICON_DOWNLOAD,
         native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
         suggested_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
         suggested_display_precision=1,

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -72,6 +72,34 @@ class MikrotikSwitch(MikrotikEntity, SwitchEntity, RestoreEntity):
         if "write" not in self.coordinator.data["access"]:
             raise HomeAssistantError("Write access required")
 
+    def _find_rule_id(
+        self, data_key: str, match_field: str, match_value: str
+    ) -> str | None:
+        """Find the .id of a rule in coordinator data by matching a field value."""
+        for uid in self.coordinator.data[data_key]:
+            if self.coordinator.data[data_key][uid][match_field] == match_value:
+                return self.coordinator.data[data_key][uid][".id"]
+        return None
+
+    async def _toggle_rule(
+        self, data_key: str, match_field: str, match_value: str, disable: bool
+    ) -> None:
+        """Toggle a firewall/queue rule by looking up its .id and calling set_value."""
+        self._require_write_access()
+
+        value = self._find_rule_id(data_key, match_field, match_value)
+        if value is None:
+            msg = _RULE_NOT_FOUND_DISABLE if disable else _RULE_NOT_FOUND_ENABLE
+            _LOGGER.error(msg, self.entity_id)
+            return
+
+        path = self.entity_description.data_switch_path
+        mod_param = self.entity_description.data_switch_parameter
+        await self.hass.async_add_executor_job(
+            self.coordinator.set_value, path, ".id", value, mod_param, disable
+        )
+        await self.coordinator.async_refresh()
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
         self._require_write_access()
@@ -183,51 +211,11 @@ class MikrotikNATSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        self._require_write_access()
-
-        path = self.entity_description.data_switch_path
-        param = ".id"
-        value = None
-        for uid in self.coordinator.data["nat"]:
-            if self.coordinator.data["nat"][uid]["uniq-id"] == (
-                f"{self._data['chain']},{self._data['action']},{self._data['protocol']},"
-                f"{self._data['in-interface']}:{self._data['dst-port']}-"
-                f"{self._data['out-interface']}:{self._data['to-addresses']}:{self._data['to-ports']}"
-            ):
-                value = self.coordinator.data["nat"][uid][".id"]
-
-        if value is None:
-            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
-            return
-        mod_param = self.entity_description.data_switch_parameter
-        await self.hass.async_add_executor_job(
-            self.coordinator.set_value, path, param, value, mod_param, False
-        )
-        await self.coordinator.async_refresh()
+        await self._toggle_rule("nat", "uniq-id", self._data["uniq-id"], disable=False)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        self._require_write_access()
-
-        path = self.entity_description.data_switch_path
-        param = ".id"
-        value = None
-        for uid in self.coordinator.data["nat"]:
-            if self.coordinator.data["nat"][uid]["uniq-id"] == (
-                f"{self._data['chain']},{self._data['action']},{self._data['protocol']},"
-                f"{self._data['in-interface']}:{self._data['dst-port']}-"
-                f"{self._data['out-interface']}:{self._data['to-addresses']}:{self._data['to-ports']}"
-            ):
-                value = self.coordinator.data["nat"][uid][".id"]
-
-        if value is None:
-            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
-            return
-        mod_param = self.entity_description.data_switch_parameter
-        await self.hass.async_add_executor_job(
-            self.coordinator.set_value, path, param, value, mod_param, True
-        )
-        await self.coordinator.async_refresh()
+        await self._toggle_rule("nat", "uniq-id", self._data["uniq-id"], disable=True)
 
 
 # ---------------------------
@@ -238,53 +226,15 @@ class MikrotikMangleSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        self._require_write_access()
-
-        path = self.entity_description.data_switch_path
-        param = ".id"
-        value = None
-        for uid in self.coordinator.data["mangle"]:
-            if self.coordinator.data["mangle"][uid]["uniq-id"] == (
-                f"{self._data['chain']},{self._data['action']},{self._data['protocol']},"
-                f"{self._data['src-address']}:{self._data['src-port']}-"
-                f"{self._data['dst-address']}:{self._data['dst-port']},"
-                f"{self._data['src-address-list']}-{self._data['dst-address-list']}"
-            ):
-                value = self.coordinator.data["mangle"][uid][".id"]
-
-        if value is None:
-            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
-            return
-        mod_param = self.entity_description.data_switch_parameter
-        await self.hass.async_add_executor_job(
-            self.coordinator.set_value, path, param, value, mod_param, False
+        await self._toggle_rule(
+            "mangle", "uniq-id", self._data["uniq-id"], disable=False
         )
-        await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        self._require_write_access()
-
-        path = self.entity_description.data_switch_path
-        param = ".id"
-        value = None
-        for uid in self.coordinator.data["mangle"]:
-            if self.coordinator.data["mangle"][uid]["uniq-id"] == (
-                f"{self._data['chain']},{self._data['action']},{self._data['protocol']},"
-                f"{self._data['src-address']}:{self._data['src-port']}-"
-                f"{self._data['dst-address']}:{self._data['dst-port']},"
-                f"{self._data['src-address-list']}-{self._data['dst-address-list']}"
-            ):
-                value = self.coordinator.data["mangle"][uid][".id"]
-
-        if value is None:
-            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
-            return
-        mod_param = self.entity_description.data_switch_parameter
-        await self.hass.async_add_executor_job(
-            self.coordinator.set_value, path, param, value, mod_param, True
+        await self._toggle_rule(
+            "mangle", "uniq-id", self._data["uniq-id"], disable=True
         )
-        await self.coordinator.async_refresh()
 
 
 # ---------------------------
@@ -295,51 +245,15 @@ class MikrotikFilterSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        self._require_write_access()
-
-        path = self.entity_description.data_switch_path
-        param = ".id"
-        value = None
-        for uid in self.coordinator.data["filter"]:
-            if self.coordinator.data["filter"][uid]["uniq-id"] == (
-                f"{self._data['chain']},{self._data['action']},{self._data['protocol']},{self._data['layer7-protocol']},"
-                f"{self._data['in-interface']},{self._data['in-interface-list']}:{self._data['src-address']},{self._data['src-address-list']}:{self._data['src-port']}-"
-                f"{self._data['out-interface']},{self._data['out-interface-list']}:{self._data['dst-address']},{self._data['dst-address-list']}:{self._data['dst-port']}"
-            ):
-                value = self.coordinator.data["filter"][uid][".id"]
-
-        if value is None:
-            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
-            return
-        mod_param = self.entity_description.data_switch_parameter
-        await self.hass.async_add_executor_job(
-            self.coordinator.set_value, path, param, value, mod_param, False
+        await self._toggle_rule(
+            "filter", "uniq-id", self._data["uniq-id"], disable=False
         )
-        await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        self._require_write_access()
-
-        path = self.entity_description.data_switch_path
-        param = ".id"
-        value = None
-        for uid in self.coordinator.data["filter"]:
-            if self.coordinator.data["filter"][uid]["uniq-id"] == (
-                f"{self._data['chain']},{self._data['action']},{self._data['protocol']},{self._data['layer7-protocol']},"
-                f"{self._data['in-interface']},{self._data['in-interface-list']}:{self._data['src-address']},{self._data['src-address-list']}:{self._data['src-port']}-"
-                f"{self._data['out-interface']},{self._data['out-interface-list']}:{self._data['dst-address']},{self._data['dst-address-list']}:{self._data['dst-port']}"
-            ):
-                value = self.coordinator.data["filter"][uid][".id"]
-
-        if value is None:
-            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
-            return
-        mod_param = self.entity_description.data_switch_parameter
-        await self.hass.async_add_executor_job(
-            self.coordinator.set_value, path, param, value, mod_param, True
+        await self._toggle_rule(
+            "filter", "uniq-id", self._data["uniq-id"], disable=True
         )
-        await self.coordinator.async_refresh()
 
 
 # ---------------------------
@@ -350,43 +264,11 @@ class MikrotikQueueSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        self._require_write_access()
-
-        path = self.entity_description.data_switch_path
-        param = ".id"
-        value = None
-        for uid in self.coordinator.data["queue"]:
-            if self.coordinator.data["queue"][uid]["name"] == f"{self._data['name']}":
-                value = self.coordinator.data["queue"][uid][".id"]
-
-        if value is None:
-            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
-            return
-        mod_param = self.entity_description.data_switch_parameter
-        await self.hass.async_add_executor_job(
-            self.coordinator.set_value, path, param, value, mod_param, False
-        )
-        await self.coordinator.async_refresh()
+        await self._toggle_rule("queue", "name", self._data["name"], disable=False)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        self._require_write_access()
-
-        path = self.entity_description.data_switch_path
-        param = ".id"
-        value = None
-        for uid in self.coordinator.data["queue"]:
-            if self.coordinator.data["queue"][uid]["name"] == f"{self._data['name']}":
-                value = self.coordinator.data["queue"][uid][".id"]
-
-        if value is None:
-            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
-            return
-        mod_param = self.entity_description.data_switch_parameter
-        await self.hass.async_add_executor_job(
-            self.coordinator.set_value, path, param, value, mod_param, True
-        )
-        await self.coordinator.async_refresh()
+        await self._toggle_rule("queue", "name", self._data["name"], disable=True)
 
 
 # ---------------------------
@@ -430,55 +312,11 @@ class MikrotikRawSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        self._require_write_access()
-
-        path = self.entity_description.data_switch_path
-        param = ".id"
-        value = None
-        for uid in self.coordinator.data["raw"]:
-            if self.coordinator.data["raw"][uid]["uniq-id"] == (
-                f"{self._data['chain']},{self._data['action']},{self._data['protocol']},"
-                f"{self._data['in-interface']},{self._data['in-interface-list']}:"
-                f"{self._data['src-address']},{self._data['src-address-list']}:{self._data['src-port']}-"
-                f"{self._data['out-interface']},{self._data['out-interface-list']}:"
-                f"{self._data['dst-address']},{self._data['dst-address-list']}:{self._data['dst-port']}"
-            ):
-                value = self.coordinator.data["raw"][uid][".id"]
-
-        if value is None:
-            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
-            return
-        mod_param = self.entity_description.data_switch_parameter
-        await self.hass.async_add_executor_job(
-            self.coordinator.set_value, path, param, value, mod_param, False
-        )
-        await self.coordinator.async_refresh()
+        await self._toggle_rule("raw", "uniq-id", self._data["uniq-id"], disable=False)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        self._require_write_access()
-
-        path = self.entity_description.data_switch_path
-        param = ".id"
-        value = None
-        for uid in self.coordinator.data["raw"]:
-            if self.coordinator.data["raw"][uid]["uniq-id"] == (
-                f"{self._data['chain']},{self._data['action']},{self._data['protocol']},"
-                f"{self._data['in-interface']},{self._data['in-interface-list']}:"
-                f"{self._data['src-address']},{self._data['src-address-list']}:{self._data['src-port']}-"
-                f"{self._data['out-interface']},{self._data['out-interface-list']}:"
-                f"{self._data['dst-address']},{self._data['dst-address-list']}:{self._data['dst-port']}"
-            ):
-                value = self.coordinator.data["raw"][uid][".id"]
-
-        if value is None:
-            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
-            return
-        mod_param = self.entity_description.data_switch_parameter
-        await self.hass.async_add_executor_job(
-            self.coordinator.set_value, path, param, value, mod_param, True
-        )
-        await self.coordinator.async_refresh()
+        await self._toggle_rule("raw", "uniq-id", self._data["uniq-id"], disable=True)
 
 
 # ---------------------------

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -9,6 +9,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .entity import MikrotikEntity, MikrotikInterfaceEntityMixin, async_add_entities
@@ -18,6 +19,10 @@ from .switch_types import (
 )
 
 _LOGGER = getLogger(__name__)
+
+_CAPSMAN_MANAGED = "managed by CAPsMAN"
+_RULE_NOT_FOUND_ENABLE = "Rule not found for %s, cannot enable"
+_RULE_NOT_FOUND_DISABLE = "Rule not found for %s, cannot disable"
 
 
 # ---------------------------
@@ -62,14 +67,21 @@ class MikrotikSwitch(MikrotikEntity, SwitchEntity, RestoreEntity):
         else:
             return self.entity_description.icon_disabled
 
+    def _require_write_access(self) -> None:
+        """Raise HomeAssistantError if write access is not available."""
+        if "write" not in self.coordinator.data["access"]:
+            raise HomeAssistantError("Write access required")
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = self.entity_description.data_reference
         value = self._data[self.entity_description.data_reference]
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, False
@@ -78,12 +90,14 @@ class MikrotikSwitch(MikrotikEntity, SwitchEntity, RestoreEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = self.entity_description.data_reference
         value = self._data[self.entity_description.data_reference]
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, True
@@ -112,15 +126,14 @@ class MikrotikPortSwitch(MikrotikInterfaceEntityMixin, MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> str | None:
         """Turn on the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = self.entity_description.data_reference
-        if self._data["about"] == "managed by CAPsMAN":
+        if self._data.get("about") == _CAPSMAN_MANAGED:
             _LOGGER.error("Unable to enable %s, managed by CAPsMAN", self._data[param])
-            return "managed by CAPsMAN"
-        if "-" in self._data["port-mac-address"]:
+            return _CAPSMAN_MANAGED
+        if "-" in self._data.get("port-mac-address", ""):
             param = "name"
         value = self._data[self.entity_description.data_reference]
         mod_param = self.entity_description.data_switch_parameter
@@ -138,15 +151,14 @@ class MikrotikPortSwitch(MikrotikInterfaceEntityMixin, MikrotikSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> str | None:
         """Turn off the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = self.entity_description.data_reference
-        if self._data["about"] == "managed by CAPsMAN":
+        if self._data.get("about") == _CAPSMAN_MANAGED:
             _LOGGER.error("Unable to disable %s, managed by CAPsMAN", self._data[param])
-            return "managed by CAPsMAN"
-        if "-" in self._data["port-mac-address"]:
+            return _CAPSMAN_MANAGED
+        if "-" in self._data.get("port-mac-address", ""):
             param = "name"
         value = self._data[self.entity_description.data_reference]
         mod_param = self.entity_description.data_switch_parameter
@@ -171,8 +183,7 @@ class MikrotikNATSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = ".id"
@@ -185,6 +196,9 @@ class MikrotikNATSwitch(MikrotikSwitch):
             ):
                 value = self.coordinator.data["nat"][uid][".id"]
 
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, False
@@ -193,8 +207,7 @@ class MikrotikNATSwitch(MikrotikSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = ".id"
@@ -207,6 +220,9 @@ class MikrotikNATSwitch(MikrotikSwitch):
             ):
                 value = self.coordinator.data["nat"][uid][".id"]
 
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, True
@@ -222,8 +238,7 @@ class MikrotikMangleSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = ".id"
@@ -237,6 +252,9 @@ class MikrotikMangleSwitch(MikrotikSwitch):
             ):
                 value = self.coordinator.data["mangle"][uid][".id"]
 
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, False
@@ -245,8 +263,7 @@ class MikrotikMangleSwitch(MikrotikSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = ".id"
@@ -260,6 +277,9 @@ class MikrotikMangleSwitch(MikrotikSwitch):
             ):
                 value = self.coordinator.data["mangle"][uid][".id"]
 
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, True
@@ -275,8 +295,7 @@ class MikrotikFilterSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = ".id"
@@ -289,6 +308,9 @@ class MikrotikFilterSwitch(MikrotikSwitch):
             ):
                 value = self.coordinator.data["filter"][uid][".id"]
 
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, False
@@ -297,8 +319,7 @@ class MikrotikFilterSwitch(MikrotikSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = ".id"
@@ -311,6 +332,9 @@ class MikrotikFilterSwitch(MikrotikSwitch):
             ):
                 value = self.coordinator.data["filter"][uid][".id"]
 
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, True
@@ -326,8 +350,7 @@ class MikrotikQueueSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = ".id"
@@ -336,6 +359,9 @@ class MikrotikQueueSwitch(MikrotikSwitch):
             if self.coordinator.data["queue"][uid]["name"] == f"{self._data['name']}":
                 value = self.coordinator.data["queue"][uid][".id"]
 
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, False
@@ -344,8 +370,7 @@ class MikrotikQueueSwitch(MikrotikSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = ".id"
@@ -354,6 +379,9 @@ class MikrotikQueueSwitch(MikrotikSwitch):
             if self.coordinator.data["queue"][uid]["name"] == f"{self._data['name']}":
                 value = self.coordinator.data["queue"][uid][".id"]
 
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, True
@@ -369,8 +397,7 @@ class MikrotikKidcontrolPauseSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = self.entity_description.data_reference
@@ -383,8 +410,7 @@ class MikrotikKidcontrolPauseSwitch(MikrotikSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = self.entity_description.data_reference
@@ -404,8 +430,7 @@ class MikrotikRawSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = ".id"
@@ -420,6 +445,9 @@ class MikrotikRawSwitch(MikrotikSwitch):
             ):
                 value = self.coordinator.data["raw"][uid][".id"]
 
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_ENABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, False
@@ -428,8 +456,7 @@ class MikrotikRawSwitch(MikrotikSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the switch."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         param = ".id"
@@ -444,6 +471,9 @@ class MikrotikRawSwitch(MikrotikSwitch):
             ):
                 value = self.coordinator.data["raw"][uid][".id"]
 
+        if value is None:
+            _LOGGER.error(_RULE_NOT_FOUND_DISABLE, self.entity_id)
+            return
         mod_param = self.entity_description.data_switch_parameter
         await self.hass.async_add_executor_job(
             self.coordinator.set_value, path, param, value, mod_param, True
@@ -459,8 +489,7 @@ class MikrotikContainerSwitch(MikrotikSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Start the container."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         await self.hass.async_add_executor_job(
@@ -470,8 +499,7 @@ class MikrotikContainerSwitch(MikrotikSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Stop the container."""
-        if "write" not in self.coordinator.data["access"]:
-            return
+        self._require_write_access()
 
         path = self.entity_description.data_switch_path
         await self.hass.async_add_executor_job(

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,53 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260327-legacy-cleanup — SonarCloud remediation, complexity reduction, modernisation
+
+**Date:** 2026-03-27
+**Branch:** `refactor/legacy-cleanup`
+**Status:** In Review (targeting dev)
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `apiparser.py` | **Bug fix:** `from_entry_bool` now applies `reverse` to default when field absent — fixes DHCP leases/servers incorrectly showing disabled |
+| `apiparser.py` | Removed identity type coercions (`str(str)`, `int(int)`) in `from_entry()` |
+| `apiparser.py` | Extracted 8 helpers to reduce complexity: `_fill_val_str`, `_fill_val_bool`, `_convert_timestamp`, `_resolve_str_default`, `_process_source_entry`, `_get_uid_from_keys`, `_process_val_sub`, `_apply_combine` |
+| `mikrotikapi.py` | Extracted `_query_list`, `_query_command` from `query()` (18→≤15 complexity) |
+| `mikrotikapi.py` | Extracted `_find_entry` dedup helper, used by `set_value`, `execute`, `run_script` |
+| `mikrotikapi.py` | **Bug fix:** `set_value`/`execute`/`run_script` now return `False` (not `True`) when entry not found |
+| `mikrotikapi.py` | Added type hints to all public methods, extracted `_ensure_ssl_wrapper`, removed banner comments |
+| `coordinator.py` | Extracted 15+ helpers for complexity reduction: `_detect_capabilities_v6/v7`, `_has_wifi_package`, `_async_update_client_traffic`, `_calculate_interface_traffic`, `_process_interface_metadata`, `_process_bonding`, `_arp_matches_interface`, `_match_arp_clients`, `_fallback_client_ip`, `_normalize_dhcp_lease`, `_resolve_dhcp_interface`, `_count_leases_per_server`, `_parse_queue_values`, `_parse_queue_pair` |
+| `coordinator.py` | Tracker: extracted `_ensure_host_defaults`, `_first_run_availability`, `_should_ping_host`, `_ping_host` |
+| `coordinator.py` | Fixed f-string in logging (S3457), removed unnecessary `list()` |
+| `coordinator.py` | Queue parsing now catches `ValueError`/`IndexError` per entry |
+| `coordinator.py` | Firmware version parse failure logged as warning with consequence message |
+| `coordinator.py` | Fixed `default: True` + `reverse: True` in filter/raw rules (was relying on buggy from_entry_bool) |
+| `switch.py` | **Silent failure fix:** `_require_write_access()` raises `HomeAssistantError` instead of silent return |
+| `switch.py` | **Silent failure fix:** NAT/Mangle/Filter/Raw/Queue switches log error when rule not found (value=None) |
+| `switch.py` | `MikrotikPortSwitch` uses `.get()` for `about` and `port-mac-address` |
+| `switch.py` | Extracted `_CAPSMAN_MANAGED`, `_RULE_NOT_FOUND_ENABLE/DISABLE` constants |
+| `entity.py` | `_handle_coordinator_update` guards against `KeyError` when entity UID disappears |
+| `sensor_types.py` | Extracted 5 icon constants (S1192) |
+| `config_flow.py` | Set comprehension (S7494) |
+| `__init__.py` | Extracted `_collect_ids_for_desc` helper, prefixed unused params, NOSONAR on intentional `list()` |
+| `tests/` | 41 new tests (apiparser helpers, mikrotikapi _find_entry/return-false, from_entry_bool reverse regression) |
+
+### Why
+
+SonarCloud v2.3.13 report: 29 code smells (13 CRITICAL complexity, 6 string duplication, 4 MAJOR, 8 MINOR). All pre-existing upstream patterns. Also fixes tracked issues: ISS-260321-cognitive-complexity (13 functions), ISS-260321-silent-failures (8 items), from_entry_bool reverse quirk.
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint | 0 errors | ✅ |
+| Ruff format | 0 reformats needed | ✅ |
+| Tests | 525 passed, 5 skipped | ✅ |
+
+---
+
 ## CR-260326-wireless-client-count — Fix wireless client detection via bridge table
 
 **Date:** 2026-03-26

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -2,9 +2,9 @@
 
 ## Current Priorities
 
-1. ISS-260320-test-coverage — Increase test coverage to ≥80%
+1. ISS-260320-test-coverage — Increase test coverage to ≥80% (Phase 5 pending)
 2. ISS-260320-new-device-discovery — New devices require HA restart to appear
-3. ISS-260321-cognitive-complexity — Reduce cognitive complexity to ≤15 per function
+3. ISS-260320-refactor-dedup — Refactor duplicated patterns
 
 ---
 
@@ -39,7 +39,7 @@
 **Type:** Quality
 **Priority:** High
 **Created:** 2026-03-21
-**Status:** 🟢 Active — PR #30 (feature/complexity-reduction → dev)
+**Status:** 🔴 Closed — fixed in refactor/legacy-cleanup (PR #30 + round 2)
 
 **Context:**
 SonarCloud reports 14 functions exceeding cognitive complexity threshold of 15. Total project cognitive complexity is 1058. Worst offenders are upstream inherited code.
@@ -123,7 +123,7 @@ The `update_sensors` dispatcher was re-enabled in v2.3.6 to fix new devices not 
 **Type:** Bug/Quality
 **Priority:** Medium
 **Created:** 2026-03-21
-**Status:** 🟡 Backlog (partially addressed in PR #30)
+**Status:** 🔴 Closed — fixed in refactor/legacy-cleanup
 
 **Context:**
 Silent-failure audit (pr-review-toolkit:silent-failure-hunter) found 12 issues. Three critical/high items fixed in PR #30. Remaining items are pre-existing patterns.

--- a/tests/test_apiparser.py
+++ b/tests/test_apiparser.py
@@ -255,11 +255,11 @@ class TestFillDefaults:
         assert result["enabled"] is True
 
     def test_bool_reverse_default(self):
-        """When source is absent, default is returned without applying reverse."""
+        """When source is absent, reverse is applied to default (bug fix)."""
         data = {}
         vals = [{"name": "enabled", "type": "bool", "default": True, "reverse": True}]
         result = fill_defaults(data, vals)
-        assert result["enabled"] is True
+        assert result["enabled"] is False
 
 
 # --- fill_vals ---
@@ -482,3 +482,200 @@ class TestFromEntryNoneHandling:
         """None bypasses the type coercion since it's not str/int/float."""
         result = from_entry({"comment": None}, "comment", default="fallback")
         assert result is None
+
+
+# --- from_entry_bool reverse bug fix ---
+
+
+class TestFromEntryBoolReverseBugFix:
+    """Regression tests for the from_entry_bool reverse quirk.
+
+    When 'disabled' field is absent from API response (common for dynamic DHCP
+    leases), from_entry_bool must apply reverse to the default value.
+    """
+
+    def test_missing_disabled_with_reverse_returns_true(self):
+        """DHCP lease without 'disabled' field should be enabled=True."""
+        result = from_entry_bool({}, "disabled", default=False, reverse=True)
+        assert result is True
+
+    def test_missing_disabled_without_reverse_returns_false(self):
+        result = from_entry_bool({}, "disabled", default=False, reverse=False)
+        assert result is False
+
+    def test_missing_with_reverse_and_default_true(self):
+        result = from_entry_bool({}, "disabled", default=True, reverse=True)
+        assert result is False
+
+    def test_present_disabled_false_with_reverse(self):
+        """When disabled=False present, enabled should be True (reverse)."""
+        result = from_entry_bool(
+            {"disabled": False}, "disabled", default=False, reverse=True
+        )
+        assert result is True
+
+    def test_present_disabled_true_with_reverse(self):
+        """When disabled=True present, enabled should be False (reverse)."""
+        result = from_entry_bool(
+            {"disabled": True}, "disabled", default=False, reverse=True
+        )
+        assert result is False
+
+
+# --- from_entry identity coercion removal ---
+
+
+class TestFromEntryIdentityCoercionRemoved:
+    """Verify that str/int values are not unnecessarily re-wrapped."""
+
+    def test_str_returned_directly(self):
+        result = from_entry({"name": "ether1"}, "name", default="x")
+        assert result == "ether1"
+        assert type(result) is str
+
+    def test_int_returned_directly(self):
+        result = from_entry({"port": 8728}, "port", default=0)
+        assert result == 8728
+        assert type(result) is int
+
+
+# --- _set_data / _get_data helpers ---
+
+
+class TestDataHelpers:
+    def test_set_data_with_uid(self):
+        from custom_components.mikrotik_router.apiparser import _set_data, _get_data
+
+        data = {"u1": {}}
+        _set_data(data, "u1", "name", "ether1")
+        assert data["u1"]["name"] == "ether1"
+        assert _get_data(data, "u1", "name") == "ether1"
+
+    def test_set_data_without_uid(self):
+        from custom_components.mikrotik_router.apiparser import _set_data, _get_data
+
+        data = {}
+        _set_data(data, None, "name", "ether1")
+        assert data["name"] == "ether1"
+        assert _get_data(data, None, "name") == "ether1"
+
+
+# --- _resolve_str_default ---
+
+
+class TestResolveStrDefault:
+    def test_explicit_default(self):
+        from custom_components.mikrotik_router.apiparser import _resolve_str_default
+
+        assert _resolve_str_default({"name": "x", "default": "fallback"}) == "fallback"
+
+    def test_no_default(self):
+        from custom_components.mikrotik_router.apiparser import _resolve_str_default
+
+        assert _resolve_str_default({"name": "x"}) == ""
+
+    def test_default_val_reference(self):
+        from custom_components.mikrotik_router.apiparser import _resolve_str_default
+
+        val = {"name": "name", "default_val": "default-name", "default-name": "ether1"}
+        assert _resolve_str_default(val) == "ether1"
+
+
+# --- _convert_timestamp ---
+
+
+class TestConvertTimestamp:
+    def test_converts_seconds_timestamp(self):
+        from custom_components.mikrotik_router.apiparser import (
+            _convert_timestamp,
+            _get_data,
+        )
+
+        data = {"u1": {"ts": 1700000000}}
+        _convert_timestamp(data, "u1", "ts")
+        result = _get_data(data, "u1", "ts")
+        assert hasattr(result, "tzinfo")
+
+    def test_converts_milliseconds_timestamp(self):
+        from custom_components.mikrotik_router.apiparser import (
+            _convert_timestamp,
+            _get_data,
+        )
+
+        data = {"u1": {"ts": 1700000000000}}
+        _convert_timestamp(data, "u1", "ts")
+        result = _get_data(data, "u1", "ts")
+        assert hasattr(result, "tzinfo")
+
+    def test_skips_non_int(self):
+        from custom_components.mikrotik_router.apiparser import (
+            _convert_timestamp,
+            _get_data,
+        )
+
+        data = {"u1": {"ts": "not-a-number"}}
+        _convert_timestamp(data, "u1", "ts")
+        assert _get_data(data, "u1", "ts") == "not-a-number"
+
+    def test_skips_zero(self):
+        from custom_components.mikrotik_router.apiparser import (
+            _convert_timestamp,
+            _get_data,
+        )
+
+        data = {"u1": {"ts": 0}}
+        _convert_timestamp(data, "u1", "ts")
+        assert _get_data(data, "u1", "ts") == 0
+
+
+# --- get_uid refactored ---
+
+
+class TestGetUidRefactored:
+    def test_primary_key_empty_value_returns_none(self):
+        """Entry with key present but empty value should return None."""
+        assert get_uid({"name": ""}, "name", None, None, None) is None
+
+    def test_secondary_key_used_when_primary_missing(self):
+        result = get_uid({"alt": "eth0"}, "name", "alt", None, None)
+        assert result == "eth0"
+
+    def test_secondary_key_empty_returns_none(self):
+        assert get_uid({"alt": ""}, "name", "alt", None, None) is None
+
+
+# --- _process_val_sub / _apply_combine ---
+
+
+class TestFillValsProcExtracted:
+    def test_combine_keys(self):
+        from custom_components.mikrotik_router.apiparser import _process_val_sub
+
+        val_sub = [
+            {"name": "result"},
+            {"action": "combine"},
+            {"key": "a"},
+            {"text": "-"},
+            {"key": "b"},
+        ]
+        name, value = _process_val_sub(val_sub, {"a": "hello", "b": "world"})
+        assert name == "result"
+        assert value == "hello-world"
+
+    def test_combine_missing_key_uses_unknown(self):
+        from custom_components.mikrotik_router.apiparser import _process_val_sub
+
+        val_sub = [
+            {"name": "result"},
+            {"action": "combine"},
+            {"key": "missing"},
+        ]
+        _name, value = _process_val_sub(val_sub, {})
+        assert value == "unknown"
+
+    def test_no_name_returns_none(self):
+        from custom_components.mikrotik_router.apiparser import _process_val_sub
+
+        val_sub = [{"action": "combine"}, {"key": "a"}]
+        name, _value = _process_val_sub(val_sub, {"a": "x"})
+        assert name is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2862,9 +2862,10 @@ def test_dhcp_server_enriched_defaults():
     assert entry["address-pool"] == "unknown"
     assert entry["comment"] == ""
     assert entry["lease-count"] == 0
-    # When "disabled" is absent, from_entry_bool returns default=False
-    # (reverse is NOT applied to defaults), so enabled=False → status="disabled"
-    assert entry["status"] == "disabled"
+    # When "disabled" is absent, from_entry_bool now correctly applies reverse
+    # to the default (bug fix), so enabled=True → status="enabled"
+    assert entry["enabled"] is True
+    assert entry["status"] == "enabled"
 
 
 def test_dhcp_server_status_enabled():

--- a/tests/test_mikrotikapi.py
+++ b/tests/test_mikrotikapi.py
@@ -41,7 +41,7 @@ class TestInit:
         api = make_api()
         assert api._connected is False
         assert api._reconnected is True
-        assert api.error is None
+        assert api.error == ""
         assert api.connection_error_reported is False
         assert api.disable_health is False
 
@@ -286,10 +286,10 @@ class TestSetValue:
             is False
         )
 
-    def test_entry_not_found_returns_true(self):
+    def test_entry_not_found_returns_false(self):
         api, _ = self._connected_api_with_query([{"name": "other", ".id": "*1"}])
         result = api.set_value("/interface", "name", "nonexistent", "disabled", True)
-        assert result is True
+        assert result is False
 
     def test_lock_released_after_set(self):
         api, mock_resp = self._connected_api_with_query(
@@ -312,7 +312,7 @@ class TestRunScript:
         api._connection_epoch = time()
         assert api.run_script("test_script") is False
 
-    def test_script_not_found_returns_true_no_deadlock(self):
+    def test_script_not_found_returns_false_no_deadlock(self):
         """Regression test: run_script must release lock when script not found."""
         api = make_api()
         api._connected = True
@@ -324,7 +324,7 @@ class TestRunScript:
         mock_response.__bool__ = MagicMock(return_value=True)
         api._connection.path.return_value = mock_response
         result = api.run_script("missing_script")
-        assert result is True
+        assert result is False
         # Critical: lock must be released
         assert api.lock.acquire(timeout=1) is True
         api.lock.release()
@@ -391,3 +391,104 @@ class TestCurrentMilliseconds:
         result = MikrotikAPI._current_milliseconds()
         assert isinstance(result, int)
         assert result > 0
+
+
+# --- _find_entry ---
+
+
+class TestFindEntry:
+    def test_finds_matching_entry(self):
+        response = [
+            {"name": "ether1", ".id": "*1"},
+            {"name": "ether2", ".id": "*2"},
+        ]
+        assert MikrotikAPI._find_entry(response, "name", "ether2") == "*2"
+
+    def test_returns_none_when_not_found(self):
+        response = [{"name": "ether1", ".id": "*1"}]
+        assert MikrotikAPI._find_entry(response, "name", "missing") is None
+
+    def test_returns_none_for_empty_response(self):
+        assert MikrotikAPI._find_entry([], "name", "any") is None
+
+    def test_missing_param_key_skipped(self):
+        response = [{"other": "val", ".id": "*1"}]
+        assert MikrotikAPI._find_entry(response, "name", "val") is None
+
+
+# --- set_value returns False on not-found ---
+
+
+class TestSetValueReturnsFalseOnNotFound:
+    def test_set_value_returns_false_when_entry_not_found(self):
+        api = make_api()
+        api._connected = True
+        api._connection = MagicMock()
+        mock_path = MagicMock()
+        mock_path.__iter__ = MagicMock(
+            return_value=iter([{"name": "other", ".id": "*1"}])
+        )
+        mock_path.__bool__ = MagicMock(return_value=True)
+        api._connection.path.return_value = mock_path
+
+        result = api.set_value("/interface", "name", "nonexistent", "disabled", True)
+        assert result is False
+
+    def test_execute_returns_false_when_entry_not_found(self):
+        api = make_api()
+        api._connected = True
+        api._connection = MagicMock()
+        mock_path = MagicMock()
+        mock_path.__iter__ = MagicMock(
+            return_value=iter([{"name": "other", ".id": "*1"}])
+        )
+        mock_path.__bool__ = MagicMock(return_value=True)
+        api._connection.path.return_value = mock_path
+
+        result = api.execute("/interface", "set", "name", "nonexistent")
+        assert result is False
+
+    def test_run_script_returns_false_when_not_found(self):
+        api = make_api()
+        api._connected = True
+        api._connection = MagicMock()
+        mock_path = MagicMock()
+        mock_path.__iter__ = MagicMock(
+            return_value=iter([{"name": "other_script", ".id": "*1"}])
+        )
+        mock_path.__bool__ = MagicMock(return_value=True)
+        api._connection.path.return_value = mock_path
+
+        result = api.run_script("missing_script")
+        assert result is False
+
+
+# --- _query_list / _query_command extracted ---
+
+
+class TestQueryExtracted:
+    def test_query_returns_list(self):
+        api = make_api()
+        api._connected = True
+        api._connection = MagicMock()
+        mock_path = MagicMock()
+        mock_path.__iter__ = MagicMock(return_value=iter([{"name": "ether1"}]))
+        mock_path.__bool__ = MagicMock(return_value=True)
+        api._connection.path.return_value = mock_path
+
+        result = api.query("/interface")
+        assert result == [{"name": "ether1"}]
+
+    def test_query_command(self):
+        api = make_api()
+        api._connected = True
+        api._connection = MagicMock()
+        mock_path = MagicMock()
+        mock_path.__bool__ = MagicMock(return_value=True)
+        mock_path.return_value = iter([{"status": "running"}])
+        api._connection.path.return_value = mock_path
+
+        result = api.query(
+            "/interface/ethernet", command="monitor", args={".id": "*1", "once": True}
+        )
+        assert result == [{"status": "running"}]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.mikrotik_router.switch import (
     MikrotikSwitch,
@@ -117,25 +118,27 @@ class TestMikrotikSwitch:
         )
 
     @pytest.mark.asyncio
-    async def test_async_turn_on_noop_without_write_access(self):
+    async def test_async_turn_on_raises_without_write_access(self):
         coord = make_mock_coordinator()
         coord.data["access"] = ["policy", "reboot"]  # no "write"
         coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": True}}
         entity = _make_switch(
             coordinator=coord, desc_overrides={**_SWITCH_DESC}, uid="ether1"
         )
-        await entity.async_turn_on()
+        with pytest.raises(HomeAssistantError, match="Write access required"):
+            await entity.async_turn_on()
         coord.set_value.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_async_turn_off_noop_without_write_access(self):
+    async def test_async_turn_off_raises_without_write_access(self):
         coord = make_mock_coordinator()
         coord.data["access"] = ["policy"]
         coord.data["interface"] = {"ether1": {"name": "ether1", "enabled": True}}
         entity = _make_switch(
             coordinator=coord, desc_overrides={**_SWITCH_DESC}, uid="ether1"
         )
-        await entity.async_turn_off()
+        with pytest.raises(HomeAssistantError, match="Write access required"):
+            await entity.async_turn_off()
         coord.set_value.assert_not_called()
 
 
@@ -479,7 +482,8 @@ class TestMikrotikRawSwitch:
             desc_overrides={**_RAW_DESC},
             uid="rule1",
         )
-        await entity.async_turn_on()
+        with pytest.raises(HomeAssistantError, match="Write access required"):
+            await entity.async_turn_on()
         coord.set_value.assert_not_called()
 
 
@@ -559,7 +563,8 @@ class TestMikrotikContainerSwitch:
             desc_overrides={**_CONTAINER_DESC},
             uid="*1",
         )
-        await entity.async_turn_on()
+        with pytest.raises(HomeAssistantError, match="Write access required"):
+            await entity.async_turn_on()
         coord.execute.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Bug fix:** `from_entry_bool` reverse quirk — when `disabled` field absent from API, reverse is now applied to default (fixes DHCP leases/servers incorrectly showing disabled)
- **Bug fix:** `set_value`/`execute`/`run_script` now return `False` when entry not found (was returning `True`)
- **Bug fix:** Filter/Raw rules had `default: True` + `reverse: True` relying on buggy behavior — corrected to `default: False`
- **Silent failures:** Switch write-access check raises `HomeAssistantError` instead of silent return
- **Silent failures:** NAT/Mangle/Filter/Raw/Queue log error when rule not found (value=None)
- **Silent failures:** Entity `_handle_coordinator_update` guards KeyError with debug logging
- **Silent failures:** Queue parsing catches ValueError/IndexError per entry with exception details
- **Silent failures:** FW version parsing narrowed to (ValueError, IndexError) with exception in log
- **Complexity:** apiparser.py — extracted 8 helpers, all 5 functions now ≤15 (was 52, 47, 30, 27, 17)
- **Complexity:** coordinator.py — extracted 15+ helpers for 6 functions (was 27, 26, 25, 22, 18, 16)
- **Complexity:** mikrotikapi.py — extracted `_query_list`, `_query_command`, `_find_entry` (was 18)
- **Complexity:** `__init__.py` — extracted `_collect_ids_for_desc` (was 16)
- **Modernisation:** mikrotikapi.py — type hints on all public methods, `_ensure_ssl_wrapper`, removed banner comments
- **Code smells:** Extracted 5 icon constants, CAPsMAN constant, rule-not-found constants (S1192)
- **Code smells:** Fixed f-string logging (S3457), set comprehension (S7494), unused params (S1172)
- **Tests:** 41 new tests covering all extracted helpers and bug fix regressions (525 total, 0 fail)

Resolves all 29 SonarCloud code smells from v2.3.13 master analysis.
Closes ISS-260321-cognitive-complexity, ISS-260321-silent-failures.

## Test Plan
- [ ] `ruff check . && ruff format --check .` — 0 errors
- [ ] `pytest tests/ -v` — 525 passed, 5 skipped
- [ ] Verify DHCP leases show `enabled=True` when `disabled` field absent (from_entry_bool fix)
- [ ] Verify switch toggle without write access shows error in UI (HomeAssistantError)
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)