### PR TITLE
fix: parse major_fw_version from /system/resource so capability detection works for read-only users

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1664,6 +1664,53 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         if "uptime_epoch" in self.ds["resource"]:
             self.rebootcheck = self.ds["resource"]["uptime_epoch"]
 
+        self._parse_fw_version_from_resource()
+
+    # ---------------------------
+    #   _parse_fw_version_from_resource
+    # ---------------------------
+    def _parse_fw_version_from_resource(self) -> None:
+        """Parse current firmware version from /system/resource.version.
+
+        The current installed version is read-accessible to any user with the
+        `read` policy bit (no write/policy/reboot required). Running this after
+        get_system_resource() populates self.ds["resource"] ensures
+        major_fw_version is set in time for get_capabilities() to dispatch
+        correctly, even when get_firmware_update() short-circuits on its
+        permission gate (read-only service users).
+
+        Skips if major_fw_version is already non-zero. For users with the full
+        permission set, get_firmware_update() runs first in the hwinfo refresh
+        order and is authoritative; on subsequent normal polling cycles (where
+        only get_system_resource runs) the early-return defends against
+        re-parsing a value already set in a prior cycle — major_fw_version is
+        sticky across cycles once populated.
+        """
+        if self.major_fw_version > 0:
+            return
+        full_version = self.ds["resource"].get("version")
+        if not full_version or full_version == "unknown":
+            return
+        try:
+            version = re.sub("[^0-9\\.]", "", full_version.split()[0])
+            version_parts = version.split(".")
+            self.major_fw_version = int(version_parts[0])
+            self.minor_fw_version = int(version_parts[1]) if len(version_parts) > 1 else 0
+            _LOGGER.debug(
+                "Mikrotik %s FW version major=%s minor=%s (%s; from /system/resource)",
+                self.host,
+                self.major_fw_version,
+                self.minor_fw_version,
+                full_version,
+            )
+        except (ValueError, IndexError) as e:
+            _LOGGER.warning(
+                "Mikrotik %s unable to determine FW version from '%s' (%s); capability detection may be incomplete until next successful parse",
+                self.host,
+                full_version,
+                e,
+            )
+
     # ---------------------------
     #   get_firmware_update
     # ---------------------------


### PR DESCRIPTION
## Summary

Fixes the capability-detection cascade for read-only RouterOS users by adding a read-side fallback that parses `major_fw_version` from `/system/resource.version` — in addition to the existing parse inside `get_firmware_update()`, which is write-gated and therefore inaccessible to read-only users.

Detailed problem statement and root-cause trace in #82.

## Change

Adds a small helper `_parse_fw_version_from_resource()` called at the end of `get_system_resource()`. It only writes `major_fw_version` if it's still at its `__init__` sentinel `0`, so users with the full permission set are unaffected — `get_firmware_update()` runs first in the hwinfo refresh order and remains authoritative for them.

`get_firmware_update()` is left untouched; the gate on the actual `check-for-updates` action and the `update.*` entities is preserved as RouterOS itself requires.

## What this fixes

For users without `write+policy+reboot` on RouterOS 7.x:
- `get_capabilities()` dispatches correctly → `_wifimodule` set per package detection
- `support_wireless` / `support_capsman` / `support_ppp` reflect actual router capabilities
- Wireless data populates → `clients_wireless` reflects real client count
- CAPsMAN data populates on CAPsMAN routers
- PPP data populates on routers with PPP
- Client traffic accounting (`_async_update_client_traffic` at coordinator.py:744) dispatches correctly per RouterOS version

## What this does NOT change

- The `check-for-updates` action and `update.*_routeros_update` / `update.*_routerboard_firmware_update` entities still require `write+policy+reboot` (RouterOS-side requirement, correctly preserved)
- Users with the full permission set are unaffected — `_parse_fw_version_from_resource()` self-skips when `major_fw_version > 0` from `get_firmware_update()`'s existing parse

## Verified

- hAP ax^3 (wifi-qcom) on RouterOS 7.22.3, with a `read,api,rest-api,sensitive,test` user
- Before: `sensor.<device>_wireless_clients = 0` with 13 wireless clients connected; `_wifimodule="wireless"`; integration querying `/interface/wireless/registration-table` which returns `400 "no such command or directory (wireless)"` under wifi-qcom
- After: `clients_wireless` reflects the live registration table count
- `update.*_routeros_update` entities remain unavailable (gate preserved)
- No regression on the existing path — verified `major_fw_version` parse via `installed-version` still runs first for users with full permissions

## Notes

Happy to revise the structure if a different approach is preferred — e.g. extracting version parsing into a top-level method, or restructuring `get_firmware_update()` to separate "current version" from "update available" more deliberately. Whatever fits the codebase best.

Companion issue: #82