### PR TITLE
docs: tracking-visibility rule + backfill 2 librouteros follow-ups (ISS-260526)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,9 @@ See [Quality Gates](docs/quality-gates.md) for full checklist. Key additions vs 
 - **Branches:** `master` (main), `dev`, `feature/<desc>`, `fix/<desc>`
 - **Commits:** Conventional (`fix:`, `feat:`, `docs:`, `refactor:`, `chore:`)
 - **PR target:** jnctech fork, never upstream unless explicitly told
+
+## Tracking visibility (public vs private)
+
+This is a **public** fork — `docs/ISSUES.md`, `docs/CHANGE-REGISTER.md`, `docs/FEATURE-POLL.md`, `docs/architecture.md`, and `docs/decisions/ADR-*` are visible to every user. Keep them **integration-facing**: bugs, enhancements, ADRs, and changes about the code/behaviour, with no homelab specifics.
+
+Anything sensitive or internal goes in **`docs/internal/`** (gitignored — see `.gitignore`): tokens, MACs, internal hostnames, router captures/debug dumps, and pure session/process meta. When filing, ask: *is this about the integration's code (public), or does it carry homelab specifics / session meta (→ `docs/internal/`)?*

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,25 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260530-tracking-visibility-and-handoff-backfill — document public/private tracking + promote 2 librouteros follow-ups
+
+**Date:** 2026-05-30
+**Branch:** `docs/iss-260526-mikrotik-backfill`
+**Status:** Docs only — no integration code or behaviour change.
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `CLAUDE.md` | New **Tracking visibility (public vs private)** section: integration-facing trackers (`docs/ISSUES.md`, `CHANGE-REGISTER.md`, `FEATURE-POLL.md`, `architecture.md`, `decisions/ADR-*`) are public; sensitive/internal (tokens, MACs, hostnames, captures, session meta) goes in gitignored `docs/internal/`. |
+| `docs/ISSUES.md` | Promoted two follow-ups of `ISS-260512-ci-manifest-drift` from body bullets to their own entries: `ISS-260512-librouteros-concurrency-adr` (Active, High) and `ENH-260512-librouteros-test-matrix` (Backlog, Medium). |
+
+### Why
+
+Part of the cross-repo handoff-gap backfill (config `ISS-260526`) — a one-time sweep promoting un-filed commitments referenced in session handoffs into their owning repo's tracker. The two librouteros follow-ups were named in the 2026-05-12 handoff and listed as bullets under the (now-closed) ci-manifest-drift entry, but never filed as their own trackable entries, so they were invisible to the tracker. Both verified still-live: no concurrency ADR exists (ADR-005 is a narrower lock-context-manager refactor, not the client-ownership/lock-scope/timeout/failure-mode model), and CI has no librouteros version matrix. The CLAUDE.md rule was added because this is a public fork — the public/private split already existed in `.gitignore` but was undocumented.
+
+---
+
 ## CR-260525-issue-68-capsman-detection — CAPsMAN disabled for 7.13+ routers on the legacy `wireless` package
 
 **Date:** 2026-05-25

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -172,9 +172,30 @@ External audit found that `.github/workflows/ci.yml` was installing `librouteros
 3. New `manifest-drift` job fails the PR if any `requirements*.txt` diverges from `manifest.json`.
 4. New `zip-structure` job builds the release zip the same way `release.yml` does and asserts `manifest.json` is at the zip root.
 
-**Follow-up (separate work):**
-- `ISS-260512-librouteros-concurrency-adr` — document the API concurrency model (client ownership, lock scope, timeouts, mid-response failure mode).
-- `ENH-260512-librouteros-test-matrix` — explicit version matrix (`3.4.1`, latest `3.x`, expected-fail `4.x`) before relaxing the `<4.0` cap.
+**Follow-up (separate work):** now tracked as their own entries —
+- `ISS-260512-librouteros-concurrency-adr` (Active, below)
+- `ENH-260512-librouteros-test-matrix` (Backlog)
+
+---
+
+### ISS-260512-librouteros-concurrency-adr — document the API concurrency model
+**Type:** Documentation (ADR)
+**Priority:** High
+**Created:** 2026-05-12
+**Status:** 🔴 Open
+**Promoted:** 2026-05-30 — was a follow-up bullet under `ISS-260512-ci-manifest-drift`; filed as its own entry (handoff-gap backfill, config `ISS-260526`).
+
+**Description:**
+Write an ADR (model on `docs/decisions/`, ADR-007 shape) documenting the librouteros/API concurrency model that the v2.3.14/15/16 fix sequence exposed as fragile:
+1. **Client ownership** — main and tracker coordinators each own a separate `MikrotikAPI` instance (`coordinator.py:146` and `:297`).
+2. **Lock scope** — `threading.Lock` in `mikrotikapi.py`, held around all API path operations including the response iteration (post-v2.3.16), shared by service calls / switches / buttons / main poll on the main client.
+3. **Timeouts** — current constructor values in `mikrotikapi.py`.
+4. **Latency under load** — 10× interfaces, large DHCP lease tables, bridge hosts, wireless registrations.
+5. **Failure mode** — when librouteros raises mid-response (the v2.3.14/15/16 history is the case study).
+
+Land as a doc-only PR to `dev`; add a `CR-260512-…-concurrency-adr` entry and resolve to Done on merge.
+
+**Related:** `ISS-260512-ci-manifest-drift` (parent), `ISS-260509-mikrotikapi-concurrency` (the lock fix this documents), `ADR-005-lock-context-managers`.
 
 ---
 
@@ -319,6 +340,20 @@ On routers with empty registration tables (hAP ac2 with new WiFi package), wirel
 **Fix:**
 - Add `is_wireless` bool field to host data in coordinator (set by `_is_wireless_host`)
 - Update device_tracker.py to check `self._data.get("is_wireless")` instead of source
+
+---
+
+### ENH-260512-librouteros-test-matrix — explicit librouteros version test matrix
+**Type:** Enhancement (CI)
+**Priority:** Medium
+**Created:** 2026-05-12
+**Status:** 🔴 Open
+**Promoted:** 2026-05-30 — was a follow-up bullet under `ISS-260512-ci-manifest-drift`; filed as its own entry (handoff-gap backfill, config `ISS-260526`).
+
+**Need:**
+Explicit CI jobs covering librouteros `3.4.1`, latest `3.x`, and expected-fail `4.x`. Needed before the `manifest.json` `<4.0` cap can be relaxed — the cap exists because 4.0.1 broke `connect()`. The matrix turns the compatibility boundary into an asserted CI fact rather than a manual pin watched by hand.
+
+**Related:** `ISS-260512-ci-manifest-drift` (parent), `ISS-260417-librouteros-4x-break` (the 4.x break the cap guards).
 
 ---
 


### PR DESCRIPTION
## Summary

The **HACS bucket** of the cross-repo handoff-gap backfill (config `ISS-260526`) for this fork, plus a documentation fix it surfaced. Docs only — no integration code or behaviour change.

### 1. Document the public/private tracking split (`CLAUDE.md`)
This is a **public** fork, but the rule for *what* gets tracked publicly vs git-ignored was only implicit in `.gitignore`. Added a **Tracking visibility** section making it explicit:
- **Public** (integration-facing): `docs/ISSUES.md`, `docs/CHANGE-REGISTER.md`, `docs/FEATURE-POLL.md`, `docs/architecture.md`, `docs/decisions/ADR-*`.
- **Git-ignored** (`docs/internal/*`): tokens, MACs, internal hostnames, router captures/debug dumps, pure session/process meta.

### 2. Promote 2 un-filed librouteros follow-ups (`docs/ISSUES.md`)
Both were referenced in the 2026-05-12 handoff and listed as bullets under the now-closed `ISS-260512-ci-manifest-drift`, but never filed as their own trackable entries (so they were invisible to the tracker). Both verified **still live**:
- **`ISS-260512-librouteros-concurrency-adr`** (Active, High) — no concurrency ADR exists (`ADR-005` is a narrower lock-context-manager refactor, not the client-ownership/lock-scope/timeout/failure-mode model the handoff specced).
- **`ENH-260512-librouteros-test-matrix`** (Backlog, Med) — CI has no `3.4.1` / `3.x` / expected-fail `4.x` matrix.

### 3. `CR-260530` change-register entry

## Notes
- Integration-facing engineering items, no homelab specifics → public per the rule above.
- Two IDs still show on a fresh `--slug Mikrotik` sweep and are **not** leaks: `ENH-260509-poe-energy-sensors` (filed on the separate `docs/enh-260509-poe-energy` branch, resolves on its own merge) and `ISS-260523-issue-68` (slug-abbrev of the filed `ISS-260523-issue-68-capsman-interface`).

## Post-Deploy Actions
None.

## Test Plan
- [ ] `docs/ISSUES.md` renders — both new entries well-formed under Active / Backlog
- [ ] `CLAUDE.md` Tracking-visibility section reads correctly
- [ ] No code/CI files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)