### PR TITLE
feat: declare quality_scale silver in manifest

### DIFF
--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -9,6 +9,7 @@
     "documentation": "https://github.com/jnctech/homeassistant-mikrotik_router",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/jnctech/homeassistant-mikrotik_router/issues",
+    "quality_scale": "silver",
     "requirements": [
         "librouteros>=3.4.1,<4.0",
         "mac-vendor-lookup>=0.1.12"

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,25 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260608-declare-quality-scale — declare `quality_scale: silver` in manifest
+
+**Date:** 2026-06-08
+**Branch:** `feature/declare-quality-scale` → PR to `dev`
+**Status:** In Review
+
+### What changed
+- `custom_components/mikrotik_router/manifest.json`: added `"quality_scale": "silver"` (alphabetical key position, between `issue_tracker` and `requirements`).
+
+### Why
+Bronze and Silver Integration Quality Scale rules are met as of the conformance work this session (parallel-updates, runtime-data, reauthentication-flow merged in #84/#85/#89; scorecard reviewed 2026-06-08 — see `ENH-260608-quality-scale-conformance`). Declaring the tier in the manifest records the achieved level.
+
+### Notes / cite-or-null
+- This is a **fork** of the unmaintained `tomaae/homeassistant-mikrotik_router`; the original (not this fork) is the HACS-store-listed copy, so `quality_scale` here is a conformance signal rather than a store gate.
+- hassfest validates the manifest key order and the `quality_scale` value — verified via the `Check hassfest` CI job on this PR. <!-- HASSFEST-STATUS -->
+- Remaining tiers (Gold `reconfiguration-flow`, Platinum `strict-typing`) are tracked under the conformance ENH, to land with the coordinator decomposition.
+
+---
+
 ## CR-260608-reauthentication-flow — re-auth on invalid credentials (quality-scale Silver)
 
 **Date:** 2026-06-08

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -18,7 +18,7 @@ Bronze and Silver Integration Quality Scale rules are met as of the conformance 
 
 ### Notes / cite-or-null
 - This is a **fork** of the unmaintained `tomaae/homeassistant-mikrotik_router`; the original (not this fork) is the HACS-store-listed copy, so `quality_scale` here is a conformance signal rather than a store gate.
-- hassfest validates the manifest key order and the `quality_scale` value — verified via the `Check hassfest` CI job on this PR. <!-- HASSFEST-STATUS -->
+- hassfest validates the manifest key order and the `quality_scale` value — **verified PASS** via the `Check hassfest` CI job on PR #91 (run 27123239920). No `quality_scale.yaml` rules file is required for this custom integration.
 - Remaining tiers (Gold `reconfiguration-flow`, Platinum `strict-typing`) are tracked under the conformance ENH, to land with the coordinator decomposition.
 
 ---

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -42,10 +42,11 @@ Bring the integration to the HA Integration Quality Scale Bronze/Silver baseline
 - [x] **parallel-updates** (Silver) — `PARALLEL_UPDATES` per platform (`feature/parallel-updates`, CR-260608-parallel-updates)
 - [x] **runtime-data** (Bronze) — typed `ConfigEntry.runtime_data` (`feature/runtime-data`, ADR-012, CR-260608-runtime-data)
 - [x] **reauthentication-flow** (Silver) — `async_step_reauth` + raise `ConfigEntryAuthFailed` on `wrong_login` (`feature/reauthentication-flow`, CR-260608-reauthentication-flow)
+- [x] **declare `quality_scale`** — `"quality_scale": "silver"` in `manifest.json` now that Bronze+Silver are met (`feature/declare-quality-scale`, CR-260608-declare-quality-scale)
 - [ ] **reconfiguration-flow** (Gold), **strict-typing** (Platinum) — later, alongside the coordinator decomposition
 - Already conformant: config-flow, has-entity-name, test-before-setup/-configure, entity-unique-id, brands, entity-translations (26 locales), diagnostics, config-entry-unloading.
 
-After Bronze+Silver are met, declare `quality_scale` in `manifest.json`.
+Bronze+Silver met and declared (`quality_scale: silver`). Remaining tiers (Gold reconfiguration-flow, Platinum strict-typing) tracked above.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `"quality_scale": "silver"` to `manifest.json` now that all Bronze and Silver Integration Quality Scale rules are met (parallel-updates #84, runtime-data #85, reauthentication-flow #89; scorecard reviewed 2026-06-08).
- Ticks the declare item under `ENH-260608-quality-scale-conformance` and files `CR-260608-declare-quality-scale`.

## Context
This is a fork of the unmaintained `tomaae/homeassistant-mikrotik_router`; the original (not this fork) is the HACS-store-listed copy, so `quality_scale` here records the achieved conformance level rather than gating a store listing.

## Test Plan
- [ ] `Check hassfest` CI job passes (validates manifest key order + the quality_scale value)
- [ ] Remaining Gold/Platinum tiers stay tracked under the conformance ENH

🤖 Generated with [Claude Code](https://claude.com/claude-code)