### PR TITLE
test: rework test_sensor.py as the test-quality reference implementation

### DIFF
--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,33 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260608-test-sensor-exemplar — rework test_sensor.py as the test-quality reference
+
+**Date:** 2026-06-08
+**Branch:** `feature/test-sensor-exemplar` → PR to `dev`
+**Status:** In Review
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `tests/test_sensor.py` | Rewritten as the reference implementation for the test-suite review: local `MagicMock(spec=MikrotikCoordinator)` + the real `MikrotikSensorEntityDescription` (no yes-man mocks), `@pytest.mark.parametrize` for the native_value / unit-of-measurement / DHCP cases, a `dhcp_client_data` fixture, and input→output assertions. 12 cases (was 10), ~half the per-case code. |
+
+### Why
+
+First, lowest-risk pass of the test-suite hardening (`ENH-260608-test-suite-hardening`). Provides a concrete pattern the other test modules can be migrated to. Background + findings: `docs/internal/test-suite-review-2026-06-08.md` (internal).
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint + format | All checks passed | ✅ |
+| Pytest | 595 passed, 5 skipped (devbox `python:3.13`, `__pycache__` cleared) | ✅ |
+| Pre-PR gate | code-review: clean — coverage preserved + extended (10→12), no false passes, spec'd mocks verified; silent-failure-hunter / simplifier N/A (test-only) | ✅ |
+| ADR | None — test-only | n/a |
+
+---
+
 ## CR-260608-runtime-data — store runtime data on `ConfigEntry.runtime_data` (quality-scale Bronze)
 
 **Date:** 2026-06-08

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -17,6 +17,20 @@
 
 ## Active
 
+### ENH-260608-test-suite-hardening — migrate tests to spec'd mocks, parametrize, behaviour assertions
+**Type:** Enhancement (test quality)
+**Priority:** Medium
+**Created:** 2026-06-08
+**Status:** 🟡 In Progress — `test_sensor.py` done as the reference; remaining modules to follow
+
+The suite leans on unspecced `MagicMock` (yes-man) coordinators/descriptions, near-zero `parametrize`, and assertions on internal representation rather than behaviour. Migrate each module to: `spec=`/real-type mocks (typos/renames fail), `@pytest.mark.parametrize` for data-driven cases, fixtures for shared arrange, and input→output assertions. Full findings: `docs/internal/test-suite-review-2026-06-08.md`.
+
+- [x] `test_sensor.py` — reference implementation (`feature/test-sensor-exemplar`, CR-260608-test-sensor-exemplar)
+- [ ] `conftest.py` — add `spec=` to the shared `make_mock_*` factories (highest value; surfaces yes-man passes across all entity tests)
+- [ ] remaining entity test modules (binary_sensor, switch, button, device_tracker, entity, update)
+
+---
+
 ### ENH-260608-quality-scale-conformance — close HA Integration Quality Scale gaps
 **Type:** Enhancement (conformance)
 **Priority:** Medium

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,35 +1,100 @@
-"""Tests for Mikrotik Router sensor entities."""
+"""Tests for Mikrotik Router sensor entities.
 
-from homeassistant.const import UnitOfElectricCurrent
+REFERENCE IMPLEMENTATION (2026-06-08) — worked example for the patterns in
+docs/internal/test-suite-review-2026-06-08.md. Read this file as the target
+shape when reworking the other test modules:
 
+  * spec= mocks at the boundary — a typo'd/renamed coordinator attribute now
+    raises AttributeError instead of silently returning a Mock (no yes-man).
+  * REAL entity descriptions — a renamed field in sensor_types.py breaks the
+    test, instead of a kitchen-sink MagicMock accepting stale names forever.
+  * @pytest.mark.parametrize for data-driven cases — the axis that varies is
+    the table; adding a case is one line, not a copy-pasted block.
+  * fixtures for shared "arrange".
+  * set INPUTS (coordinator.data) and assert OUTPUTS (native_value) — never
+    poke or assert internal representation.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.const import CONF_HOST, CONF_NAME, UnitOfElectricCurrent
+
+from custom_components.mikrotik_router.coordinator import MikrotikCoordinator
 from custom_components.mikrotik_router.sensor import (
-    MikrotikSensor,
     MikrotikClientTrafficSensor,
+    MikrotikSensor,
 )
-from custom_components.mikrotik_router.sensor_types import SENSOR_TYPES
+from custom_components.mikrotik_router.sensor_types import (
+    SENSOR_TYPES,
+    MikrotikSensorEntityDescription,
+)
 
-from .conftest import (
-    make_mock_coordinator,
-    make_mock_entity_description,
-    patch_coordinator_entity_init,
-)
+from .conftest import patch_coordinator_entity_init
+
+
+# ---------------------------------------------------------------------------
+# Local, spec'd scaffolding.
+#
+# These builders are intentionally local to this file. conftest's make_mock_*
+# helpers are unspecced MagicMocks (a "yes-man" that accepts any attribute);
+# migrating them to spec= is a separate pass that touches every entity test
+# module. This file shows where that pass should land.
+# ---------------------------------------------------------------------------
+
+
+def _coordinator(data: dict) -> MagicMock:
+    """A coordinator mock pinned to the real MikrotikCoordinator interface.
+
+    `spec=` means reading an attribute the real class does not define raises
+    AttributeError rather than returning a fresh Mock — so a typo or a renamed
+    coordinator attribute fails the test loudly instead of passing silently.
+    """
+    coordinator = MagicMock(spec=MikrotikCoordinator)
+    coordinator.data = data
+    config_entry = MagicMock()  # ConfigEntry is an HA boundary type; mock is fine
+    config_entry.data = {CONF_NAME: "TestRouter", CONF_HOST: "10.0.0.1"}
+    config_entry.options = {}
+    coordinator.config_entry = config_entry
+    return coordinator
+
+
+def _description(**overrides) -> MikrotikSensorEntityDescription:
+    """Build a REAL sensor entity description.
+
+    Using the actual dataclass (not a MagicMock) means a field renamed or
+    removed in sensor_types.py breaks these tests — which is the point. It also
+    rejects fields that don't belong to a sensor description, so the test can't
+    quietly depend on a switch-only attribute.
+    """
+    overrides.setdefault("key", "test_sensor")
+    overrides.setdefault("name", "Test Sensor")
+    # data_name / data_reference are read by custom_name() for uid entities;
+    # default them so a uid sensor can be built without boilerplate per test.
+    overrides.setdefault("data_name", "name")
+    overrides.setdefault("data_reference", "name")
+    return MikrotikSensorEntityDescription(**overrides)
+
+
+def _build_sensor(data, description, *, cls=MikrotikSensor, uid=None):
+    """Construct a sensor with HA's CoordinatorEntity.__init__ patched out."""
+    coordinator = _coordinator(data)
+    with patch_coordinator_entity_init():
+        return cls(coordinator, description, uid)
+
+
+# ---------------------------------------------------------------------------
+# Regression pin for issue #60 (keep — this is a legitimate "pin a fixed bug").
+# ---------------------------------------------------------------------------
 
 
 def test_poe_out_current_uses_milliampere_native_unit():
