### PR TITLE
chore(release): v2.3.19-beta.2 pre-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
+## What's New — v2.3.19-beta.2 (pre-release)
+
+A roll-up of the quality-scale and read-only fixes on `dev`, cut as a pre-release for validation before the v2.3.19 stable release. **⚠️ Pre-release — please report any issues on GitHub.**
+
+- **Read-only users now get wireless / CAPsMAN / PPP data.** On RouterOS 7.x, an HA user without `write`/`policy`/`reboot` rights previously saw zero wireless clients because the firmware version (needed for capability detection) was only read on a write-gated path. The version is now read from `/system/resource` as well, so detection works without granting write access. Thanks to @ahharvey for the fix and wifi-qcom testing. Addresses #82.
+- **Reauthentication flow.** If your router credentials change, re-enter them via Home Assistant's standard reauth prompt instead of removing and re-adding the integration.
+- **Cleaner entity names.** Distinct device-trackers and per-VLAN DHCP-server sensors no longer collide into `_2`/`_3` entity IDs (e.g. several devices all reporting the DHCP hostname `lwip0`). `unique_id`s are unchanged, so existing entity IDs and automations are preserved. See [ADR-013](docs/decisions/ADR-013-entity-naming-disambiguation.md).
+- **HA Quality Scale: Silver.** Bronze + Silver tiers met and declared — typed `runtime_data`, per-platform `PARALLEL_UPDATES`, and the reauthentication flow.
+- **More diagnosable firmware detection.** Version-gated polling paths now log at debug instead of silently doing nothing while the firmware version is briefly unknown (§2.1).
+- Internal: test-suite hardening (real-typed test factories) and CI resilience (actionlint retry).
+
 ## What's New — v2.3.18
 
 CAPsMAN now works on RouterOS 7.13+ devices that still run the legacy `wireless` package. Wireless clients on those setups weren't being detected before; they are now.

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -14,5 +14,5 @@
         "librouteros>=3.4.1,<4.0",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.18"
+    "version": "2.3.19-beta.2"
 }

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,24 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260608-release-v2.3.19-beta.2 — pre-release for validation of the v2.3.19 roll-up
+
+**Date:** 2026-06-08
+**Branch:** `chore/release-v2.3.19-beta.2` → PR to `dev`
+**Status:** Pre-release — pre-release tag `v2.3.19-beta.2` cut from `dev` for validation before the stable `v2.3.19` (dev→master).
+
+### What Changed
+- `manifest.json` version `2.3.18 → 2.3.19-beta.2`.
+- `README.md`, `info.md` — `v2.3.19-beta.2` What's New rolling up the cycle's user-facing changes.
+
+### Why
+Cut a pre-release (`v2.3.19-beta.2`) so beta-opted HACS users can validate the rolled `dev` state — read-only fw-version capability detection (#82, @ahharvey), reauthentication flow (#89), entity-naming (#94/ADR-013), `quality_scale: silver`, and the §2.1 fw-version fall-through fixes (#97) — before the stable `v2.3.19` is tagged on `master`. (`v2.3.19-beta.1` was cut and deleted earlier this cycle; this is beta.2.)
+
+### Release ops
+Stable `v2.3.19` will bump `2.3.19-beta.2 → 2.3.19`, merge `dev→master`, and tag on `master` (not pre-release), crediting @ahharvey in the What's New.
+
+---
+
 ## CR-260608-fw-version-silent-fallthrough — handle unknown firmware version (0) in fw-gated paths (§2.1)
 
 **Date:** 2026-06-08

--- a/info.md
+++ b/info.md
@@ -10,6 +10,15 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
+### What's new in v2.3.19-beta.2 (pre-release)
+Rolls up the quality-scale and read-only fixes on `dev` for validation before the v2.3.19 stable release. ⚠️ Pre-release — please report issues on GitHub.
+- **Read-only users now get wireless / CAPsMAN / PPP data** — on RouterOS 7.x, an HA user without write/policy/reboot rights previously saw zero wireless clients. The firmware version is now read from `/system/resource`, so capability detection works without granting write access. Thanks to @ahharvey for the fix and wifi-qcom testing. Addresses #82.
+- **Reauthentication flow** — if your router credentials change, re-enter them via the normal Home Assistant reauth prompt instead of deleting and re-adding the integration.
+- **Cleaner entity names** — distinct device-trackers and per-VLAN DHCP-server sensors no longer collide into `_2`/`_3` names (e.g. several devices all reporting the hostname `lwip0`). `unique_id`s are unchanged, so existing entity IDs and automations are preserved.
+- **HA Quality Scale: Silver** — Bronze + Silver tiers met and declared (typed runtime-data, per-platform parallel updates, reauthentication).
+- **More diagnosable firmware detection** — version-gated polling paths now log at debug instead of silently doing nothing while the firmware version is briefly unknown.
+- Internal: test-suite hardening and CI resilience.
+
 ### What's new in v2.3.18
 - **CAPsMAN now works on legacy-wireless routers** — RouterOS 7.13+ devices still running the legacy `wireless` package weren't detecting CAPsMAN wireless clients. Fixed. Addresses #68.
 - **See which AP a wireless client is on** — new `capsman-interface` attribute on device trackers (e.g. `Slaapkamer`), useful for per-room automations. Works even when DHCP/ARP claimed the host first. Existing `interface` / `source` attributes unchanged.


### PR DESCRIPTION
## Summary
Bumps `manifest.json` to **2.3.19-beta.2** and adds the `v2.3.19-beta.2` What's New to README/info. Pre-release to validate the rolled `dev` state before the stable `v2.3.19` (dev→master).

Rolled changes since v2.3.18: read-only fw-version capability detection (#82, @ahharvey), reauthentication flow (#89), entity-naming disambiguation (#94/ADR-013), `quality_scale: silver`, §2.1 fw-version fall-through fixes (#97), test-hardening + CI resilience.

## After merge
Cut GitHub **pre-release** tag `v2.3.19-beta.2` from `dev` → `release.yml` builds the zip. Stable `v2.3.19` later bumps to the final number + dev→master.

## Test Plan
- [ ] hassfest accepts the `2.3.19-beta.2` version string
- [ ] CI green (py3.13 + 3.14)
- [x] manifest valid JSON; no test asserts the manifest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)