### PR TITLE
fix(coordinator): handle unknown firmware version (0) in fw-gated paths (§2.1)

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -520,6 +520,11 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             self._detect_capabilities_v6(packages)
         elif self.major_fw_version >= 7:
             self._detect_capabilities_v7(packages)
+        else:
+            _LOGGER.debug(
+                "Mikrotik %s firmware version unknown (0); skipping capability detection this cycle",
+                self.host,
+            )
 
         for pkg, attr in [
             ("ups", "support_ups"),
@@ -765,6 +770,11 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             await self.hass.async_add_executor_job(self.process_accounting)
         elif self.major_fw_version >= 7:
             await self.hass.async_add_executor_job(self.process_kid_control_devices)
+        else:
+            _LOGGER.debug(
+                "Mikrotik %s firmware version unknown (0); skipping client traffic collection this cycle",
+                self.host,
+            )
 
     def get_access(self) -> None:
         """Get access rights from Mikrotik"""
@@ -1611,7 +1621,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     {"name": "poe-in-current", "default": 0},
                 ],
             )
-        elif 0 < self.major_fw_version >= 7:
+        elif self.major_fw_version >= 7:
             self.ds["health7"] = parse_api(
                 data=self.ds["health7"],
                 source=self.api.query("/system/health"),
@@ -1623,6 +1633,11 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             if self.ds["health7"]:
                 for uid, vals in self.ds["health7"].items():
                     self.ds["health"][uid] = vals["value"]
+        else:
+            _LOGGER.debug(
+                "Mikrotik %s firmware version unknown (0); skipping system health this cycle",
+                self.host,
+            )
 
     # ---------------------------
     #   get_system_resource

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,30 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260608-fw-version-silent-fallthrough — handle unknown firmware version (0) in fw-gated paths (§2.1)
+
+**Date:** 2026-06-08
+**Branch:** `fix/fw-version-silent-fallthrough` → PR to `dev`
+**Status:** In Review
+
+### What changed
+- `coordinator.py` — three `major_fw_version`-gated methods silently no-op'd when the version is `0`; each now has an explicit `else:` that logs at **DEBUG**:
+  - `get_capabilities` (`:519`) — capability detection was skipped, leaving `support_*` flags at defaults silently.
+  - `_async_update_client_traffic` (`:764`) — client-traffic collection was skipped silently.
+  - `get_system_health` (`:1597`) — fixed the malformed chained comparison `elif 0 < self.major_fw_version >= 7` → `elif self.major_fw_version >= 7` (the `0 <` clause was dead; the bug was the `else`-less skip at v0), plus the new `else` log.
+- `tests/test_coordinator.py` — added `major_fw_version=0` cases for all three methods (caplog asserts the no-op is logged and state is unchanged). Existing v7 health tests cover the elif fix.
+
+### Why
+`major_fw_version` initialises to `0` (`coordinator.py:324`) and is only set in `get_firmware_update` (`:1719`), which early-returns for accounts lacking write/policy/reboot and leaves `0` on a firmware-parse failure. So `0` is a real runtime state (primarily read-only accounts), in which capability detection, client-traffic and health silently did nothing with no diagnostic. Resolves `ISS-260608-fw-version-silent-fallthrough` (§2.1).
+
+### Log level
+DEBUG, not WARNING: on a read-only account the version never self-heals, so a per-30s-poll warning would spam. The contributor read-only fw-version fix (#82) addresses the *reachability* at source; this change makes the residual (parse-failure) case observable rather than silent. Coordinated to land alongside #82 in the v2.3.19 roll-up.
+
+### Verification
+Full suite **609 passed, 5 skipped** under `python:3.14` (WSL-local runner on twentyone); ruff lint + format clean (local 0.11.4; CI pins 0.9.0). coordinator-reviewer agent: PASS (one NIT fixed — `@pytest.mark.asyncio` added for consistency). 3.13 leg → CI.
+
+---
+
 ## CR-260608-spec-entity-description — real-typed entity-description test factory (test-hardening pass #1a)
 
 **Date:** 2026-06-08

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -10,7 +10,7 @@
 >
 > **Open threads — the "remaining" for the planning session:**
 > - **`ENH-260608-test-suite-hardening` (HIGH — pre-release deliverable).** Done: `test_sensor.py` (#86), `make_mock_entity_description` real-typed across 6 modules (#95). **Remaining (the big one): `make_mock_coordinator` → `spec=MikrotikCoordinator` — 96 call sites / 7 modules; the review warns it WILL surface real yes-man gaps.** Then T1 fw-version decouple (set `ds["resource"]["version"]`, not `major_fw_version`), T4 parametrize clusters, T6 fixtures, T3 `make_coordinator` `object.__new__` (last/hardest). NOTE: an *older* local branch `feature/test-conftest-coordinator-spec` (`ae1cdde`, unpushed) attempted the coordinator-factory spec early-session — superseded; re-do fresh against current `dev`.
-> - **Code-issue bugs — `refactor-strategy-2026-06-08.md` §2.1, VERIFIED, still NOT filed/fixed.** Silent fall-throughs (no `else`, silently no-op at `major_fw_version == 0`): `coordinator.py:518` (`get_capabilities`), `:750` (`_async_update_client_traffic`), `:1583/1600` (`get_system_health`; the `elif 0 < self.major_fw_version >= 7` is malformed). File an ENH + fix (add `else`/log). Also §2.1: dual-writer temporal coupling, duplicated fw-version regex, bare `except` in `_resolve_manufacturer`/`update.py`, magic RouterOS path literals. (Line numbers predate #94 — re-confirm before fixing.)
+> - **Code-issue bugs — §2.1.** Silent fall-throughs (no `else`, silently no-op at `major_fw_version == 0`): **FILED + FIXED** as `ISS-260608-fw-version-silent-fallthrough` on branch `fix/fw-version-silent-fallthrough` (re-confirmed current lines `coordinator.py:519/764/1597`; the malformed `elif 0 < self.major_fw_version >= 7` corrected). Remaining §2.1 (NOT yet done): dual-writer temporal coupling, duplicated fw-version regex, bare `except` in `_resolve_manufacturer`/`update.py`, magic RouterOS path literals.
 > - **Gold/Platinum conformance** — `reconfiguration-flow` (Gold) + `strict-typing` (Platinum), alongside the coordinator god-object decomposition (`refactor-strategy-2026-06-08.md` Phase 2).
 > - **`ENH-260608-netwatch-naming` (jnctech #70)** — same mechanism as ADR-013's `data_name_compose`, but needs `get_netwatch` to parse `name` + a name-vs-comment precedence decision. Own PR.
 > - **`ISS-260608-env-sensor-empty-state`** — env sensor returns `''` on empty RouterOS var; return `None`/unavailable.
@@ -35,6 +35,25 @@
 ---
 
 ## Active
+
+### ISS-260608-fw-version-silent-fallthrough — fw-version-gated paths silently no-op at version 0
+**Type:** Bug
+**Priority:** Medium
+**Created:** 2026-06-08
+**Status:** 🟡 In Review — fix in `fix/fw-version-silent-fallthrough` → `dev` (CR-260608-fw-version-silent-fallthrough)
+
+**Symptom:**
+When `major_fw_version` is `0`, three version-gated coordinator methods silently did nothing with no diagnostic log: `get_capabilities` (capability detection skipped → `support_*` flags left at defaults), `_async_update_client_traffic` (client-traffic collection skipped), and `get_system_health` (health skipped). For read-only accounts this is a persistent state, so capsman/wireless/ppp sensors and client-traffic could be silently absent.
+
+**Root cause:**
+`major_fw_version` initialises to `0` (`coordinator.py:324`) and is only set in `get_firmware_update` (`:1719`), which early-returns for accounts lacking write/policy/reboot rights and leaves `0` on a firmware-string parse failure. The three `if 0 < v < 7 / elif v >= 7` chains had no `else`, so version 0 fell through silently. `get_system_health` additionally had a malformed `elif 0 < self.major_fw_version >= 7` (dead `0 <` clause; worked for v7 by accident).
+
+**Fix (§2.1):**
+Add an explicit `else:` to each chain that logs at **DEBUG** ("firmware version unknown (0); skipping … this cycle"); fix the malformed elif to `elif self.major_fw_version >= 7`. DEBUG (not WARNING) because a read-only account never self-heals the version → a per-poll warning would spam; the contributor read-only fw-version fix (#82) addresses the *reachability* at source. Tests: `major_fw_version=0` cases for all three (caplog). Verified 609 passed/5 skipped (py3.14); coordinator-reviewer PASS.
+
+**Related:** #82/#81 (read-only fw-version at source); part of the §2.1 batch (remaining §2.1 items still open — see In-flight).
+
+---
 
 ### ENH-260608-entity-naming — distinct entities collide on friendly names (`_N` entity_id suffixes)
 **Type:** Enhancement (entity naming / quality)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """Unit tests for Mikrotik Router coordinator and apiparser logic."""
 
+import logging
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
@@ -17,6 +18,7 @@ from custom_components.mikrotik_router.coordinator import (
 )
 from custom_components.mikrotik_router.const import (
     CONF_SCAN_INTERVAL,
+    CONF_SENSOR_CLIENT_TRAFFIC,
     CONF_SENSOR_POE,
     CONF_SENSOR_PORT_TRAFFIC,
     CONF_TRACK_IFACE_CLIENTS,
@@ -296,6 +298,19 @@ def test_health_fw7_flattens_name_value_pairs():
     assert coordinator.ds["health"]["temperature"] == 50
     assert coordinator.ds["health"]["voltage"] == pytest.approx(12.1)
     assert coordinator.ds["health"]["poe-in-voltage"] == pytest.approx(48.0)
+
+
+def test_health_v0_unknown_skips_and_logs(caplog):
+    """FW version 0 (unknown): system health is skipped, not silently no-op'd."""
+    coordinator = make_coordinator(major_fw_version=0)
+    coordinator.host = "10.0.0.1"
+
+    with caplog.at_level(logging.DEBUG):
+        coordinator.get_system_health()
+
+    assert coordinator.ds["health"] == {}
+    assert coordinator.ds["health7"] == {}
+    assert "skipping system health" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -3394,6 +3409,47 @@ def test_capabilities_ups_and_gps():
     coordinator.get_capabilities()
     assert coordinator.support_ups is True
     assert coordinator.support_gps is True
+
+
+def test_capabilities_v0_unknown_skips_detection_and_logs(caplog):
+    """FW version 0 (unknown): capability detection is skipped, not silently no-op'd."""
+    coordinator = make_coordinator(major_fw_version=0)
+    coordinator.support_ppp = False
+    coordinator.support_capsman = False
+    coordinator.support_wireless = False
+    coordinator.support_ups = False
+    coordinator.support_gps = False
+    coordinator.host = "10.0.0.1"
+    coordinator._wifimodule = "wireless"
+
+    with caplog.at_level(logging.DEBUG):
+        coordinator.get_capabilities()
+
+    assert coordinator.support_capsman is False
+    assert coordinator.support_wireless is False
+    assert coordinator.support_ppp is False
+    assert coordinator._wifimodule == "wireless"
+    assert "skipping capability detection" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_client_traffic_v0_unknown_skips_and_logs(caplog):
+    """FW version 0 (unknown): client traffic collection is skipped, not silently no-op'd."""
+    coordinator = make_coordinator(
+        major_fw_version=0,
+        options={CONF_SENSOR_CLIENT_TRAFFIC: True},
+    )
+    coordinator.host = "10.0.0.1"
+    coordinator.api = MagicMock()
+    coordinator.api.connected.return_value = True
+    coordinator.hass = MagicMock()
+    coordinator.hass.async_add_executor_job = AsyncMock()
+
+    with caplog.at_level(logging.DEBUG):
+        await coordinator._async_update_client_traffic()
+
+    coordinator.hass.async_add_executor_job.assert_not_called()
+    assert "skipping client traffic collection" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Three `major_fw_version`-gated coordinator methods silently no-op'd when the firmware version is `0`, with no diagnostic. `major_fw_version` inits to `0` (`coordinator.py:324`) and is only set in `get_firmware_update` (`:1719`), which **early-returns for accounts lacking write/policy/reboot** and leaves `0` on a firmware-parse failure — so `0` is a real, persistent runtime state (primarily read-only accounts).

- **`get_capabilities`** (`:519`) — no `else` → capability detection skipped; `support_*` flags silently left at defaults (capsman/wireless/ppp sensors can be absent).
- **`_async_update_client_traffic`** (`:764`) — no `else` → client-traffic collection silently skipped.
- **`get_system_health`** (`:1597`) — malformed `elif 0 < self.major_fw_version >= 7` (dead `0 <` clause; worked for v7 by accident) **plus** no `else` → health silently skipped at v0.

Each chain now has an explicit `else:` that logs at **DEBUG**, and the malformed elif is fixed to `elif self.major_fw_version >= 7`.

### Why DEBUG (not WARNING)
On a read-only account the version never self-heals, so a per-30s-poll WARNING would spam the log. The contributor read-only fw-version fix (#82 / #81, @ahharvey) addresses the **reachability** at source; this PR makes the residual (parse-failure) case **observable** instead of silent. Intended to land alongside #82 in the v2.3.19 roll-up.

## Test Plan
- [x] Added `major_fw_version=0` cases for all three methods (`tests/test_coordinator.py`) asserting via `caplog` that the no-op is logged and state is unchanged.
- [x] Existing v7 health tests (`test_health_fw7_flattens_name_value_pairs`, `test_health_v7_parsing`) cover the elif fix.
- [x] Full suite **609 passed, 5 skipped** under `python:3.14` (WSL2 runner).
- [x] `ruff check` + `ruff format --check` clean (local 0.11.4; CI pins 0.9.0).
- [x] coordinator-reviewer agent: PASS (one NIT fixed — `@pytest.mark.asyncio` added for consistency).
- [ ] CI green on py3.13 + py3.14.

## Tracking
- Closes `ISS-260608-fw-version-silent-fallthrough` (§2.1); `CR-260608-fw-version-silent-fallthrough`.
- Coordinates with #82/#81 (read-only fw-version at source). No ADR (bug fix). No version bump — folds into the v2.3.19 roll-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)