### PR TITLE
fix(ci): install runtime deps from manifest + drift and zip-structure guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        # Install runtime deps from manifest.json so CI tests the same
+        # version constraints HA installs. Test deps stay separate.
         run: |
+          python -c "import json; print('\n'.join(json.load(open('custom_components/mikrotik_router/manifest.json'))['requirements']))" > /tmp/runtime-requirements.txt
+          cat /tmp/runtime-requirements.txt
+          pip install -r /tmp/runtime-requirements.txt
           pip install pytest pytest-homeassistant-custom-component pytest-cov
-          pip install mac-vendor-lookup librouteros
 
       - name: Test with pytest
         run: >
@@ -113,6 +117,78 @@ jobs:
           " > /tmp/runtime-requirements.txt
           cat /tmp/runtime-requirements.txt
           pip-audit -r /tmp/runtime-requirements.txt
+
+  manifest-drift:
+    name: Manifest <-> requirements drift guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.13"
+
+      - name: Assert manifest runtime deps match requirements*.txt
+        # Prevents the failure mode where CI silently tests a different
+        # librouteros version than HA installs.
+        run: |
+          python <<'PY'
+          import json, pathlib, re, sys
+
+          def key(spec):
+              return re.split(r"[<>=!~ ]", spec, maxsplit=1)[0].strip().lower()
+
+          manifest = sorted(
+              json.load(open("custom_components/mikrotik_router/manifest.json"))["requirements"],
+              key=key,
+          )
+          manifest_keys = {key(s) for s in manifest}
+
+          failed = False
+          for f in ("requirements.txt", "requirements_dev.txt", "requirements_tests.txt"):
+              lines = [
+                  ln.strip()
+                  for ln in pathlib.Path(f).read_text().splitlines()
+                  if ln.strip() and not ln.lstrip().startswith("#")
+              ]
+              runtime = sorted((ln for ln in lines if key(ln) in manifest_keys), key=key)
+              if runtime != manifest:
+                  print(f"::error file={f}::drift vs manifest.json")
+                  print(f"  manifest: {manifest}")
+                  print(f"  {f}:     {runtime}")
+                  failed = True
+
+          sys.exit(1 if failed else 0)
+          PY
+
+  zip-structure:
+    name: HACS zip structure check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Build release zip (mirrors release.yml)
+        run: cd custom_components/mikrotik_router && zip -r ../../mikrotik_router-check.zip ./
+
+      - name: Assert manifest.json is at zip root
+        # HACS requires a flat root layout. A nested
+        # mikrotik_router/manifest.json shape installs to the wrong path.
+        run: |
+          unzip -l mikrotik_router-check.zip | head -30
+          if ! unzip -p mikrotik_router-check.zip manifest.json > /dev/null 2>&1; then
+            echo "::error::manifest.json is not at zip root"
+            exit 1
+          fi
+          if unzip -l mikrotik_router-check.zip | grep -E "mikrotik_router/manifest.json"; then
+            echo "::error::zip is nested under mikrotik_router/"
+            exit 1
+          fi
+          echo "OK: manifest.json at zip root"
 
   lint-actions:
     name: GitHub Actions lint (actionlint)

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,46 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260512-ci-manifest-drift-guard — CI installs runtime deps from manifest; add drift + zip-structure guards
+
+**Date:** 2026-05-12
+**Branch:** `fix/ci-manifest-drift-guard`
+**Status:** In Review (targeting `dev`)
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `.github/workflows/ci.yml` (tests job) | Replace bare `pip install mac-vendor-lookup librouteros` with `pip install -r /tmp/runtime-requirements.txt` generated from `manifest.json`. CI now installs exactly what HA installs. |
+| `.github/workflows/ci.yml` | New job `manifest-drift` asserts runtime entries in `requirements.txt`, `requirements_dev.txt`, and `requirements_tests.txt` match `manifest.json` exactly. Fails the PR if they diverge. |
+| `.github/workflows/ci.yml` | New job `zip-structure` builds the release zip with the same `cd custom_components/mikrotik_router && zip -r ../../...` command used by `release.yml`, then asserts `manifest.json` is at the zip root (no nested `mikrotik_router/` directory). |
+| `requirements.txt`, `requirements_dev.txt`, `requirements_tests.txt` | Pin `librouteros>=3.4.1,<4.0` to match the manifest cap introduced in v2.3.14. |
+
+### Why
+
+External audit (Codex, 2026-05-12) found that CI was installing `librouteros` unpinned, resolving to `4.0.1`, while `manifest.json` correctly pinned `<4.0` since the v2.3.14 hotfix. The shipped-vs-tested dependency boundary diverged: the integration was shipping on `<4.0` but every CI run since the hotfix had been testing against 4.x. The hotfix itself was effectively shipped untested against the version it was hotfixing.
+
+The drift guard ensures this class of failure cannot silently regress: any change to `manifest.json` requirements without a matching update to all three `requirements*.txt` files now fails CI. The zip-structure guard closes a separate latent risk: HACS root-flat packaging bugs are easy to reintroduce, and `release.yml` had no artefact-shape verification.
+
+### Why this surfaced now
+
+The `<4.0` cap was added in commit b6ad8e0 (v2.3.14, 4 weeks ago) to work around the librouteros 4.0.0/4.0.1 `connect()` kwarg break. The three `requirements*.txt` files were not updated at the same time, and `ci.yml` was using bare unpinned installs predating the cap. The audit identified the inconsistency by reading all four files together.
+
+### Test Plan
+
+- [ ] CI `tests` job log shows `librouteros>=3.4.1,<4.0` in `cat /tmp/runtime-requirements.txt`
+- [ ] `manifest-drift` job passes on this PR
+- [ ] `zip-structure` job lists `manifest.json` near the top of the zip and reports `OK`
+- [ ] Full pytest suite still passes on Python 3.13 and 3.14
+
+### Follow-up (not in this PR)
+
+- ADR documenting the librouteros API concurrency model — see `ISS-260512-librouteros-concurrency-adr`
+- Explicit librouteros version test matrix (`3.4.1`, latest `3.x`, expected-fail `4.x`) before relaxing the `<4.0` cap — see `ENH-260512-librouteros-test-matrix`
+- Cleanup PR: delete `Pipfile`, strip flake8/pylint from `setup.cfg`, move ruff config to `pyproject.toml`
+
+---
+
 ## CR-260509-fix-api-concurrency-lock — v2.3.16: hold API lock around set_value/execute response iteration
 
 **Date:** 2026-05-09

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -2,7 +2,8 @@
 
 ## Current Priorities
 
