### PR TITLE
test(coordinator): harden #82 read-only fw-version fix (tests + unavailable-version log)

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1725,6 +1725,11 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             return
         full_version = self.ds["resource"].get("version")
         if not full_version or full_version == "unknown":
+            _LOGGER.debug(
+                "Mikrotik %s firmware version unavailable from /system/resource (got %r); capability detection deferred until it is",
+                self.host,
+                full_version,
+            )
             return
         try:
             version = re.sub("[^0-9\\.]", "", full_version.split()[0])

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -24,7 +24,36 @@ Changes listed in reverse chronological order.
 DEBUG, not WARNING: on a read-only account the version never self-heals, so a per-30s-poll warning would spam. The contributor read-only fw-version fix (#82) addresses the *reachability* at source; this change makes the residual (parse-failure) case observable rather than silent. Coordinated to land alongside #82 in the v2.3.19 roll-up.
 
 ### Verification
-Full suite **609 passed, 5 skipped** under `python:3.14` (WSL-local runner on twentyone); ruff lint + format clean (local 0.11.4; CI pins 0.9.0). coordinator-reviewer agent: PASS (one NIT fixed — `@pytest.mark.asyncio` added for consistency). 3.13 leg → CI.
+Full suite **609 passed, 5 skipped** under `python:3.14` (WSL-local runner on twentyone); ruff lint + format clean (local 0.11.4; CI pins 0.9.0). coordinator-reviewer agent: PASS (one NIT fixed — `@pytest.mark.asyncio` added for consistency). 3.13 + 3.14 green in CI (#97).
+
+---
+
+## CR-260608-issue-82-readonly-fw-version — read-only users get capability detection on RouterOS 7.x
+
+**Date:** 2026-06-08
+**Branch:** core fix in PR [#81](https://github.com/jnctech/homeassistant-mikrotik_router/pull/81) (`ahharvey:fix/major-fw-version-readonly-fallback`, **merged to `dev`** via merge commit `3b14465`, authorship preserved); maintainer hardening (tests + log + docs) in `fix/issue-82-hardening` → PR to `dev`.
+**Status:** Core fix merged (#81); hardening In Review. Version bump deferred to the rolled `v2.3.19` release (crediting @ahharvey there).
+
+### What Changed
+
+| Area | Change |
+|------|--------|
+| `coordinator.py` | New `_parse_fw_version_from_resource()` parses `major`/`minor_fw_version` from the read-only `/system/resource.version`, called at the tail of `get_system_resource()`. Self-skips when `major_fw_version > 0`, so `get_firmware_update()` (write-gated) stays authoritative for privileged users. *(ahharvey, #81)* |
+| `coordinator.py` | **Hardening:** DEBUG log when `/system/resource.version` is unavailable/`unknown` — a silent-failure-hunter finding; the falsy/`unknown` early-return otherwise degraded to default capability detection with no log signal. |
+| `tests/test_coordinator.py` | **Hardening:** 7 tests — major/minor parse, bare-major default, privileged self-skip, `unknown`/missing/malformed no-ops, and an end-to-end read-only cascade (wifi-qcom under a `read,api,sensitive` user → `_wifimodule="wifi"`, `support_wireless=True`). |
+| `docs/ISSUES.md` | New `ISS-260608-readonly-capability-detection`. |
+
+### Why
+
+On RouterOS 7.x, `major_fw_version` had only one writer outside `__init__` — `get_firmware_update()`, which early-returns when the user lacks `write`+`policy`+`reboot`. Under a read-only HA user it stayed `0`, so `get_capabilities()` (dispatch gated on `major_fw_version`) never ran: `support_wireless`/`support_capsman`/`support_ppp` kept defaults and `_wifimodule` stayed `"wireless"`, querying `/interface/wireless/registration-table` — which returns `400 "no such command or directory (wireless)"` on wifi-qcom. The current firmware version is read-accessible at `/system/resource.version`, so parsing it there (before `get_capabilities()` in the hwinfo loop) restores detection without granting write access; the `check-for-updates` action and `update.*` entities remain write-gated. Relates to `ISS-260608-fw-version-silent-fallthrough` (§2.1) which makes the *downstream* consumers diagnosable when the version is still unknown.
+
+### Quality Gate Results
+
+| Metric | Value | Gate |
+|--------|-------|------|
+| Pytest | Full suite **613 passed, 5 skipped** under `python:3.14` (WSL2 runner) on the hardening branch (dev + #81 + hardening). | ✅ |
+| Ruff | lint + format clean (local 0.11.4; CI pins 0.9.0). | ✅ |
+| ADR | None — internal version-sourcing change, not a data-format / entity-identity / API-contract change. | n/a |
 
 ---
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -55,6 +55,23 @@ Add an explicit `else:` to each chain that logs at **DEBUG** ("firmware version 
 
 ---
 
+### ISS-260608-readonly-capability-detection — capability detection fails for read-only users on RouterOS 7.x
+**Type:** Bug
+**Priority:** High
+**Created:** 2026-06-08
+**Status:** 🟢 Core fix MERGED to `dev` (PR [#81](https://github.com/jnctech/homeassistant-mikrotik_router/pull/81), @ahharvey, merge `3b14465`). Maintainer hardening (tests + log + docs) In Review in `fix/issue-82-hardening` → `dev`. Ships in the rolled `v2.3.19` release.
+
+**Symptom:**
+On RouterOS 7.x, an integration user without `write`/`policy`/`reboot` permissions silently gets no wireless / CAPsMAN / PPP / per-client-traffic data — e.g. `sensor._wireless_clients` reads `0` with clients connected, and `wifi-qcom` routers are queried on the non-existent `/interface/wireless` endpoint (`400 "no such command or directory (wireless)"`). Reported in [#82](https://github.com/jnctech/homeassistant-mikrotik_router/issues/82) by @ahharvey (hAP ax³ / wifi-qcom, RouterOS 7.22.3).
+
+**Root cause:**
+`major_fw_version` is only parsed inside `get_firmware_update()`, which early-returns under read-only access. It stays `0`, so `get_capabilities()` dispatch (gated on `major_fw_version`) never runs and support flags / `_wifimodule` keep their defaults.
+
+**Fix:**
+New `_parse_fw_version_from_resource()` parses the version from the read-only `/system/resource.version` at the tail of `get_system_resource()` (runs before `get_capabilities()` in the hwinfo loop). Self-skips when `major_fw_version > 0`, leaving the privileged `get_firmware_update()` path authoritative. Maintainer hardening adds 7 tests + a DEBUG log on the version-unavailable branch. No ADR (internal sourcing change). Complements `ISS-260608-fw-version-silent-fallthrough` (§2.1, downstream consumers).
+
+---
+
 ### ENH-260608-entity-naming — distinct entities collide on friendly names (`_N` entity_id suffixes)
 **Type:** Enhancement (entity naming / quality)
 **Priority:** Medium

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5098,3 +5098,111 @@ def test_has_wifi_package_disabled_wireless_falls_back_to_version():
     coordinator = _make_v7_coordinator(21)
 
     assert coordinator._has_wifi_package({"wireless": {"enabled": False}}) is True
+
+
+# ---------------------------------------------------------------------------
+# Group: _parse_fw_version_from_resource() — read-side FW version (#82)
+#   Read-only users never reach get_firmware_update() (write+policy+reboot
+#   gated), so major_fw_version must also be parseable from the read-only
+#   /system/resource.version. Without it, get_capabilities() never dispatches
+#   and wireless/CAPsMAN/PPP data stays empty.
+# ---------------------------------------------------------------------------
+
+
+def _resource_coordinator(version, major_fw_version=0):
+    coordinator = make_coordinator(major_fw_version=major_fw_version)
+    coordinator.host = "10.0.0.1"
+    if version is not None:
+        coordinator.ds["resource"]["version"] = version
+    return coordinator
+
+
+def test_parse_fw_version_from_resource_reads_major_minor():
+    """A real /system/resource.version string yields major+minor."""
+    coordinator = _resource_coordinator("7.22.3 (stable)")
+
+    coordinator._parse_fw_version_from_resource()
+
+    assert coordinator.major_fw_version == 7
+    assert coordinator.minor_fw_version == 22
+
+
+def test_parse_fw_version_from_resource_no_minor_defaults_zero():
+    """A bare major version parses with minor defaulting to 0."""
+    coordinator = _resource_coordinator("7")
+
+    coordinator._parse_fw_version_from_resource()
+
+    assert coordinator.major_fw_version == 7
+    assert coordinator.minor_fw_version == 0
+
+
+def test_parse_fw_version_from_resource_self_skips_when_already_set():
+    """get_firmware_update() runs first for privileged users; do not re-parse."""
+    coordinator = _resource_coordinator("6.49.10", major_fw_version=7)
+    coordinator.minor_fw_version = 13
+
+    coordinator._parse_fw_version_from_resource()
+
+    # Authoritative privileged parse is preserved, not overwritten.
+    assert coordinator.major_fw_version == 7
+    assert coordinator.minor_fw_version == 13
+
+
+def test_parse_fw_version_from_resource_unknown_version_is_noop():
+    """The parse_api 'unknown' sentinel must not be parsed as a version."""
+    coordinator = _resource_coordinator("unknown")
+
+    coordinator._parse_fw_version_from_resource()
+
+    assert coordinator.major_fw_version == 0
+
+
+def test_parse_fw_version_from_resource_missing_version_is_noop():
+    """No version key (resource not yet populated) leaves the sentinel intact."""
+    coordinator = _resource_coordinator(None)
+
+    coordinator._parse_fw_version_from_resource()
+
+    assert coordinator.major_fw_version == 0
+
+
+def test_parse_fw_version_from_resource_malformed_is_noop():
+    """A non-numeric version is swallowed without raising or setting a value."""
+    coordinator = _resource_coordinator("garbage")
+
+    coordinator._parse_fw_version_from_resource()
+
+    assert coordinator.major_fw_version == 0
+
+
+def test_readonly_capability_cascade_unblocked_end_to_end():
+    """#82: read-side version parse lets get_capabilities() dispatch on a
+    wifi-qcom router under a user without write/policy/reboot — the helper
+    runs at the tail of get_system_resource(), before get_capabilities()."""
+    coordinator = make_coordinator(
+        major_fw_version=0,
+        api_responses={
+            "/system/package": [
+                {"name": "wifi-qcom", "disabled": False},
+            ],
+        },
+    )
+    coordinator.ds["access"] = ["read", "api", "sensitive"]
+    coordinator.ds["resource"]["version"] = "7.22.3 (stable)"
+    coordinator.host = "10.0.0.1"
+    coordinator.support_ppp = False
+    coordinator.support_capsman = False
+    coordinator.support_wireless = False
+    coordinator.support_ups = False
+    coordinator.support_gps = False
+    coordinator._wifimodule = "wireless"
+
+    # Order mirrors _async_update_hwinfo: resource parse, then capabilities.
+    coordinator._parse_fw_version_from_resource()
+    coordinator.get_capabilities()
+
+    assert coordinator.major_fw_version == 7
+    assert coordinator.support_wireless is True
+    assert coordinator._wifimodule == "wifi"
+    assert coordinator.support_capsman is False


### PR DESCRIPTION
## Summary
Maintainer hardening for the read-only firmware-version fix that **landed in #81** (`_parse_fw_version_from_resource()`, @ahharvey, merged to `dev` via `3b14465`). #81 shipped the core fix without test coverage; this PR adds it, plus a small silent-failure log.

- **Tests** (`tests/test_coordinator.py`, 7 cases): major/minor parse, bare-major default, privileged self-skip (`major_fw_version > 0`), `unknown`/missing/malformed no-ops, and an end-to-end read-only cascade (wifi-qcom under a `read,api,sensitive` user → `_wifimodule="wifi"`, `support_wireless=True`).
- **Log** (`coordinator.py`): a `DEBUG` line when `/system/resource.version` is unavailable/`unknown` — a silent-failure-hunter finding; the falsy/`unknown` early-return otherwise degraded to default capability detection with no signal.

## Why separate from #81
#81 was 36 commits behind `dev` and contained only @ahharvey's commit. Merging his fix to `dev` directly (merge, not squash — authorship preserved) kept his PR clean; this PR layers our governance/tests/log on top, clearly attributed.

## Test Plan
- [x] Full suite **613 passed, 5 skipped** under `python:3.14` (WSL2 runner) on `dev + #81 + this`.
- [x] `ruff check` + `ruff format --check` clean (local 0.11.4; CI pins 0.9.0).
- [ ] CI green on py3.13 + py3.14.

## Tracking
- `CR-260608-issue-82-readonly-fw-version`; `ISS-260608-readonly-capability-detection` (core fix 🟢 merged, hardening In Review).
- No version bump — folds into the rolled `v2.3.19` release (crediting @ahharvey). No ADR (internal version-sourcing change).
- Complements `ISS-260608-fw-version-silent-fallthrough` (§2.1, PR #97).

🤖 Generated with [Claude Code](https://claude.com/claude-code)