### PR TITLE
fix: pin librouteros<4.0 to restore connection (v2.3.14 hotfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
-## What's New — v2.3.13
+## What's New — v2.3.14
+
+**librouteros 4.x hotfix** — Pin `librouteros<4.0` in `manifest.json`. Version 4.0.1 of librouteros renamed `connect()`'s `login_methods` kwarg to `login_method`, breaking every install that auto-upgraded. Addresses [#55](https://github.com/jnctech/homeassistant-mikrotik_router/issues/55) and [#56](https://github.com/jnctech/homeassistant-mikrotik_router/issues/56). Proper 4.x migration will ship in a future release.
+
+## v2.3.13
 
 **Wireless client detection fix** — Wireless clients on routers with empty WiFi registration tables (e.g. hAP ac2 with the new WiFi package) are now correctly detected via bridge host table lookup. The `clients_wireless` and `clients_wired` counters are accurate for these devices.
 

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -10,8 +10,8 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/jnctech/homeassistant-mikrotik_router/issues",
     "requirements": [
-        "librouteros>=3.4.1",
+        "librouteros>=3.4.1,<4.0",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.13"
+    "version": "2.3.14"
 }

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,37 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260417-hotfix-librouteros-4x-pin — v2.3.14 hotfix: pin librouteros<4.0
+
+**Date:** 2026-04-17
+**Branch:** `fix/librouteros-4x-pin`
+**Status:** In Review (targeting master)
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `manifest.json` | Pin `librouteros>=3.4.1,<4.0`; bump version to 2.3.14 |
+| `README.md` | Add v2.3.14 section explaining the pin |
+| `info.md` | Add v2.3.14 entry |
+| `docs/ISSUES.md` | Add ISS-260417-librouteros-4x-break |
+
+### Why
+
+librouteros 4.0.1 (released before 2026-04-10) renamed the `connect()` kwarg `login_methods` → `login_method`. Every new or upgrading install of v2.3.13 pulls 4.0.1 (no upper bound in manifest) and fails on first connection attempt with `connect() got an unexpected keyword argument 'login_methods'`. Reported in #55 (2026-04-10) and #56 (2026-04-13).
+
+The pin is a minimum-risk stopgap: it restores the prior working state for all users by blocking 4.x until proper migration lands. No code changes in the integration itself, so behaviour is identical to v2.3.13 for users already on librouteros 3.x.
+
+### Follow-up
+
+Open a new ISS to migrate to librouteros 4.x: rename `login_methods` → `login_method` in `mikrotikapi.py:102`, audit other 4.0.1 breaking changes, then drop the upper pin.
+
+### Quality Gate Results
+
+Docs/config-only change; no code touched. No tests added.
+
+---
+
 ## CR-260327-phase5-tests — Phase 5 integration tests and coverage gap closure
 
 **Date:** 2026-03-27

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -2,13 +2,40 @@
 
 ## Current Priorities
 
-1. ISS-260320-new-device-discovery — New devices require HA restart to appear
-2. ISS-260320-refactor-dedup — Refactor duplicated patterns
-3. ISS-260326-tracker-wireless-detection — Device tracker uses old wireless detection logic
+1. ISS-260417-librouteros-4x-break — librouteros 4.0.1 breaks `connect()` kwarg; all users affected (hotfix v2.3.14 pins `<4.0`)
+2. ISS-260320-new-device-discovery — New devices require HA restart to appear
+3. ISS-260320-refactor-dedup — Refactor duplicated patterns
+4. ISS-260326-tracker-wireless-detection — Device tracker uses old wireless detection logic
 
 ---
 
 ## Active
+
+### ISS-260417-librouteros-4x-break — librouteros 4.0.1 breaks connection for all users
+**Type:** Bug
+**Priority:** Critical
+**Created:** 2026-04-17
+**Status:** 🟡 In Progress — hotfix branch `fix/librouteros-4x-pin` (v2.3.14) pins `librouteros<4.0`. Proper 4.x migration tracked separately.
+
+**Symptom:**
+Users on v2.3.13 (or any prior release) see: `connect() got an unexpected keyword argument 'login_methods'. Did you mean 'login_method'?`
+
+**Root cause:**
+librouteros 4.0.1 renamed the `connect()` keyword argument `login_methods` → `login_method`. `manifest.json` declared `librouteros>=3.4.1` with no upper bound, so HACS auto-installed 4.0.1 on upgrade. `mikrotikapi.py:102` still passes the old name.
+
+**Related GitHub issues:**
+- #55 (reported 2026-04-10) — direct stack trace
+- #56 (reported 2026-04-13) — same symptom post-HA-2026.4.2 update; references upstream #477
+
+**Hotfix (v2.3.14):**
+- `manifest.json`: pin `librouteros>=3.4.1,<4.0`
+
+**Follow-up (new ISS to be created for future release):**
+- Rename kwarg in `mikrotikapi.py` to `login_method`
+- Audit remaining librouteros 4.0.1 breaking changes
+- Bump floor to `>=4.0`, drop upper bound
+
+---
 
 ### ISS-260320-new-device-discovery — New devices require HA restart to appear
 **Type:** Feature

--- a/info.md
+++ b/info.md
@@ -10,7 +10,10 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
-### What's new in v2.3.13
+### What's new in v2.3.14
+- **Hotfix** — Pin `librouteros<4.0` to prevent integration failure after librouteros 4.0.1 release (`connect()` kwarg rename). Addresses #55 and #56.
+
+### v2.3.13
 - **Wireless client detection fix** — Clients on routers with empty WiFi registration tables (e.g. hAP ac2) now correctly detected as wireless via bridge host table lookup
 - **DHCP server sensors** — New status and lease count sensors per DHCP server instance
 - **Documentation** — Comprehensive data store schema, sensor gap analysis, and community feature poll


### PR DESCRIPTION
## Summary
- **Hotfix for broken integration on all current installs.** librouteros 4.0.1 renamed the `connect()` kwarg `login_methods` → `login_method`; `manifest.json` had no upper bound, so HACS auto-installed 4.0.1 and every connection attempt fails with `connect() got an unexpected keyword argument 'login_methods'`.
- One-line fix: pin `librouteros>=3.4.1,<4.0` in `manifest.json`. Version bumped to 2.3.14. No code changes.
- Fixes #55, #56.

## Rationale
Minimum-risk stopgap to restore all users immediately. Pinning to a known-working 3.x release avoids touching any integration code, so behaviour is identical to v2.3.13 for users already on librouteros 3.x and auto-downgrades users who were bitten by 4.0.1 on next restart.

Proper 4.x migration (rename kwarg, audit rest of 4.0.1 breaking changes, drop upper pin) is tracked as a follow-up in `docs/ISSUES.md` under `ISS-260417-librouteros-4x-break`.

## Live Test (on my HA install, which was also affected)
- Before deploy: 4 routers all disconnected, logs full of `login_methods` errors
- After scp + `ha core restart`:
  - 447 mikrotik entities updating within 5 min (all 4 routers: hAP ac2, hAP ax3, RB4011, CRS310)
  - 0 `login_methods` errors in logs
  - Residual unavailable/unknown entities are pre-existing quirks, not regression

## Test Plan
- [x] Manifest pins `librouteros<4.0`, version bumped to 2.3.14
- [x] README.md and info.md v2.3.14 sections reference the fix and link to #55/#56
- [x] ISS-260417-librouteros-4x-break added to `docs/ISSUES.md` as Active/Critical with follow-up plan
- [x] CR-260417-hotfix-librouteros-4x-pin added to `docs/CHANGE-REGISTER.md`
- [x] Deployed to live HA, integration reconnected, 447 entities active, zero connection errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)