### PR TITLE
fix(ci): bump dessant/lock-threads v5.0.1 -> v6.0.2 (dev parity)

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771  # v5.0.1
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c  # v6.0.2
         with:
           github-token: ${{ github.token }}
           exclude-any-issue-labels: "planned, help-wanted, security"


### PR DESCRIPTION
## Summary

Mirrors the `master` fix ([#79](https://github.com/jnctech/homeassistant-mikrotik_router/pull/79), merged + verified green) onto `dev`, so a future `dev → master` merge can't reintroduce the old `v5.0.1` pin.

`dessant/lock-threads@v5.0.1` caps `github-token` at `maxLength: 100`, which GitHub's now-longer auto `GITHUB_TOKEN` exceeds — failing the scheduled **Lock** workflow. v6.0.2 lifts the limit; inputs used here are unchanged across v5→v6.

- Bump `@…v5.0.1` → `@89ae32b08ed1a541efecbab17912962a5e38981c  # v6.0.2` (SHA-pinned).

## Test plan
- [ ] Same one-line change already verified green on `master` via `workflow_dispatch` ([run 26710941921](https://github.com/jnctech/homeassistant-mikrotik_router/actions/runs/26710941921)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)