### PR TITLE
fix(ci): bump dessant/lock-threads v5.0.1 -> v6.0.2 (github-token length error)

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771  # v5.0.1
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c  # v6.0.2
         with:
           github-token: ${{ github.token }}
           exclude-any-issue-labels: "planned, help-wanted, security"


### PR DESCRIPTION
## Summary

The scheduled **Lock** workflow has been failing ([run 26702116266](https://github.com/jnctech/homeassistant-mikrotik_router/actions/runs/26702116266)):

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

`.github/workflows/lock.yml` passes the default `${{ github.token }}` — not a misconfigured secret. GitHub recently lengthened the auto `GITHUB_TOKEN` past 100 chars, and the pinned `dessant/lock-threads@v5.0.1` (2023) validates `github-token` at `maxLength: 100`, so it now rejects the token before running. Upstream fixed this in **v6.0.1 (2026-05-21)** / **v6.0.2 (2026-05-23)** — the timing matches when our scheduled run started failing.

## Change
- Bump `dessant/lock-threads` `@…v5.0.1` → `@89ae32b08ed1a541efecbab17912962a5e38981c  # v6.0.2` (SHA-pinned, per repo convention).
- All inputs this workflow uses (`github-token`, `exclude-any-{issue,pr}-labels`, `{issue,pr}-inactive-days`, `{issue,pr}-lock-reason`) are unchanged in v6 — verified against v6.0.2 `action.yml`.

Targets `master` because scheduled workflows run from the default branch; `dev` will pick it up on the next sync (flag if you'd like a parallel dev bump to avoid drift).

## Test plan
- [ ] After merge, trigger via **workflow_dispatch** (the `Lock` workflow has `workflow_dispatch:`) and confirm a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)