### PR TITLE
refactor: store runtime data on ConfigEntry.runtime_data (quality-scale runtime-data)

### DIFF
--- a/custom_components/mikrotik_router/__init__.py
+++ b/custom_components/mikrotik_router/__init__.py
@@ -21,7 +21,12 @@ from homeassistant.const import CONF_NAME, CONF_VERIFY_SSL
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import PLATFORMS, DOMAIN, DEFAULT_VERIFY_SSL
-from .coordinator import MikrotikData, MikrotikCoordinator, MikrotikTrackerCoordinator
+from .coordinator import (
+    MikrotikConfigEntry,
+    MikrotikData,
+    MikrotikCoordinator,
+    MikrotikTrackerCoordinator,
+)
 
 SCRIPT_SCHEMA = vol.Schema({vol.Required("router"): cv.string, vol.Required("script"): cv.string})
 
@@ -78,17 +83,28 @@ def _collect_ids_for_desc(desc, data: dict, inst_lower: str, valid_ids: set) -> 
 
 
 def _get_mikrotik_data(hass: HomeAssistant, entry_id: str) -> MikrotikData | None:
-    """Look up MikrotikData for a config entry, logging an error if missing."""
-    domain_data = hass.data.get(DOMAIN, {})
-    if entry_id in domain_data:
-        return domain_data[entry_id]
+    """Look up MikrotikData for a config entry, logging why if unavailable.
 
-    _LOGGER.error(
-        "Config entry '%s' not found. Available: %s",
-        entry_id,
-        list(domain_data.keys()),
-    )
-    return None
+    Reads the loaded entry's runtime_data (the HA-recommended store) rather than
+    hass.data[DOMAIN]. Returns None for two distinct cases, logged separately so
+    the operator knows which to fix:
+      * the entry_id is unknown (bad/stale argument), or
+      * the entry exists but is not loaded (disabled / setup retrying / reloading)
+        — runtime_data only exists between setup and unload.
+    """
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is None:
+        _LOGGER.error("Config entry '%s' not found in the registry", entry_id)
+        return None
+    if not isinstance(entry.runtime_data, MikrotikData):
+        _LOGGER.error(
+            "Config entry '%s' (%s) is not loaded (state=%s); load the Mikrotik integration before running this service",
+            entry_id,
+            entry.title,
+            entry.state,
+        )
+        return None
+    return entry.runtime_data
 
 
 async def async_cleanup_entities(call: ServiceCall) -> ServiceResponse:
@@ -98,7 +114,7 @@ async def async_cleanup_entities(call: ServiceCall) -> ServiceResponse:
 
     mikrotik_data = _get_mikrotik_data(hass, entry_id)
     if mikrotik_data is None:
-        raise HomeAssistantError(f"Config entry '{entry_id}' not found")
+        raise HomeAssistantError(f"Config entry '{entry_id}' not found or not loaded")
 
     coordinator = mikrotik_data.data_coordinator
     config_entry = coordinator.config_entry
@@ -190,7 +206,7 @@ async def async_cleanup_stale_hosts(call: ServiceCall) -> ServiceResponse:
 
     mikrotik_data = _get_mikrotik_data(hass, entry_id)
     if mikrotik_data is None:
-        raise HomeAssistantError(f"Config entry '{entry_id}' not found")
+        raise HomeAssistantError(f"Config entry '{entry_id}' not found or not loaded")
 
     coordinator = mikrotik_data.data_coordinator
     inst = coordinator.config_entry.data[CONF_NAME].lower()
@@ -255,14 +271,14 @@ def _async_register_services(hass: HomeAssistant) -> None:
 # ---------------------------
 #   async_setup_entry
 # ---------------------------
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, config_entry: MikrotikConfigEntry) -> bool:
     """Set up a config entry."""
     _async_register_services(hass)
     coordinator = MikrotikCoordinator(hass, config_entry)
     await coordinator.async_config_entry_first_refresh()
     coordinator_tracker = MikrotikTrackerCoordinator(hass, config_entry, coordinator)
     await coordinator_tracker.async_config_entry_first_refresh()
