### PR TITLE
feat: set PARALLEL_UPDATES per platform (quality-scale parallel-updates)

### DIFF
--- a/custom_components/mikrotik_router/binary_sensor.py
+++ b/custom_components/mikrotik_router/binary_sensor.py
@@ -20,6 +20,10 @@ from .binary_sensor_types import SENSOR_TYPES, SENSOR_SERVICES  # noqa: F401
 
 _LOGGER = getLogger(__name__)
 
+# The coordinator centralises all polling; binary-sensor updates perform no
+# per-entity device I/O, so no parallelism limit is needed.
+PARALLEL_UPDATES = 0
+
 
 # ---------------------------
 #   async_setup_entry

--- a/custom_components/mikrotik_router/button.py
+++ b/custom_components/mikrotik_router/button.py
@@ -15,6 +15,10 @@ from .exceptions import ApiEntryNotFound
 
 _LOGGER = getLogger(__name__)
 
+# Buttons send commands to the router; serialise them to avoid simultaneous
+# writes the device may mishandle.
+PARALLEL_UPDATES = 1
+
 
 # ---------------------------
 #   async_setup_entry

--- a/custom_components/mikrotik_router/device_tracker.py
+++ b/custom_components/mikrotik_router/device_tracker.py
@@ -36,6 +36,10 @@ from .const import (
 
 _LOGGER = getLogger(__name__)
 
+# The coordinator centralises all polling; tracker updates perform no per-entity
+# device I/O, so no parallelism limit is needed.
+PARALLEL_UPDATES = 0
+
 
 async def async_add_entities(hass: HomeAssistant, config_entry: ConfigEntry, dispatcher: dict[str, Callable]):
     """Add entities."""

--- a/custom_components/mikrotik_router/sensor.py
+++ b/custom_components/mikrotik_router/sensor.py
@@ -18,6 +18,10 @@ from .sensor_types import SENSOR_TYPES, SENSOR_SERVICES  # noqa: F401
 
 _LOGGER = getLogger(__name__)
 
+# The coordinator centralises all polling; sensor updates perform no per-entity
+# device I/O, so no parallelism limit is needed.
+PARALLEL_UPDATES = 0
+
 
 # ---------------------------
 #   async_setup_entry

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -20,6 +20,10 @@ from .switch_types import (
 
 _LOGGER = getLogger(__name__)
 
+# Switches send commands to the router; serialise them — RouterOS can mishandle
+# simultaneous writes (see the API-lock concurrency history, #64).
+PARALLEL_UPDATES = 1
+
 _CAPSMAN_MANAGED = "managed by CAPsMAN"
 _RULE_NOT_FOUND_ENABLE = "Rule not found for %s, cannot enable"
 _RULE_NOT_FOUND_DISABLE = "Rule not found for %s, cannot disable"

--- a/custom_components/mikrotik_router/update.py
+++ b/custom_components/mikrotik_router/update.py
@@ -23,6 +23,10 @@ from .update_types import SENSOR_TYPES, SENSOR_SERVICES  # noqa: F401
 from packaging.version import Version
 
 _LOGGER = getLogger(__name__)
+
+# This platform exposes an install action (firmware update); serialise commands
+# so concurrent installs can't be issued to the router at once.
+PARALLEL_UPDATES = 1
 DEVICE_UPDATE = "device_update"
 
 

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,11 +4,39 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260608-parallel-updates — declare `PARALLEL_UPDATES` per platform (quality-scale Silver)
+
+**Date:** 2026-06-08
+**Branch:** `feature/parallel-updates` → PR to `dev`
+**Status:** In Review
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `sensor.py`, `binary_sensor.py`, `device_tracker.py` | `PARALLEL_UPDATES = 0` — read-only platforms; the coordinator centralises all polling, so entity updates do no per-entity device I/O. |
+| `switch.py`, `button.py`, `update.py` | `PARALLEL_UPDATES = 1` — these send commands to the router (switch toggle, button press, `update.async_install`); serialise to avoid simultaneous writes RouterOS can mishandle. |
+
+### Why
+
+Closes the HA Integration Quality-Scale **Silver `parallel-updates`** rule: every platform must explicitly declare update parallelism. Values follow the rule's guidance for coordinator-based integrations (0 for read-only, a limit for command platforms).
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint + format | All checks passed | ✅ |
+| Pre-PR review | **Light pass** (per workflow: scale to diff size) — declarative module constants; nothing for `/simplify` (no logic) or silent-failure-hunter (no error handling); values verified against the official rule | ✅ |
+| Pytest | 593 passed, 5 skipped (devbox `python:3.13`) | ✅ |
+| ADR | None — not a data-format / entity-identity / API-contract change | n/a |
+
+---
+
 ## CR-260608-sync-master-to-dev — reconcile diverged branches + document the sync model
 
 **Date:** 2026-06-08
-**Branch:** `chore/sync-master-to-dev` → PR to `dev`
-**Status:** In Review
+**Branch:** `chore/sync-master-to-dev` → PR #83 to `dev` (merge commit)
+**Status:** Merged
 
 ### What Changed
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -17,11 +17,29 @@
 
 ## Active
 
+### ENH-260608-quality-scale-conformance — close HA Integration Quality Scale gaps
+**Type:** Enhancement (conformance)
+**Priority:** Medium
+**Created:** 2026-06-08
+**Status:** 🟡 In Progress
+
+Bring the integration to the HA Integration Quality Scale Bronze/Silver baseline. Verified scorecard reviewed against the official rules 2026-06-08.
+
+- [x] **parallel-updates** (Silver) — `PARALLEL_UPDATES` per platform (`feature/parallel-updates`, CR-260608-parallel-updates)
+- [ ] **runtime-data** (Bronze) — typed `ConfigEntry.runtime_data` (drafted; ADR pending)
+- [ ] **reauthentication-flow** (Silver) — `async_step_reauth` + raise `ConfigEntryAuthFailed` on `wrong_login`
+- [ ] **reconfiguration-flow** (Gold), **strict-typing** (Platinum) — later, alongside the coordinator decomposition
+- Already conformant: config-flow, has-entity-name, test-before-setup/-configure, entity-unique-id, brands, entity-translations (26 locales), diagnostics, config-entry-unloading.
+
+After Bronze+Silver are met, declare `quality_scale` in `manifest.json`.
+
+---
+
 ### ISS-260608-dev-master-divergence — `dev` and `master` synced by parallel commits, not merges
 **Type:** Process / repo hygiene
 **Priority:** Medium
 **Created:** 2026-06-08
-**Status:** 🟢 Reconciled on `chore/sync-master-to-dev` (PR to `dev`); going-forward rule added to CLAUDE.md
+**Status:** 🟢 Reconciled on `dev` (PR #83, merge commit); going-forward rule added to CLAUDE.md
 
 **Symptom:**
 `git merge-base --is-ancestor origin/master origin/dev` returned **false** — `master` appeared "4 commits ahead" of `dev` even though the *code trees were content-identical* (only `README.md` differed by the PoE-energy guide). The 4 commits were patch-duplicates already on `dev` under different SHAs (e.g. `b98b7e2 fix(ci): lock-threads` vs `f71da08 …(dev parity)`; `1877bb5 Release v2.3.18` vs `4adda71`).
@@ -30,7 +48,7 @@
 master↔dev were kept in sync by **re-applying changes as parallel commits** (`…(dev parity)`, duplicate release commits) instead of true merges, so git never recorded shared history and the branches drift permanently. This makes feature branching ambiguous (which base?) and PRs noisy (a master-based branch rebased onto dev drags master-only commits along).
 
 **Resolution:**
-One-time `master → dev` reconciliation merge (`chore/sync-master-to-dev`) — clean, brought only the README PoE guide. Going forward: features → `dev` → `master`; releases cut by **merging** `dev → master`; any hotfix landing on `master` first is **back-merged to `dev` with a real merge commit** so `dev ⊇ master` always holds. Rule documented in CLAUDE.md § Branch Strategy.
+One-time `master → dev` reconciliation **merge commit** (PR #83) — clean, brought only the README PoE guide. Going forward: features → `dev` → `master`; releases cut by **merging** `dev → master`; any hotfix landing on `master` first is **back-merged to `dev` with a real merge commit** so `dev ⊇ master` always holds. Rule documented in CLAUDE.md § Branch Strategy.
 
 ---
 


### PR DESCRIPTION
## Summary
Closes the HA Integration Quality-Scale **Silver `parallel-updates`** rule — every platform now explicitly declares its update parallelism.

- `sensor`, `binary_sensor`, `device_tracker` → **`PARALLEL_UPDATES = 0`** (read-only; the coordinator centralises all polling, no per-entity device I/O)
- `switch`, `button`, `update` → **`PARALLEL_UPDATES = 1`** (these send commands to the router — toggle / press / `async_install`; serialise to avoid simultaneous writes RouterOS can mishandle)

Values follow the [parallel-updates rule](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/parallel-updates/) guidance for coordinator-based integrations. Tracked as part of `ENH-260608-quality-scale-conformance`.

## Post-Deploy Actions
- None.

## Test Plan
- [x] Ruff lint + format clean
- [x] 593 passed, 5 skipped on the devbox (`python:3.13`, matches CI)
- [x] Each value verified against the rule (read-only = 0, command platform = 1; `update.py` has `async_install`)

> Note: best merged **after** #83 (the dev↔master reconciliation). If the `CHANGE-REGISTER.md` / `ISSUES.md` top entries conflict with #83 at merge time, it's a trivial resolve — the code changes never conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)