### PR TITLE
ci: harden actionlint step against transient 504s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,10 +202,20 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: "1.7.7"
+          # sha256 of actionlint_1.7.7_linux_amd64.tar.gz from the official release checksums
+          ACTIONLINT_SHA256: "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
         run: |
+          set -euo pipefail
+          # Download to a file (not a pipe) so --retry can recover from transient
+          # GitHub CDN 504s; verify the pinned checksum before extracting.
           curl -sSfL --proto-redir -all,https \
-            https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz \
-            | tar -xz actionlint
+            --retry 5 --retry-delay 3 --retry-all-errors --retry-connrefused \
+            -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
           ./actionlint -color
 
   secrets:

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,21 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260608-actionlint-pin-retry — harden the actionlint CI step against transient 504s
+
+**Date:** 2026-06-08
+**Branch:** `ci/actionlint-pin-retry` → PR to `dev`
+**Status:** In Review
+
+### What changed
+- `.github/workflows/ci.yml` `lint-actions` job: the actionlint binary was downloaded via `curl … | tar -xz` (a pipe, no retry). A GitHub CDN **504** corrupted the stream and failed the job — observed on multiple pushes 2026-06-08, each needing a manual re-run.
+- Now: download to a file with `curl --retry 5 --retry-delay 3 --retry-all-errors --retry-connrefused`, verify the **pinned SHA256** (`023070a…0757` for `actionlint_1.7.7_linux_amd64.tar.gz`, from the official release checksums), then extract. `set -euo pipefail` so any step fails loudly.
+
+### Why
+Transient registry/CDN errors were turning a deterministic lint into a flaky gate. Retries recover from the 504; the checksum keeps the supply-chain posture consistent with the repo's SHA-pinned `uses:` actions.
+
+---
+
 ## CR-260608-declare-quality-scale — declare `quality_scale: silver` in manifest
 
 **Date:** 2026-06-08


### PR DESCRIPTION
## Summary
The `lint-actions` job downloaded the actionlint binary via `curl … | tar -xz` (a pipe, no retry). A GitHub CDN **504** corrupts the stream and fails the job — seen on several pushes 2026-06-08, each needing a manual re-run.

## What changed
- Download to a file with `curl --retry 5 --retry-delay 3 --retry-all-errors --retry-connrefused` (retries recover from the 504).
- Verify the **pinned SHA256** of `actionlint_1.7.7_linux_amd64.tar.gz` (`023070a…0757`, from the official release checksums) before extracting — keeps the supply-chain posture consistent with the repo's SHA-pinned `uses:` actions.
- `set -euo pipefail` for fail-loud behaviour.

## Test Plan
- [ ] The `GitHub Actions lint (actionlint)` job on this PR passes (and the checksum step prints `OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)