-    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = MikrotikData(
+    config_entry.runtime_data = MikrotikData(
         data_coordinator=coordinator,
         tracker_coordinator=coordinator_tracker,
     )
@@ -277,7 +293,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 # ---------------------------
 #   async_reload_entry
 # ---------------------------
-async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+async def async_reload_entry(hass: HomeAssistant, config_entry: MikrotikConfigEntry) -> None:
     """Reload the config entry when it changed."""
     await hass.config_entries.async_reload(config_entry.entry_id)
 
@@ -285,13 +301,14 @@ async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 # ---------------------------
 #   async_unload_entry
 # ---------------------------
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, config_entry: MikrotikConfigEntry) -> bool:
     """Unload a config entry."""
 
     if unload_ok := await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS):
-        hass.data[DOMAIN].pop(config_entry.entry_id)
-
-        if not hass.data[DOMAIN]:
+        # runtime_data is dropped by Home Assistant automatically on unload.
+        # Only remove the shared services once the last entry is gone.
+        other_entries_loaded = any(entry.entry_id != config_entry.entry_id for entry in hass.config_entries.async_loaded_entries(DOMAIN))
+        if not other_entries_loaded:
             hass.services.async_remove(DOMAIN, SERVICE_CLEANUP_ENTITIES)
             hass.services.async_remove(DOMAIN, SERVICE_CLEANUP_STALE_HOSTS)
 

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -122,6 +122,12 @@ class MikrotikData:
     tracker_coordinator: MikrotikTrackerCoordinator
 
 