-1. ISS-260509-mikrotikapi-concurrency — `set_value`/`execute` iterate the librouteros response outside the API lock; fixed in v2.3.16 (#64)
+1. ISS-260512-ci-manifest-drift — CI installs `librouteros` unpinned and resolves to 4.0.1, while `manifest.json` pins `<4.0`; v2.3.14 hotfix was effectively untested against the version it shipped to (external audit 2026-05-12). **Fix in `fix/ci-manifest-drift-guard`.**
+2. ISS-260509-mikrotikapi-concurrency — `set_value`/`execute` iterate the librouteros response outside the API lock; fixed in v2.3.16 (#64)
 2. ISS-260509-ha-2026.5-untested — HA 2026.5.0 not yet validated against the integration; testing planned
 3. ISS-260417-librouteros-4x-break — librouteros 4.0.1 breaks `connect()` kwarg; hotfix v2.3.14 pinned `<4.0` (proper 4.x migration tracked separately)
 4. ISS-260320-new-device-discovery — New devices require HA restart (UID tracking in place, dispatcher needs entity guard hardening)
@@ -10,6 +11,32 @@
 ---
 
 ## Active
+
+### ISS-260512-ci-manifest-drift — CI tested against the wrong librouteros version
+**Type:** Bug (process / supply chain)
+**Priority:** High
+**Created:** 2026-05-12
+**Status:** 🟡 In Progress — fix in `fix/ci-manifest-drift-guard`
+
+**Symptom:**
+External audit found that `.github/workflows/ci.yml` was installing `librouteros` unpinned (`pip install mac-vendor-lookup librouteros`), so CI resolved to whatever PyPI returned — currently `librouteros 4.0.1`. `manifest.json` pins `librouteros>=3.4.1,<4.0` (added in commit b6ad8e0 / v2.3.14 to work around the 4.x `connect()` break). HA therefore installs `<4.0` while every CI run since the hotfix tested against 4.x. The v2.3.14 hotfix was effectively shipped untested against the version it was hotfixing.
+
+**Contributing factors:**
+- `requirements.txt`, `requirements_dev.txt`, `requirements_tests.txt` all left `librouteros>=3.4.1` without an upper bound — even if CI installed from one of them, it would still resolve to 4.x.
+- No CI guard asserts manifest ↔ requirements consistency, so the drift was invisible.
+- `release.yml` builds the zip but no CI job verifies the artefact's HACS root-flat layout — an adjacent latent risk.
+
+**Fix:**
+1. Pin `librouteros>=3.4.1,<4.0` in all three `requirements*.txt`.
+2. CI `tests` job installs from `manifest.json` (the same pattern already proven in the `dependency-audit` job at lines 106–115).
+3. New `manifest-drift` job fails the PR if any `requirements*.txt` diverges from `manifest.json`.
+4. New `zip-structure` job builds the release zip the same way `release.yml` does and asserts `manifest.json` is at the zip root.
+
+**Follow-up (separate work):**
+- `ISS-260512-librouteros-concurrency-adr` — document the API concurrency model (client ownership, lock scope, timeouts, mid-response failure mode).
+- `ENH-260512-librouteros-test-matrix` — explicit version matrix (`3.4.1`, latest `3.x`, expected-fail `4.x`) before relaxing the `<4.0` cap.
+
+---
 
 ### ISS-260509-mikrotikapi-concurrency — set_value/execute corrupt socket under rapid use
 **Type:** Bug

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-librouteros>=3.4.1
+librouteros>=3.4.1,<4.0
 mac-vendor-lookup>=0.1.12

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ pytest-homeassistant-custom-component
 pytest-cov
 
 # Runtime deps (must match manifest.json)
-librouteros>=3.4.1
+librouteros>=3.4.1,<4.0
 mac-vendor-lookup>=0.1.12
 
 # Linting & formatting

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -4,5 +4,5 @@ pytest-homeassistant-custom-component
 pytest-cov
 
 # Runtime deps (must match manifest.json)
-librouteros>=3.4.1
+librouteros>=3.4.1,<4.0
 mac-vendor-lookup>=0.1.12

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -73,9 +73,19 @@ async def test_flow_user_init(hass):
 
 async def test_flow_user_creates_entry(hass):
     """Test a successful user config flow creates an entry."""
-    with patch(
-        "custom_components.mikrotik_router.config_flow.MikrotikAPI",
-        return_value=_mock_api(connect_return=True),
+    # Patch both import sites: config_flow uses MikrotikAPI for the credential
+    # check, and coordinator instantiates it during async_setup_entry that HA
+    # runs after CREATE_ENTRY. Without the coordinator patch the real
+    # librouteros.connect() reaches the socket layer (HASocketBlockedError).
+    with (
+        patch(
+            "custom_components.mikrotik_router.config_flow.MikrotikAPI",
+            return_value=_mock_api(connect_return=True),
+        ),
+        patch(
+            "custom_components.mikrotik_router.coordinator.MikrotikAPI",
+            return_value=_mock_api(connect_return=True),
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": "user"}, data=MOCK_USER_INPUT
@@ -152,9 +162,15 @@ async def test_flow_user_duplicate_name(hass):
 
 async def test_flow_import(hass):
     """Test the import step delegates to user step."""
-    with patch(
-        "custom_components.mikrotik_router.config_flow.MikrotikAPI",
-        return_value=_mock_api(connect_return=True),
+    with (
+        patch(
+            "custom_components.mikrotik_router.config_flow.MikrotikAPI",
+            return_value=_mock_api(connect_return=True),
+        ),
+        patch(
+            "custom_components.mikrotik_router.coordinator.MikrotikAPI",
+            return_value=_mock_api(connect_return=True),
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": "import"}, data=MOCK_USER_INPUT


### PR DESCRIPTION
## Summary

- **P0 fix:** CI was installing `librouteros` unpinned, resolving to `4.0.1`, while `manifest.json` pins `<4.0` (since v2.3.14). The shipped-vs-tested dependency boundary diverged — every CI run since the v2.3.14 hotfix was testing against the version the hotfix was meant to work around.
- Pin `librouteros>=3.4.1,<4.0` in all three `requirements*.txt` to match `manifest.json`.
- Switch the `tests` job to install runtime deps from `manifest.json` (the same pattern already proven in the `dependency-audit` job).
- Add `manifest-drift` CI job — fails the PR if `requirements*.txt` runtime entries diverge from `manifest.json`. This cannot silently regress again.
- Add `zip-structure` CI job — builds the release zip with the same command `release.yml` uses and asserts `manifest.json` is at the zip root (HACS root-flat layout).

## Why

External audit (Codex, 2026-05-12) caught the drift: `manifest.json` correctly pinned `<4.0` since commit b6ad8e0 (v2.3.14), but `requirements*.txt` and `ci.yml` were never updated to match. Audit narrative: *found a real P0 supply/test drift, corrected the shipped-vs-tested dependency boundary, and added checks so it cannot silently regress.*

The `zip-structure` job is a bonus pickup — `release.yml` had no artefact-shape verification, and HACS root-flat packaging bugs are a known historical failure mode in this repo.

## Post-Deploy Actions

None. This is CI-only; no runtime behaviour changes.

## Test Plan

- [ ] `tests` job log shows `librouteros>=3.4.1,<4.0` in the `cat /tmp/runtime-requirements.txt` step
- [ ] `manifest-drift` job passes on this PR
- [ ] `zip-structure` job lists `manifest.json` near the top of the zip and prints `OK: manifest.json at zip root`
- [ ] Full pytest suite still passes on Python 3.13 and 3.14
- [ ] Locally verified: dropping `,<4.0` from `requirements.txt` would make `manifest-drift` fail

## Follow-up (separate PRs)

- ADR documenting the librouteros API concurrency model (client ownership, lock scope, timeouts, failure mode when librouteros raises mid-response) — `ISS-260512-librouteros-concurrency-adr`
- Explicit librouteros version test matrix (`3.4.1`, latest `3.x`, expected-fail `4.x`) before relaxing the `<4.0` cap — `ENH-260512-librouteros-test-matrix`
- Cleanup PR: delete `Pipfile`, strip flake8/pylint from `setup.cfg`, move ruff config to `pyproject.toml`

Refs: `ISS-260512-ci-manifest-drift`, `CR-260512-ci-manifest-drift-guard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)