### PR TITLE
chore: release v2.3.19 (version bump + What's New)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
+## What's New — v2.3.19
+
+Internal reliability and Home Assistant best-practice (Integration Quality Scale) work — no new entities or user-facing behaviour changes.
+
+- Runtime state is now stored on Home Assistant's typed `ConfigEntry.runtime_data` instead of a global dict, so config-entry reloads and unloads are cleaner ([ADR-012](docs/decisions/ADR-012-config-entry-runtime-data.md)).
+- Each platform declares its update concurrency (`PARALLEL_UPDATES`).
+- The `cleanup_entities` / `cleanup_stale_hosts` services now distinguish "entry not found" from "entry not loaded" in their errors.
+- Test-suite quality improvements (no shipped behaviour change).
+
 ## What's New — v2.3.18
 
 CAPsMAN now works on RouterOS 7.13+ devices that still run the legacy `wireless` package. Wireless clients on those setups weren't being detected before; they are now.

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -13,5 +13,5 @@
         "librouteros>=3.4.1,<4.0",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.18"
+    "version": "2.3.19"
 }

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,32 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260608-release-v2.3.19 — version bump + What's New for the v2.3.19 stable release
+
+**Date:** 2026-06-08
+**Branch:** `chore/release-v2.3.19` → PR to `dev` (DRAFT — hold until `v2.3.19-beta.1` validates)
+**Status:** Draft
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `custom_components/mikrotik_router/manifest.json` | Version `2.3.18 → 2.3.19`. |
+| `info.md`, `README.md` | v2.3.19 "What's New" — honest framing: internal reliability + HA Quality-Scale conformance, no new entities / user-facing behaviour. |
+
+### Why
+
+Stable release-prep for the conformance line already on `dev` (runtime-data CR-260608-runtime-data / ADR-012, parallel-updates CR-260608-parallel-updates, test-sensor-exemplar). Cut as a **draft** so the manifest bump lands only after `v2.3.19-beta.1` (cut from `dev`, manifest still 2.3.18 per the beta convention) is validated.
+
+### Release sequence (fire when beta validates)
+
+1. Mark this PR ready → merge to `dev` (manifest on `dev` becomes 2.3.19).
+2. Merge `dev → master` with a **real merge commit** (keeps `dev ⊇ master`; per ISS-260608 sync rule).
+3. Create a GitHub Release, tag **`v2.3.19`**, target `master`, **not** pre-release → `release.yml` builds + attaches `mikrotik_router.zip`.
+4. HACS serves `v2.3.19` as the stable version.
+
+---
+
 ## CR-260608-test-sensor-exemplar — rework test_sensor.py as the test-quality reference
 
 **Date:** 2026-06-08

--- a/info.md
+++ b/info.md
@@ -10,6 +10,9 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
+### What's new in v2.3.19
+- **Reliability & Home Assistant best-practice conformance** — internal change, no new entities or behaviour. The integration now stores its runtime state on Home Assistant's typed config-entry storage and declares per-platform update concurrency, bringing it in line with the HA Integration Quality Scale. Reloads and unloads are cleaner, and the `cleanup_entities` / `cleanup_stale_hosts` services give clearer errors when an entry isn't loaded.
+
 ### What's new in v2.3.18
 - **CAPsMAN now works on legacy-wireless routers** — RouterOS 7.13+ devices still running the legacy `wireless` package weren't detecting CAPsMAN wireless clients. Fixed. Addresses #68.
 - **See which AP a wireless client is on** — new `capsman-interface` attribute on device trackers (e.g. `Slaapkamer`), useful for per-room automations. Works even when DHCP/ARP claimed the host first. Existing `interface` / `source` attributes unchanged.


### PR DESCRIPTION
## Summary
**DRAFT — hold until `v2.3.19-beta.1` validates.** Stable release-prep for the conformance work already merged to `dev`.

- `manifest.json`: `2.3.18 → 2.3.19`
- `info.md` / `README.md`: v2.3.19 "What's New" (honest: internal reliability + HA Quality-Scale conformance, **no new entities / user-facing behaviour**)
- CR-260608-release-v2.3.19

## What v2.3.19 contains (vs v2.3.18)
- typed `ConfigEntry.runtime_data` (ADR-012) · `PARALLEL_UPDATES` per platform · clearer cleanup-service errors · test-suite quality · dev↔master reconciliation

## Fire sequence (when beta is validated)
1. Mark this PR **ready** → merge to `dev`
2. Merge `dev → master` with a **real merge commit** (keeps `dev ⊇ master`, per ISS-260608)
3. GitHub Release, tag **`v2.3.19`**, target `master`, **not** pre-release → `release.yml` builds `mikrotik_router.zip`
4. HACS serves `v2.3.19` stable

## Test Plan
- Validate `v2.3.19-beta.1` in HA first (setup / reload / unload / cleanup services). No code changes in this PR beyond the version string + notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)