+# Typed config entry — its runtime_data is the MikrotikData above. This is the
+# HA-recommended replacement for hass.data[DOMAIN][entry_id] (quality-scale
+# `runtime-data` rule) and the seed of the integration's typed data model.
+type MikrotikConfigEntry = ConfigEntry[MikrotikData]
+
+
 class MikrotikTrackerCoordinator(DataUpdateCoordinator[None]):
     def __init__(
         self,

--- a/custom_components/mikrotik_router/device_tracker.py
+++ b/custom_components/mikrotik_router/device_tracker.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 from typing import Any, Callable
 
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.const import STATE_NOT_HOME
 from homeassistant.helpers import entity_platform as ep
@@ -18,7 +17,7 @@ from homeassistant.util.dt import utcnow
 
 from homeassistant.components.device_tracker.const import SourceType
 
-from .coordinator import MikrotikCoordinator
+from .coordinator import MikrotikConfigEntry, MikrotikCoordinator
 from .device_tracker_types import (
     SENSOR_TYPES,  # noqa: F401
     SENSOR_SERVICES,  # noqa: F401
@@ -27,7 +26,6 @@ from .device_tracker_types import (
 from .entity import _run_entity_setup_loop, MikrotikEntity, copy_attrs
 from .helper import format_attribute
 from .const import (
-    DOMAIN,
     CONF_TRACK_HOSTS,
     DEFAULT_TRACK_HOSTS,
     CONF_TRACK_HOSTS_TIMEOUT,
@@ -41,7 +39,7 @@ _LOGGER = getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 
-async def async_add_entities(hass: HomeAssistant, config_entry: ConfigEntry, dispatcher: dict[str, Callable]):
+async def async_add_entities(hass: HomeAssistant, config_entry: MikrotikConfigEntry, dispatcher: dict[str, Callable]):
     """Add entities."""
     platform = ep.async_get_current_platform()
     services = platform.platform.SENSOR_SERVICES
@@ -50,7 +48,7 @@ async def async_add_entities(hass: HomeAssistant, config_entry: ConfigEntry, dis
     for service in services:
         platform.async_register_entity_service(service[0], service[1], service[2])
 
-    tracker_coord = hass.data[DOMAIN][config_entry.entry_id].tracker_coordinator
+    tracker_coord = config_entry.runtime_data.tracker_coordinator
 
     @callback
     async def async_update_controller(coordinator):
@@ -72,7 +70,7 @@ async def async_add_entities(hass: HomeAssistant, config_entry: ConfigEntry, dis
 # ---------------------------
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: MikrotikConfigEntry,
     _async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up entry for component"""

--- a/custom_components/mikrotik_router/diagnostics.py
+++ b/custom_components/mikrotik_router/diagnostics.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 from typing import Any
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from .const import DOMAIN, TO_REDACT
+from .const import TO_REDACT
+from .coordinator import MikrotikConfigEntry
 
 
-async def async_get_config_entry_diagnostics(hass: HomeAssistant, config_entry: ConfigEntry) -> dict[str, Any]:
+async def async_get_config_entry_diagnostics(hass: HomeAssistant, config_entry: MikrotikConfigEntry) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    data_coordinator = hass.data[DOMAIN][config_entry.entry_id].data_coordinator
-    tracker_coordinator = hass.data[DOMAIN][config_entry.entry_id].tracker_coordinator
+    data_coordinator = config_entry.runtime_data.data_coordinator
+    tracker_coordinator = config_entry.runtime_data.tracker_coordinator
 
     return {
         "entry": {

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 from logging import getLogger
 from typing import Any, Callable, TypeVar
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_HOST
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
@@ -32,7 +31,7 @@ from .const import (
     CONF_SENSOR_POE,
     DEFAULT_SENSOR_POE,
 )
-from .coordinator import MikrotikCoordinator, MikrotikTrackerCoordinator
+from .coordinator import MikrotikConfigEntry, MikrotikCoordinator, MikrotikTrackerCoordinator
 from .helper import format_attribute
 from .iface_attributes import (
     DEVICE_ATTRIBUTES_IFACE_CLIENT,
@@ -222,7 +221,7 @@ async def _run_entity_setup_loop(  # pragma: no cover
 #   async_add_entities
 # ---------------------------
 async def async_add_entities(  # pragma: no cover
-    hass: HomeAssistant, config_entry: ConfigEntry, dispatcher: dict[str, Callable]
+    hass: HomeAssistant, config_entry: MikrotikConfigEntry, dispatcher: dict[str, Callable]
 ):
     """Add entities."""
     platform = ep.async_get_current_platform()
@@ -237,7 +236,7 @@ async def async_add_entities(  # pragma: no cover
         """Update the values of the controller."""
         await _run_entity_setup_loop(hass, platform, config_entry, dispatcher, descriptions, coordinator)
 
-    await async_update_controller(hass.data[DOMAIN][config_entry.entry_id].data_coordinator)
+    await async_update_controller(config_entry.runtime_data.data_coordinator)
 
     unsub = async_dispatcher_connect(hass, "update_sensors", async_update_controller)
     config_entry.async_on_unload(unsub)

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,39 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260608-runtime-data — store runtime data on `ConfigEntry.runtime_data` (quality-scale Bronze)
+
+**Date:** 2026-06-08
+**Branch:** `feature/runtime-data` → PR to `dev`
+**Status:** In Review
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `coordinator.py` | New `type MikrotikConfigEntry = ConfigEntry[MikrotikData]`. |
+| `__init__.py` | `async_setup_entry` stores `config_entry.runtime_data`; `_get_mikrotik_data()` resolves via `async_get_entry()` + `isinstance(MikrotikData)` guard, logging not-found vs not-loaded (`entry.state`) distinctly; `async_unload_entry` tears down shared services via `async_loaded_entries()` (`any()` check). |
+| `entity.py`, `device_tracker.py`, `diagnostics.py` | Read coordinators from `config_entry.runtime_data`; entry params typed `MikrotikConfigEntry`; dropped now-dead `DOMAIN`/`ConfigEntry` imports. |
+| `tests/test_init.py` | Migrated setup/unload/`_get_mikrotik_data` **and** the cleanup-service tests to the runtime_data lookup (new `_hass_with_loaded_entry`); `_make_mock_mikrotik_data` builds a real `MikrotikData`. |
+| `docs/decisions/ADR-012-config-entry-runtime-data.md` (new) | Decision record. |
+
+### Why
+
+Satisfies the quality-scale Bronze **`runtime-data`** rule and seeds the typed data model for the planned coordinator decomposition. See ADR-012.
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint + format | All checks passed | ✅ |
+| Pytest | 593 passed, 5 skipped (devbox `python:3.13`, `__pycache__` cleared) | ✅ |
+| Pre-PR gate | code-review (no blockers); silent-failure-hunter (1 MEDIUM applied — split not-found/not-loaded diagnostics); simplifier (typed reload/setup handlers, `any()`) | ✅ |
+| ADR | ADR-012 (storage-contract change) | ✅ |
+
+> A false-green from stale devbox `__pycache__` initially hid 8 broken cleanup-service tests; caught, fixed, and the runbook hardened (clear cache + `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`).
+
+---
+
 ## CR-260608-parallel-updates — declare `PARALLEL_UPDATES` per platform (quality-scale Silver)
 
 **Date:** 2026-06-08

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -26,7 +26,7 @@
 Bring the integration to the HA Integration Quality Scale Bronze/Silver baseline. Verified scorecard reviewed against the official rules 2026-06-08.
 
 - [x] **parallel-updates** (Silver) — `PARALLEL_UPDATES` per platform (`feature/parallel-updates`, CR-260608-parallel-updates)
-- [ ] **runtime-data** (Bronze) — typed `ConfigEntry.runtime_data` (drafted; ADR pending)
+- [x] **runtime-data** (Bronze) — typed `ConfigEntry.runtime_data` (`feature/runtime-data`, ADR-012, CR-260608-runtime-data)
 - [ ] **reauthentication-flow** (Silver) — `async_step_reauth` + raise `ConfigEntryAuthFailed` on `wrong_login`
 - [ ] **reconfiguration-flow** (Gold), **strict-typing** (Platinum) — later, alongside the coordinator decomposition
 - Already conformant: config-flow, has-entity-name, test-before-setup/-configure, entity-unique-id, brands, entity-translations (26 locales), diagnostics, config-entry-unloading.

--- a/docs/decisions/ADR-012-config-entry-runtime-data.md
+++ b/docs/decisions/ADR-012-config-entry-runtime-data.md
@@ -1,0 +1,43 @@
+# ADR-012: Store runtime data on `ConfigEntry.runtime_data`
+
+**Date:** 2026-06-08
+**Status:** Accepted
+
+## Context
+
+The integration stored its per-entry runtime objects — the two coordinators, wrapped in `MikrotikData` — in `hass.data[DOMAIN][entry_id]`, and looked them up by `entry_id` in the cleanup services, the platforms, and diagnostics. Home Assistant's current guidance, and the Integration Quality-Scale **`runtime-data`** rule (Bronze), is to store per-entry runtime state on the typed `ConfigEntry.runtime_data` instead.
+
+The old pattern: (a) an untyped global dict keyed by `entry_id`; (b) manual lifecycle (set in `async_setup_entry`, `pop` in `async_unload_entry`); (c) "is this entry loaded?" is implicit; (d) no typed access to the stored object.
+
+## Decision
+
+1. Introduce `type MikrotikConfigEntry = ConfigEntry[MikrotikData]` (`coordinator.py`).
+2. `async_setup_entry` assigns `config_entry.runtime_data = MikrotikData(...)`; Home Assistant clears it on unload (no manual `pop`).
+3. All readers use `config_entry.runtime_data`:
+   - the cleanup services via `_get_mikrotik_data()`, which resolves the entry with `hass.config_entries.async_get_entry(entry_id)` and validates `isinstance(runtime_data, MikrotikData)` — logging **"not found in registry"** vs **"not loaded (state=…)"** distinctly;
+   - `entity.py`, `device_tracker.py`, `diagnostics.py` read it directly (they only run after setup populates it).
+4. `async_unload_entry` removes the shared services only when no *other* loaded entry remains (via `hass.config_entries.async_loaded_entries(DOMAIN)`), replacing the old `hass.data[DOMAIN]`-emptiness check. The filter excludes the current entry by `entry_id`, so it is correct whether or not HA still lists the unloading entry as loaded.
+5. Entry-point handlers are typed `MikrotikConfigEntry` for typed `runtime_data` access (`async_migrate_entry` excepted — `runtime_data` isn't populated at migrate time).
+
+## Consequences
+
+**Positive**
+- Satisfies the Bronze `runtime-data` rule.
+- Typed access to runtime state; the typed `ConfigEntry` is the **seed of the broader typed data model** for the planned coordinator decomposition.
+- Less manual lifecycle code — HA owns teardown; no `setdefault`/`pop`.
+- Better diagnostics: a stale `entry_id` and a not-loaded integration now produce different, actionable log lines (the old code's "not found" was misleading for the not-loaded case).
+
+**Trade-offs / risks**
+- Correctness rests on HA's documented contracts (`runtime_data` auto-cleared on unload; `async_loaded_entries` returns loaded entries). The unload teardown is written to be correct under either ordering of the unload transition.
+- The migration touched the cleanup-service tests (they now use a `runtime_data`-backed mock via `_hass_with_loaded_entry`).
+
+## Verification
+
+- **593 passed, 5 skipped** (devbox `python:3.13`, `__pycache__` cleared — see note below).
+- Full pre-PR gate: code-review (no blocking issues), silent-failure-hunter (one MEDIUM applied — split the not-found/not-loaded diagnostics, log `entry.state`), code-simplifier (typed `async_reload_entry`/platform `async_setup_entry`, `any()` for the unload check). All applied.
+
+> **Testing-hygiene note:** an earlier "593 passed" for this branch was a *false green* from stale root-owned `__pycache__` on the devbox (re-extracting a branch over the same dir ran old bytecode). It hid 8 broken cleanup-service tests. The devbox runbook now mandates clearing `__pycache__` and running with `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`.
+
+## Notes
+
+The firmware-version single-source-of-truth prototype (branch `proto/fw-version-sot`) carries a draft **ADR-012**; since this runtime-data ADR lands first on `dev`, that prototype ADR renumbers to **ADR-013** when it lands.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -17,6 +17,7 @@ Lightweight records of key design decisions for mikrotik_router HACS integration
 | [ADR-009](ADR-009-attribute-filtering-by-hardware.md) | Entity Attribute Filtering by Hardware Capability | Accepted |
 | [ADR-010](ADR-010-claude-tooling-baseline.md) | Claude Code Tooling Baseline + Mechanical Quality Gates via pyproject.toml | Accepted |
 | [ADR-011](ADR-011-capsman-attributes.md) | CAPsMAN AP-virtual interface — additive attribute, no source flip | Accepted |
+| [ADR-012](ADR-012-config-entry-runtime-data.md) | Store runtime data on `ConfigEntry.runtime_data` (typed) | Accepted |
 
 ## Template
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -33,6 +33,7 @@ from custom_components.mikrotik_router.const import (
     PLATFORMS,
     DEFAULT_VERIFY_SSL,
 )
+from custom_components.mikrotik_router.coordinator import MikrotikData
 
 
 # ---------------------------------------------------------------------------
@@ -72,11 +73,15 @@ def _make_mock_coordinator(ds=None, config_entry=None):
 
 
 def _make_mock_mikrotik_data(coordinator=None, tracker=None):
-    """Create a mock MikrotikData."""
-    data = MagicMock()
-    data.data_coordinator = coordinator or _make_mock_coordinator()
-    data.tracker_coordinator = tracker or MagicMock()
-    return data
+    """Create a real MikrotikData wrapping mock coordinators.
+
+    Must be the real dataclass (not a bare MagicMock) so the isinstance check in
+    _get_mikrotik_data passes — runtime_data is validated as MikrotikData.
+    """
+    return MikrotikData(
+        data_coordinator=coordinator or _make_mock_coordinator(),
+        tracker_coordinator=tracker or MagicMock(),
+    )
 
 
 def _make_service_call(hass, data):
@@ -85,6 +90,19 @@ def _make_service_call(hass, data):
     call.hass = hass
     call.data = data
     return call
+
+
+def _hass_with_loaded_entry(mikrotik_data):
+    """hass mock whose config entry exposes mikrotik_data via runtime_data.
+
+    Mirrors the runtime-data lookup in _get_mikrotik_data (reads
+    entry.runtime_data), replacing the old hass.data[DOMAIN][entry_id] store.
+    """
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.runtime_data = mikrotik_data
+    hass.config_entries.async_get_entry = MagicMock(return_value=entry)
+    return hass
 
 
 # ---------------------------------------------------------------------------
@@ -215,8 +233,10 @@ async def test_setup_entry_registers_coordinators_and_platforms():
     assert result is True
     mock_coord.async_config_entry_first_refresh.assert_awaited_once()
     mock_tracker.async_config_entry_first_refresh.assert_awaited_once()
-    assert DOMAIN in hass.data
-    assert config_entry.entry_id in hass.data[DOMAIN]
+    # Data is stored on the entry's runtime_data, not hass.data[DOMAIN].
+    assert isinstance(config_entry.runtime_data, MikrotikData)
+    assert config_entry.runtime_data.data_coordinator is mock_coord
+    assert config_entry.runtime_data.tracker_coordinator is mock_tracker
     hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(config_entry, PLATFORMS)
     config_entry.async_on_unload.assert_called_once()
 
@@ -295,61 +315,57 @@ async def test_setup_entry_skips_service_registration_if_already_registered():
 
 
 @pytest.mark.asyncio
-async def test_unload_entry_removes_data_and_services():
-    """Successful unload clears domain data and removes services when last entry."""
+async def test_unload_entry_removes_services_when_last_entry():
+    """Successful unload removes shared services when no other entries remain.
+
+    runtime_data is cleared by Home Assistant, not by our code, so there's
+    nothing to assert about it here.
+    """
     hass = MagicMock()
     config_entry = _make_mock_config_entry()
 
-    hass.data = {DOMAIN: {config_entry.entry_id: _make_mock_mikrotik_data()}}
     hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    hass.config_entries.async_loaded_entries = MagicMock(return_value=[])  # no others
     hass.services.async_remove = MagicMock()
 
     result = await async_unload_entry(hass, config_entry)
 
     assert result is True
-    assert config_entry.entry_id not in hass.data[DOMAIN]
-    # Last entry — services should be removed
     hass.services.async_remove.assert_any_call(DOMAIN, SERVICE_CLEANUP_ENTITIES)
     hass.services.async_remove.assert_any_call(DOMAIN, SERVICE_CLEANUP_STALE_HOSTS)
 
 
 @pytest.mark.asyncio
 async def test_unload_entry_keeps_services_if_other_entries_remain():
-    """Services not removed when other config entries still loaded."""
+    """Services not removed when other config entries are still loaded."""
     hass = MagicMock()
     config_entry = _make_mock_config_entry(entry_id="entry_1")
+    other_entry = _make_mock_config_entry(entry_id="entry_2")
 
-    hass.data = {
-        DOMAIN: {
-            "entry_1": _make_mock_mikrotik_data(),
-            "entry_2": _make_mock_mikrotik_data(),
-        }
-    }
     hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    # async_loaded_entries may still include the entry being unloaded; the code
+    # filters it out by entry_id, leaving entry_2 -> services stay registered.
+    hass.config_entries.async_loaded_entries = MagicMock(return_value=[config_entry, other_entry])
     hass.services.async_remove = MagicMock()
 
     result = await async_unload_entry(hass, config_entry)
 
     assert result is True
-    assert "entry_1" not in hass.data[DOMAIN]
-    assert "entry_2" in hass.data[DOMAIN]
     hass.services.async_remove.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_unload_entry_failure_keeps_data():
-    """Failed platform unload leaves domain data and services intact."""
+async def test_unload_entry_failure_keeps_services():
+    """Failed platform unload leaves services intact."""
     hass = MagicMock()
     config_entry = _make_mock_config_entry()
 
-    hass.data = {DOMAIN: {config_entry.entry_id: _make_mock_mikrotik_data()}}
     hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
     hass.services.async_remove = MagicMock()
 
     result = await async_unload_entry(hass, config_entry)
 
     assert result is False
-    assert config_entry.entry_id in hass.data[DOMAIN]
     hass.services.async_remove.assert_not_called()
 
 
@@ -397,28 +413,32 @@ def test_register_services_idempotent():
 
 
 def test_get_mikrotik_data_found():
-    """Returns MikrotikData when entry_id exists."""
+    """Returns the entry's runtime_data when it is loaded MikrotikData."""
     hass = MagicMock()
     mock_data = _make_mock_mikrotik_data()
-    hass.data = {DOMAIN: {"entry_1": mock_data}}
+    entry = MagicMock()
+    entry.runtime_data = mock_data
+    hass.config_entries.async_get_entry = MagicMock(return_value=entry)
 
     result = _get_mikrotik_data(hass, "entry_1")
     assert result is mock_data
 
 
-def test_get_mikrotik_data_not_found():
-    """Returns None and logs error when entry_id missing."""
+def test_get_mikrotik_data_entry_not_found():
+    """Returns None and logs error when the entry is unknown."""
     hass = MagicMock()
-    hass.data = {DOMAIN: {}}
+    hass.config_entries.async_get_entry = MagicMock(return_value=None)
 
     result = _get_mikrotik_data(hass, "nonexistent")
     assert result is None
 
 
-def test_get_mikrotik_data_no_domain():
-    """Returns None when DOMAIN not in hass.data."""
+def test_get_mikrotik_data_entry_not_loaded():
+    """Returns None when the entry exists but has no MikrotikData runtime_data."""
     hass = MagicMock()
-    hass.data = {}
+    entry = MagicMock()
+    entry.runtime_data = None  # not loaded
+    hass.config_entries.async_get_entry = MagicMock(return_value=entry)
 
     result = _get_mikrotik_data(hass, "entry_1")
     assert result is None
@@ -699,8 +719,7 @@ async def test_cleanup_entities_empty_valid_ids_aborts():
     coordinator = _make_mock_coordinator(ds={}, config_entry=config_entry)
     mikrotik_data = _make_mock_mikrotik_data(coordinator=coordinator)
 
-    hass = MagicMock()
-    hass.data = {DOMAIN: {config_entry.entry_id: mikrotik_data}}
+    hass = _hass_with_loaded_entry(mikrotik_data)
     call = _make_service_call(hass, {"entry_id": config_entry.entry_id})
 
     with patch(
@@ -744,8 +763,7 @@ async def test_cleanup_entities_removes_orphans():
         other_entry_entity,
     ]
 
-    hass = MagicMock()
-    hass.data = {DOMAIN: {config_entry.entry_id: mikrotik_data}}
+    hass = _hass_with_loaded_entry(mikrotik_data)
     call = _make_service_call(hass, {"entry_id": config_entry.entry_id})
 
     valid_ids = {"testrouter-port_status-ether1"}
@@ -782,8 +800,7 @@ async def test_cleanup_entities_no_orphans():
     mock_registry = MagicMock()
     mock_registry.entities.values.return_value = [valid_entity]
 
-    hass = MagicMock()
-    hass.data = {DOMAIN: {config_entry.entry_id: mikrotik_data}}
+    hass = _hass_with_loaded_entry(mikrotik_data)
     call = _make_service_call(hass, {"entry_id": config_entry.entry_id})
 
     with (
@@ -840,8 +857,7 @@ async def test_cleanup_stale_hosts_dry_run():
     mock_registry = MagicMock()
     mock_registry.entities.values.return_value = [stale_entity]
 
-    hass = MagicMock()
-    hass.data = {DOMAIN: {config_entry.entry_id: mikrotik_data}}
+    hass = _hass_with_loaded_entry(mikrotik_data)
     call = _make_service_call(hass, {"entry_id": config_entry.entry_id, "dry_run": True})
 
     with patch(
@@ -882,8 +898,7 @@ async def test_cleanup_stale_hosts_remove():
     mock_registry = MagicMock()
     mock_registry.entities.values.return_value = [stale_entity, sensor_entity]
 
-    hass = MagicMock()
-    hass.data = {DOMAIN: {config_entry.entry_id: mikrotik_data}}
+    hass = _hass_with_loaded_entry(mikrotik_data)
     call = _make_service_call(hass, {"entry_id": config_entry.entry_id, "dry_run": False})
 
     with patch(
@@ -918,8 +933,7 @@ async def test_cleanup_stale_hosts_no_stale():
     mock_registry = MagicMock()
     mock_registry.entities.values.return_value = [entity]
 
-    hass = MagicMock()
-    hass.data = {DOMAIN: {config_entry.entry_id: mikrotik_data}}
+    hass = _hass_with_loaded_entry(mikrotik_data)
     call = _make_service_call(hass, {"entry_id": config_entry.entry_id, "dry_run": True})
 
     with patch(
@@ -949,8 +963,7 @@ async def test_cleanup_stale_hosts_skips_other_entries():
     mock_registry = MagicMock()
     mock_registry.entities.values.return_value = [other_entity]
 
-    hass = MagicMock()
-    hass.data = {DOMAIN: {config_entry.entry_id: mikrotik_data}}
+    hass = _hass_with_loaded_entry(mikrotik_data)
     call = _make_service_call(hass, {"entry_id": config_entry.entry_id, "dry_run": True})
 
     with patch(
@@ -975,8 +988,7 @@ async def test_cleanup_stale_hosts_default_dry_run():
     mock_registry = MagicMock()
     mock_registry.entities.values.return_value = []
 
-    hass = MagicMock()
-    hass.data = {DOMAIN: {config_entry.entry_id: mikrotik_data}}
+    hass = _hass_with_loaded_entry(mikrotik_data)
     # No dry_run key — should default to True
     call = _make_service_call(hass, {"entry_id": config_entry.entry_id})
 
@@ -1046,8 +1058,7 @@ async def test_diagnostics_returns_redacted_data():
     mikrotik_data.data_coordinator = data_coord
     mikrotik_data.tracker_coordinator = tracker_coord
 
-    hass = MagicMock()
-    hass.data = {DOMAIN: {config_entry.entry_id: mikrotik_data}}
+    hass = _hass_with_loaded_entry(mikrotik_data)
 
     result = await async_get_config_entry_diagnostics(hass, config_entry)
 


### PR DESCRIPTION
## Summary
Closes the HA Integration Quality-Scale **Bronze `runtime-data`** rule — per-entry runtime state moves from the untyped `hass.data[DOMAIN][entry_id]` global to a typed `ConfigEntry.runtime_data`. This is also the **seed of the typed data model** for the planned coordinator decomposition. See **ADR-012**.

- `type MikrotikConfigEntry = ConfigEntry[MikrotikData]`
- `async_setup_entry` stores `config_entry.runtime_data`; HA clears it on unload (no manual pop)
- `_get_mikrotik_data()` resolves via `async_get_entry()` + `isinstance(MikrotikData)` guard, logging **not-found** vs **not-loaded (`entry.state`)** distinctly
- `async_unload_entry` removes shared services via `async_loaded_entries()` (last-entry check)
- platforms/diagnostics read `config_entry.runtime_data`; entry params typed `MikrotikConfigEntry`; dead imports dropped

## Post-Deploy Actions
- None.

## Test Plan
- [x] 593 passed, 5 skipped — devbox `python:3.13`, **clean `__pycache__`** (`PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`)
- [x] Ruff lint + format clean
- [x] Full pre-PR gate: code-review (no blockers), silent-failure-hunter (1 MEDIUM applied), simplifier (typed handlers, `any()`)
- [x] ADR-012 + CR-260608-runtime-data + conformance tracker updated

> Caught + fixed a false-green (stale devbox `__pycache__` had hidden 8 broken cleanup-service tests); runbook hardened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)