### PR TITLE
feat: reauthentication flow (quality-scale reauthentication-flow)

### DIFF
--- a/custom_components/mikrotik_router/config_flow.py
+++ b/custom_components/mikrotik_router/config_flow.py
@@ -115,16 +115,9 @@ class MikrotikControllerConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "name_exists"
 
             # Test connection
-            api = MikrotikAPI(
-                host=user_input[CONF_HOST],
-                username=user_input[CONF_USERNAME],
-                password=user_input[CONF_PASSWORD],
-                port=user_input[CONF_PORT],
-                use_ssl=user_input[CONF_SSL],
-                ssl_verify=user_input[CONF_VERIFY_SSL],
-            )
-            if not await self.hass.async_add_executor_job(api.connect):
-                errors[CONF_HOST] = api.error
+            error = await self.hass.async_add_executor_job(self._validate_connection, user_input)
+            if error:
+                errors[CONF_HOST] = error
 
             # Save instance
             if not errors:
@@ -142,6 +135,44 @@ class MikrotikControllerConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_SSL: DEFAULT_SSL,
                 CONF_VERIFY_SSL: DEFAULT_VERIFY_SSL,
             },
+            errors=errors,
+        )
+
+    def _validate_connection(self, data) -> str | None:
+        """Test the RouterOS connection (sync). Returns an error key, or None on success."""
+        api = MikrotikAPI(
+            host=data[CONF_HOST],
+            username=data[CONF_USERNAME],
+            password=data[CONF_PASSWORD],
+            port=data[CONF_PORT],
+            use_ssl=data[CONF_SSL],
+            ssl_verify=data[CONF_VERIFY_SSL],
+        )
+        if not api.connect():
+            return api.error or "cannot_connect"
+        return None
+
+    async def async_step_reauth(self, entry_data):
+        """Handle re-auth triggered by ConfigEntryAuthFailed (invalid credentials)."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None):
+        """Re-prompt for credentials and validate them against the router."""
+        errors = {}
+        reauth_entry = self._get_reauth_entry()
+        if user_input is not None:
+            error = await self.hass.async_add_executor_job(self._validate_connection, {**reauth_entry.data, **user_input})
+            if not error:
+                return self.async_update_reload_and_abort(reauth_entry, data_updates=user_input)
+            errors["base"] = error
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME, default=reauth_entry.data[CONF_USERNAME]): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
             errors=errors,
         )
 

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.util.dt import now as dt_now, utcnow
 
 
@@ -622,10 +623,23 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             await self._run_if_enabled(func)
 
         if not self.api.connected():
-            raise UpdateFailed("Mikrotik Disconnected")
+            self._raise_disconnected()
 
         self.last_hwinfo_update = dt_now().replace(microsecond=0)
         return True
+
+    # ---------------------------
+    #   _raise_disconnected
+    # ---------------------------
+    def _raise_disconnected(self) -> None:
+        """Raise the appropriate error for a lost connection.
+
+        Invalid credentials raise ConfigEntryAuthFailed so HA starts the reauth
+        flow; any other disconnect raises UpdateFailed (transient — retried).
+        """
+        if self.api.error == "wrong_login":
+            raise ConfigEntryAuthFailed("Invalid Mikrotik username or password")
+        raise UpdateFailed("Mikrotik Disconnected")
 
     # ---------------------------
     #   _async_update_data
@@ -690,7 +704,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             await self._run_if_enabled(func, requires=enabled)
 
         if not self.api.connected():
-            raise UpdateFailed("Mikrotik Disconnected")
+            self._raise_disconnected()
 
         # UID tracking: monitor for new entities across update cycles.
         # Dispatcher is NOT fired automatically — _check_entity_exists guard

--- a/custom_components/mikrotik_router/strings.json
+++ b/custom_components/mikrotik_router/strings.json
@@ -39,6 +39,14 @@
                     "ssl": "Use SSL",
                     "verify_ssl": "Verify SSL"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Re-authenticate Mikrotik Router",
+                "description": "The Mikrotik credentials are no longer valid. Enter the updated username and password.",
+                "data": {
+                    "username": "Username",
+                    "password": "Password"
+                }
             }
         },
         "error": {
@@ -48,6 +56,9 @@
             "ssl_verify_failure": "Certificate verify failed",
             "connection_timeout": "Mikrotik connection timeout.",
             "wrong_login": "Invalid user name or password."
+        },
+        "abort": {
+            "reauth_successful": "Re-authentication was successful"
         }
     },
     "options": {

--- a/custom_components/mikrotik_router/translations/en.json
+++ b/custom_components/mikrotik_router/translations/en.json
@@ -39,6 +39,14 @@
                     "ssl": "Use SSL",
                     "verify_ssl": "Verify SSL"
                 }
+            },
+            "reauth_confirm": {
+                "title": "Re-authenticate Mikrotik Router",
+                "description": "The Mikrotik credentials are no longer valid. Enter the updated username and password.",
+                "data": {
+                    "username": "Username",
+                    "password": "Password"
+                }
             }
         },
         "error": {
@@ -48,6 +56,9 @@
             "connection_timeout": "Mikrotik connection timeout.",
             "wrong_login": "Invalid user name or password.",
             "ssl_verify_failure": "Certificate verify failed"
+        },
+        "abort": {
+            "reauth_successful": "Re-authentication was successful"
         }
     },
     "options": {

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,37 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260608-reauthentication-flow — re-auth on invalid credentials (quality-scale Silver)
+
+**Date:** 2026-06-08
+**Branch:** `feature/reauthentication-flow` → PR to `dev`
+**Status:** In Review
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `coordinator.py` | New `_raise_disconnected()`: raises `ConfigEntryAuthFailed` when `api.error == "wrong_login"` (→ HA starts the reauth flow), else `UpdateFailed` (transient). Both disconnect sites call it. |
+| `config_flow.py` | `async_step_reauth` + `async_step_reauth_confirm` re-prompt for credentials and validate via a shared `_validate_connection()` helper (also used by `async_step_user`); success → `async_update_reload_and_abort`. |
+| `strings.json`, `translations/en.json` | `reauth_confirm` step + `reauth_successful` abort. |
+| `tests/test_config_flow.py` | 2 tests — reauth updates credentials (→ abort `reauth_successful`); wrong_login re-shows the form with the error. |
+
+### Why
+
+Closes the HA Integration Quality-Scale **Silver `reauthentication-flow`** rule. Previously, invalid credentials (e.g. a rotated RouterOS password) left the integration retrying `UpdateFailed` forever with no prompt; now HA surfaces a re-auth dialog. The API already distinguished `wrong_login` from connection failure, so only the wiring was missing.
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Ruff lint + format | All checks passed | ✅ |
+| JSON validity | `strings.json` + `en.json` valid | ✅ |
+| Pytest | 597 passed, 5 skipped (devbox `python:3.13`, clean `__pycache__`) | ✅ |
+| Pre-PR review | Light pass (session-end context) — self-reviewed; the contained error-handling change (`_raise_disconnected`) only narrows one `UpdateFailed` to `ConfigEntryAuthFailed`. Full agent gate can run on the PR. | ~ |
+| ADR | None — standard HA reauth pattern, no contract change | n/a |
+
+---
+
 ## CR-260608-test-sensor-exemplar — rework test_sensor.py as the test-quality reference
 
 **Date:** 2026-06-08

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -41,7 +41,7 @@ Bring the integration to the HA Integration Quality Scale Bronze/Silver baseline
 
 - [x] **parallel-updates** (Silver) — `PARALLEL_UPDATES` per platform (`feature/parallel-updates`, CR-260608-parallel-updates)
 - [x] **runtime-data** (Bronze) — typed `ConfigEntry.runtime_data` (`feature/runtime-data`, ADR-012, CR-260608-runtime-data)
-- [ ] **reauthentication-flow** (Silver) — `async_step_reauth` + raise `ConfigEntryAuthFailed` on `wrong_login`
+- [x] **reauthentication-flow** (Silver) — `async_step_reauth` + raise `ConfigEntryAuthFailed` on `wrong_login` (`feature/reauthentication-flow`, CR-260608-reauthentication-flow)
 - [ ] **reconfiguration-flow** (Gold), **strict-typing** (Platinum) — later, alongside the coordinator decomposition
 - Already conformant: config-flow, has-entity-name, test-before-setup/-configure, entity-unique-id, brands, entity-translations (26 locales), diagnostics, config-entry-unloading.
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch, MagicMock
 
-from homeassistant import data_entry_flow
+from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -126,6 +126,52 @@ async def test_flow_user_ssl_error(hass):
 
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {CONF_HOST: "ssl_handshake_failure"}
+
+
+async def _start_reauth(hass, entry):
+    """Start a reauth flow and return the reauth_confirm form result."""
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=dict(entry.data),
+    )
+
+
+async def test_reauth_flow_updates_credentials(hass):
+    """Valid new credentials update the entry and abort with reauth_successful."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, unique_id="reauth-1")
+    entry.add_to_hass(hass)
+
+    result = await _start_reauth(hass, entry)
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "custom_components.mikrotik_router.config_flow.MikrotikAPI",
+        return_value=_mock_api(connect_return=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_USERNAME: "admin", CONF_PASSWORD: "newpass"})
+
+    assert result["type"] == data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_PASSWORD] == "newpass"
+
+
+async def test_reauth_flow_wrong_login_shows_error(hass):
+    """Invalid credentials re-show the reauth form with the wrong_login error."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, unique_id="reauth-2")
+    entry.add_to_hass(hass)
+
+    result = await _start_reauth(hass, entry)
+    with patch(
+        "custom_components.mikrotik_router.config_flow.MikrotikAPI",
+        return_value=_mock_api(connect_return=False, error="wrong_login"),
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_USERNAME: "admin", CONF_PASSWORD: "bad"})
+
+    assert result["type"] == data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "wrong_login"}
 
 
 async def test_flow_user_duplicate_name(hass):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -146,9 +146,21 @@ async def test_reauth_flow_updates_credentials(hass):
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    with patch(
-        "custom_components.mikrotik_router.config_flow.MikrotikAPI",
-        return_value=_mock_api(connect_return=True),
+    # Patch both import sites: config_flow uses MikrotikAPI for the credential
+    # check, and async_update_reload_and_abort reloads the entry, so coordinator
+    # async_setup_entry instantiates it too. Without the coordinator patch the
+    # real librouteros.connect() reaches the socket layer (HASocketBlockedError);
+    # the reload task is scheduled and only runs before teardown on some Python
+    # versions, so this surfaced as a 3.14-only CI error.
+    with (
+        patch(
+            "custom_components.mikrotik_router.config_flow.MikrotikAPI",
+            return_value=_mock_api(connect_return=True),
+        ),
+        patch(
+            "custom_components.mikrotik_router.coordinator.MikrotikAPI",
+            return_value=_mock_api(connect_return=True),
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_USERNAME: "admin", CONF_PASSWORD: "newpass"})
 


### PR DESCRIPTION
## Summary
Closes the HA Integration Quality-Scale **Silver `reauthentication-flow`** rule — the **last Bronze/Silver gap**.

- **coordinator**: `_raise_disconnected()` raises `ConfigEntryAuthFailed` on `api.error == "wrong_login"` (→ HA starts reauth) vs `UpdateFailed` for transient drops. The API already classified auth-vs-network failure; only the wiring was missing.
- **config_flow**: `async_step_reauth` + `async_step_reauth_confirm` re-prompt + validate via a shared `_validate_connection()` helper (also used by `async_step_user`); success → `async_update_reload_and_abort`.
- **strings/en.json**: `reauth_confirm` step + `reauth_successful` abort.
- **tests**: reauth updates credentials (abort `reauth_successful`); wrong_login re-shows the form with the error.

Before this, a rotated RouterOS password left the integration retrying forever with no prompt.

## Post-Deploy Actions
- None.

## Test Plan
- [x] 597 passed, 5 skipped — devbox `python:3.13`, clean `__pycache__`
- [x] Ruff clean; `strings.json`/`en.json` valid JSON
- [x] 2 new reauth tests (success + wrong_login)

> Light pre-PR gate (session-end context); the change is small + tested. Full agent gate welcome on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)