-    """Issue #60: PoE current was declared as AMPERE but the API returns mA,
-    causing displayed values to be off by 1000x. The native unit must match
-    the raw API units (mA)."""
+    """Issue #60: PoE current was declared AMPERE but the API returns mA, so
+    displayed values were 1000x too large. Pin the native unit to mA so a future
+    edit can't silently revert it."""
     desc = next(s for s in SENSOR_TYPES if s.key == "poe_out_current")
     assert desc.native_unit_of_measurement == UnitOfElectricCurrent.MILLIAMPERE
-
-
-def _make_sensor(cls=MikrotikSensor, coordinator=None, desc_overrides=None, uid=None):
-    """Build a sensor entity with patched CoordinatorEntity.__init__."""
-    coord = coordinator or make_mock_coordinator()
-    desc = make_mock_entity_description(**(desc_overrides or {}))
-    with patch_coordinator_entity_init():
-        entity = cls(coord, desc, uid)
-    return entity
 
 
 # ---------------------------------------------------------------------------
@@ -37,24 +102,18 @@ def _make_sensor(cls=MikrotikSensor, coordinator=None, desc_overrides=None, uid=
 # ---------------------------------------------------------------------------
 
 
-class TestMikrotikSensorNativeValue:
-    def test_returns_data_attribute(self):
-        coord = make_mock_coordinator()
-        coord.data["health"] = {"temperature": 42}
-        entity = _make_sensor(
-            coordinator=coord,
-            desc_overrides={"data_path": "health", "data_attribute": "temperature"},
-        )
-        assert entity.native_value == 42
-
-    def test_returns_string_value(self):
-        coord = make_mock_coordinator()
-        coord.data["resource"] = {"version": "7.16.2"}
-        entity = _make_sensor(
-            coordinator=coord,
-            desc_overrides={"data_path": "resource", "data_attribute": "version"},
-        )
-        assert entity.native_value == "7.16.2"
+@pytest.mark.parametrize(
+    "data_path, data, attribute, expected",
+    [
+        ("health", {"temperature": 42}, "temperature", 42),
+        ("resource", {"version": "7.16.2"}, "version", "7.16.2"),
+    ],
+)
+def test_native_value_returns_data_attribute(data_path, data, attribute, expected):
+    """native_value reads description.data_attribute out of the data path."""
+    desc = _description(data_path=data_path, data_attribute=attribute)
+    sensor = _build_sensor({data_path: data}, desc)
+    assert sensor.native_value == expected
 
 
 # ---------------------------------------------------------------------------
@@ -62,67 +121,40 @@ class TestMikrotikSensorNativeValue:
 # ---------------------------------------------------------------------------
 
 
-class TestMikrotikSensorUoM:
-    def test_static_uom(self):
-        entity = _make_sensor(
-            desc_overrides={
-                "native_unit_of_measurement": "°C",
-                "data_path": "health",
-            },
-            coordinator=make_mock_coordinator(
-                data={
-                    "health": {"temperature": 42},
-                    "resource": {"board-name": "x", "platform": "x", "version": "x"},
-                    "routerboard": {"serial-number": "x"},
-                }
-            ),
-        )
-        assert entity.native_unit_of_measurement == "°C"
+@pytest.mark.parametrize(
+    "configured_unit, expected",
+    [
+        ("°C", "°C"),  # a static unit is returned verbatim
+        (None, None),  # no unit configured -> None
+    ],
+)
+def test_static_native_unit(configured_unit, expected):
+    desc = _description(
+        data_path="health",
+        data_attribute="temperature",
+        native_unit_of_measurement=configured_unit,
+    )
+    sensor = _build_sensor({"health": {"temperature": 42}}, desc)
+    assert sensor.native_unit_of_measurement == expected
 
-    def test_dynamic_uom_from_data(self):
-        coord = make_mock_coordinator()
-        coord.data["interface"] = {"ether1": {"name": "ether1", "speed-unit": "Mbps"}}
-        entity = _make_sensor(
-            coordinator=coord,
-            desc_overrides={
-                "native_unit_of_measurement": "data__speed-unit",
-                "data_path": "interface",
-                "data_reference": "name",
-            },
-            uid="ether1",
-        )
-        assert entity.native_unit_of_measurement == "Mbps"
 
-    def test_dynamic_uom_key_missing_falls_back(self):
-        """When the data__ key isn't in _data, returns the raw string."""
-        coord = make_mock_coordinator()
-        coord.data["interface"] = {"ether1": {"name": "ether1"}}
-        entity = _make_sensor(
-            coordinator=coord,
-            desc_overrides={
-                "native_unit_of_measurement": "data__speed-unit",
-                "data_path": "interface",
-                "data_reference": "name",
-            },
-            uid="ether1",
-        )
-        assert entity.native_unit_of_measurement == "data__speed-unit"
-
-    def test_none_uom(self):
-        entity = _make_sensor(
-            desc_overrides={
-                "native_unit_of_measurement": None,
-                "data_path": "health",
-            },
-            coordinator=make_mock_coordinator(
-                data={
-                    "health": {"temperature": 42},
-                    "resource": {"board-name": "x", "platform": "x", "version": "x"},
-                    "routerboard": {"serial-number": "x"},
-                }
-            ),
-        )
-        assert entity.native_unit_of_measurement is None
+@pytest.mark.parametrize(
+    "interface_data, expected",
+    [
+        ({"name": "ether1", "speed-unit": "Mbps"}, "Mbps"),  # data__ key present -> resolved
+        ({"name": "ether1"}, "data__speed-unit"),  # key absent -> raw string returned
+    ],
+)
+def test_dynamic_native_unit_from_data(interface_data, expected):
+    """A `data__<key>` unit resolves against the entity's own data, falling back
+    to the literal string when the key is absent."""
+    desc = _description(
+        data_path="interface",
+        data_attribute="name",
+        native_unit_of_measurement="data__speed-unit",
+    )
+    sensor = _build_sensor({"interface": {"ether1": interface_data}}, desc, uid="ether1")
+    assert sensor.native_unit_of_measurement == expected
 
 
 # ---------------------------------------------------------------------------
@@ -130,33 +162,34 @@ class TestMikrotikSensorUoM:
 # ---------------------------------------------------------------------------
 
 
-class TestClientTrafficSensorCustomName:
-    def test_always_returns_description_name(self):
-        coord = make_mock_coordinator()
-        coord.data["client_traffic"] = {"AA:BB:CC:DD:EE:FF": {"host-name": "MyPC", "wan-tx": 1000}}
-        entity = _make_sensor(
-            cls=MikrotikClientTrafficSensor,
-            coordinator=coord,
-            desc_overrides={
-                "name": "WAN TX",
-                "data_path": "client_traffic",
-                "data_reference": "mac-address",
-                "data_name": "host-name",
-            },
-            uid="AA:BB:CC:DD:EE:FF",
-        )
-        assert entity.custom_name == "WAN TX"
+def test_client_traffic_sensor_name_is_description_name():
+    """Client-traffic sensors always name themselves from the description, not
+    the per-client host-name."""
+    desc = _description(
+        name="WAN TX",
+        data_path="client_traffic",
+        data_reference="mac-address",
+        data_name="host-name",
+    )
+    data = {
+        "client_traffic": {
+            "AA:BB:CC:DD:EE:FF": {"host-name": "MyPC", "wan-tx": 1000},
+        }
+    }
+    sensor = _build_sensor(data, desc, cls=MikrotikClientTrafficSensor, uid="AA:BB:CC:DD:EE:FF")
+    assert sensor.custom_name == "WAN TX"
 
 
 # ---------------------------------------------------------------------------
-# DHCP Client Sensors
+# DHCP client sensors
 # ---------------------------------------------------------------------------
 
 
-class TestDHCPClientSensors:
-    def test_dhcp_status_sensor_value(self):
-        coord = make_mock_coordinator()
-        coord.data["dhcp-client"] = {
+@pytest.fixture
+def dhcp_client_data():
+    """A single bound DHCP client lease, shared across the cases below."""
+    return {
+        "dhcp-client": {
             "ether1": {
                 "interface": "ether1",
                 "status": "bound",
@@ -168,42 +201,25 @@ class TestDHCPClientSensors:
                 "comment": "",
             }
         }
-        entity = _make_sensor(
-            coordinator=coord,
-            desc_overrides={
-                "data_path": "dhcp-client",
-                "data_attribute": "status",
-                "data_name": "interface",
-                "data_uid": "interface",
-                "data_reference": "interface",
-            },
-            uid="ether1",
-        )
-        assert entity.native_value == "bound"
+    }
 
-    def test_dhcp_address_sensor_value(self):
-        coord = make_mock_coordinator()
-        coord.data["dhcp-client"] = {
-            "ether1": {
-                "interface": "ether1",
-                "status": "bound",
-                "address": "10.0.0.5/24",
-                "gateway": "10.0.0.1",
-                "dns-server": "8.8.8.8",
-                "dhcp-server": "10.0.0.1",
-                "expires-after": "23:45:00",
-                "comment": "",
-            }
-        }
-        entity = _make_sensor(
-            coordinator=coord,
-            desc_overrides={
-                "data_path": "dhcp-client",
-                "data_attribute": "address",
-                "data_name": "interface",
-                "data_uid": "interface",
-                "data_reference": "interface",
-            },
-            uid="ether1",
-        )
-        assert entity.native_value == "10.0.0.5/24"
+
+@pytest.mark.parametrize(
+    "attribute, expected",
+    [
+        ("status", "bound"),
+        ("address", "10.0.0.5/24"),
+        ("gateway", "10.0.0.1"),
+        ("dns-server", "8.8.8.8"),
+    ],
+)
+def test_dhcp_client_sensor_reads_attribute(dhcp_client_data, attribute, expected):
+    desc = _description(
+        data_path="dhcp-client",
+        data_attribute=attribute,
+        data_name="interface",
+        data_uid="interface",
+        data_reference="interface",
+    )
+    sensor = _build_sensor(dhcp_client_data, desc, uid="ether1")
+    assert sensor.native_value == expected


### PR DESCRIPTION
## Summary
Rewrites `tests/test_sensor.py` as the **reference implementation** for the test-suite review — the pattern the other modules get migrated to (`ENH-260608-test-suite-hardening`).

- local `MagicMock(spec=MikrotikCoordinator)` + the **real** `MikrotikSensorEntityDescription` — typos/renames now fail instead of yes-manning a Mock
- `@pytest.mark.parametrize` for the native_value / unit-of-measurement / DHCP cases
- a `dhcp_client_data` fixture; **set inputs (`coordinator.data`), assert outputs (`native_value`)**
- 12 cases (was 10), ~half the per-case code

Background + the full findings: `docs/internal/test-suite-review-2026-06-08.md`.

## Post-Deploy Actions
- None (test-only).

## Test Plan
- [x] 595 passed, 5 skipped — devbox `python:3.13`, clean `__pycache__`
- [x] Ruff clean
- [x] code-review: clean — coverage preserved + extended (10→12), no false passes, spec'd mocks verified
- [x] Conftest `make_mock_*` left intact (7 other modules still import them) — migrating those is the next tracked pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)