### PR TITLE
test: real-typed entity-description factory (test-hardening pass #1a)

### DIFF
--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,24 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260608-spec-entity-description — real-typed entity-description test factory (test-hardening pass #1a)
+
+**Date:** 2026-06-08
+**Branch:** `test/spec-entity-description` → PR to `dev`
+**Status:** In Review
+
+### What changed
+- `tests/conftest.py::make_mock_entity_description` now builds the **real** `Mikrotik*EntityDescription` dataclass (parameterised by platform `cls`, defaults filtered to the class's fields, overrides passed through) instead of a specless `MagicMock`. A field that doesn't exist on the platform's description now raises `TypeError` rather than silently passing on an auto-created Mock attribute.
+- The 5 non-sensor module helpers (`test_switch/update/binary_sensor/button/device_tracker`) pass their platform description class; `test_entity`'s generic `MikrotikEntity` tests keep the sensor default.
+
+### Why
+T2 in `docs/internal/test-suite-review-2026-06-08.md` — yes-man description mocks hide renamed/removed fields. First slice of `ENH-260608-test-suite-hardening` (pre-release deliverable). Surfaced (and fixed) that the switch/update tests were building sensor-typed descriptions.
+
+### Verification
+Full suite **606 passed, 5 skipped** under `python:3.14` (WSL-local); ruff format + lint clean. The larger `make_mock_coordinator` `spec=` pass (96 sites) is tracked separately under the ENH.
+
+---
+
 ## CR-260608-entity-naming — disambiguate colliding client + DHCP-server entity names (ADR-013)
 
 **Date:** 2026-06-08

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -80,9 +80,9 @@ The suite leans on unspecced `MagicMock` (yes-man) coordinators/descriptions, ne
 
 - [x] `test_sensor.py` — reference implementation (`feature/test-sensor-exemplar`, CR-260608-test-sensor-exemplar)
 - [x] new ADR-013 tests written spec'd (real description dataclass; behaviour assertions) — `feature/entity-naming`
-- [ ] `conftest.py` — add `spec=` to the shared `make_mock_*` factories (highest value; surfaces yes-man passes across all entity tests)
-- [ ] remaining entity test modules (binary_sensor, switch, button, device_tracker, entity, update)
-- [ ] T1 fw-version decoupling, T4 parametrize clusters, T6 fixtures, T3 `make_coordinator` `object.__new__` (last)
+- [x] `conftest.py::make_mock_entity_description` — now builds the **real** `Mikrotik*EntityDescription` per platform (8 sites / 6 modules) so renamed/removed fields fail (`test/spec-entity-description`). Surfaced + fixed the switch/update tests building sensor-typed descriptions.
+- [ ] `conftest.py::make_mock_coordinator` — add `spec=MikrotikCoordinator` (**96 sites / 7 modules** — the big one; will surface yes-man passes; own PR)
+- [ ] remaining: T1 fw-version decoupling, T4 parametrize clusters, T6 fixtures, T3 `make_coordinator` `object.__new__` (last)
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,15 @@
 """Fixtures for Mikrotik Router tests."""
 
+import dataclasses
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from homeassistant.const import CONF_NAME, CONF_HOST
+
+from custom_components.mikrotik_router.sensor_types import (
+    MikrotikSensorEntityDescription,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -18,36 +23,50 @@ def auto_enable_custom_integrations(enable_custom_integrations):
 # ---------------------------------------------------------------------------
 
 
-def make_mock_entity_description(**overrides):
-    """Build a MagicMock entity description with all fields entity.py expects."""
-    desc = MagicMock()
-    defaults = {
-        "key": "test_key",
-        "name": "Test Sensor",
-        "func": "MikrotikSensor",
-        "ha_group": "System",
-        "ha_connection": None,
-        "ha_connection_value": None,
-        "data_path": "interface",
-        "data_attribute": "enabled",
-        "data_name": "name",
-        "data_name_comment": False,
-        "data_name_compose": False,
-        "data_uid": "",
-        "data_reference": "name",
-        "data_attributes_list": [],
-        "data_switch_path": "/interface",
-        "data_switch_parameter": "disabled",
-        "icon_enabled": "mdi:check",
-        "icon_disabled": "mdi:close",
-        "native_unit_of_measurement": None,
-        "suggested_unit_of_measurement": None,
-        "title": "Test",
-    }
-    defaults.update(overrides)
-    for k, v in defaults.items():
-        setattr(desc, k, v)
-    return desc
+# Shared defaults spanning every platform's description. The factory filters
+# these to the fields the chosen class actually declares, so e.g. a switch test
+# can't lean on a sensor-only field.
+_ENTITY_DESC_DEFAULTS = {
+    "key": "test_key",
+    "name": "Test Sensor",
+    "func": "MikrotikSensor",
+    "ha_group": "System",
+    "ha_connection": None,
+    "ha_connection_value": None,
+    "data_path": "interface",
+    "data_attribute": "enabled",
+    "data_name": "name",
+    "data_name_comment": False,
+    "data_name_compose": False,
+    "data_uid": "",
+    "data_reference": "name",
+    "data_attributes_list": [],
+    "data_switch_path": "/interface",
+    "data_switch_parameter": "disabled",
+    "icon_enabled": "mdi:check",
+    "icon_disabled": "mdi:close",
+    "native_unit_of_measurement": None,
+    "suggested_unit_of_measurement": None,
+}
+
+
+def make_mock_entity_description(cls=MikrotikSensorEntityDescription, **overrides):
+    """Build a REAL Mikrotik*EntityDescription of the given platform type.
+
+    Unlike the old yes-man MagicMock (which returned a truthy Mock for *any*
+    attribute, hiding renamed/removed fields), this constructs the real frozen-ish
+    dataclass. Shared defaults are filtered to the fields the class declares;
+    overrides are passed straight through, so a field that does not exist on `cls`
+    raises TypeError — surfacing a test coupled to the wrong platform's description.
+
+    Pass `cls=` the platform description under test (e.g.
+    MikrotikSwitchEntityDescription for switch tests).
+    """
+    valid = {f.name for f in dataclasses.fields(cls)}
+    fields = {k: v for k, v in _ENTITY_DESC_DEFAULTS.items() if k in valid}
+    fields.update(overrides)
+    fields.setdefault("key", "test_key")
+    return cls(**fields)
 
 
 def make_mock_coordinator(data=None, options=None, name="TestRouter", host="10.0.0.1"):

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -6,6 +6,9 @@ from custom_components.mikrotik_router.binary_sensor import (
     MikrotikPortBinarySensor,
 )
 from custom_components.mikrotik_router.const import CONF_SENSOR_PPP
+from custom_components.mikrotik_router.binary_sensor_types import (
+    MikrotikBinarySensorEntityDescription,
+)
 
 from .conftest import (
     make_mock_coordinator,
@@ -16,7 +19,7 @@ from .conftest import (
 
 def _make_binary_sensor(cls=MikrotikBinarySensor, coordinator=None, desc_overrides=None, uid=None):
     coord = coordinator or make_mock_coordinator()
-    desc = make_mock_entity_description(**(desc_overrides or {}))
+    desc = make_mock_entity_description(cls=MikrotikBinarySensorEntityDescription, **(desc_overrides or {}))
     with patch_coordinator_entity_init():
         entity = cls(coord, desc, uid)
     return entity

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -9,6 +9,9 @@ from custom_components.mikrotik_router.button import (
     MikrotikScriptButton,
 )
 from custom_components.mikrotik_router.exceptions import ApiEntryNotFound
+from custom_components.mikrotik_router.button_types import (
+    MikrotikButtonEntityDescription,
+)
 
 from .conftest import (
     make_mock_coordinator,
@@ -19,7 +22,7 @@ from .conftest import (
 
 def _make_button(cls=MikrotikButton, coordinator=None, desc_overrides=None, uid=None):
     coord = coordinator or make_mock_coordinator()
-    desc = make_mock_entity_description(**(desc_overrides or {}))
+    desc = make_mock_entity_description(cls=MikrotikButtonEntityDescription, **(desc_overrides or {}))
     with patch_coordinator_entity_init():
         entity = cls(coord, desc, uid)
     entity.hass = MagicMock()

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -13,6 +13,9 @@ from custom_components.mikrotik_router.const import (
     CONF_TRACK_HOSTS,
     CONF_TRACK_HOSTS_TIMEOUT,
 )
+from custom_components.mikrotik_router.device_tracker_types import (
+    MikrotikDeviceTrackerEntityDescription,
+)
 
 from .conftest import (
     make_mock_coordinator,
@@ -23,7 +26,7 @@ from .conftest import (
 
 def _make_tracker(cls=MikrotikDeviceTracker, coordinator=None, desc_overrides=None, uid=None):
     coord = coordinator or make_mock_coordinator()
-    desc = make_mock_entity_description(**(desc_overrides or {}))
+    desc = make_mock_entity_description(cls=MikrotikDeviceTrackerEntityDescription, **(desc_overrides or {}))
     with patch_coordinator_entity_init():
         entity = cls(coord, desc, uid)
     return entity

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -15,6 +15,10 @@ from custom_components.mikrotik_router.switch import (
     MikrotikContainerSwitch,
 )
 
+from custom_components.mikrotik_router.switch_types import (
+    MikrotikSwitchEntityDescription,
+)
+
 from .conftest import (
     make_mock_coordinator,
     make_mock_entity_description,
@@ -24,7 +28,7 @@ from .conftest import (
 
 def _make_switch(cls=MikrotikSwitch, coordinator=None, desc_overrides=None, uid=None):
     coord = coordinator or make_mock_coordinator()
-    desc = make_mock_entity_description(**(desc_overrides or {}))
+    desc = make_mock_entity_description(cls=MikrotikSwitchEntityDescription, **(desc_overrides or {}))
     with patch_coordinator_entity_init():
         entity = cls(coord, desc, uid)
     entity.hass = MagicMock()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -12,6 +12,10 @@ from custom_components.mikrotik_router.update import (
     decrement_version,
 )
 
+from custom_components.mikrotik_router.update_types import (
+    MikrotikUpdateEntityDescription,
+)
+
 from .conftest import (
     make_mock_coordinator,
     make_mock_entity_description,
@@ -82,7 +86,7 @@ class TestGenerateVersionList:
 
 def _make_update_entity(cls=MikrotikRouterOSUpdate, coordinator=None, desc_overrides=None, uid=None):
     coord = coordinator or make_mock_coordinator()
-    desc = make_mock_entity_description(**(desc_overrides or {}))
+    desc = make_mock_entity_description(cls=MikrotikUpdateEntityDescription, **(desc_overrides or {}))
     with patch_coordinator_entity_init():
         entity = cls(coord, desc, uid)
     entity.hass = MagicMock()


### PR DESCRIPTION
## Summary
First slice of **ENH-260608-test-suite-hardening** (pre-release deliverable). Replaces the yes-man `make_mock_entity_description` MagicMock (T2 in the test-suite review) with one that builds the **real** `Mikrotik*EntityDescription` dataclass.

- Factory is parameterised by platform `cls`; shared defaults are filtered to that class's fields; overrides pass through → a field absent on the platform's description raises `TypeError` instead of silently passing on a Mock auto-attribute.
- Each non-sensor module helper (switch/update/binary_sensor/button/device_tracker) passes its platform description class; `test_entity`'s generic `MikrotikEntity` tests keep the sensor default.
- **Surfaced + fixed:** the switch and update tests were building sensor-typed descriptions (the yes-man let them); now correctly typed.

## Scope
This is the entity-description half of conftest pass #1. The larger `make_mock_coordinator` `spec=` pass (96 sites / 7 modules) is tracked under the ENH as its own PR.

## Verification
Full suite **606 passed, 5 skipped** under python:3.14 (WSL-local); ruff format + lint clean; CI covers 3.13+3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)