### PR TITLE
fix: environment sensor empty value → None and skip value-less vars (ISS-260608)

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1916,6 +1916,16 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             ],
         )
 
+        # RouterOS global script variables can exist with an empty value (e.g.
+        # defconfMode set by the default-config script). Empty-string is not a
+        # valid HA sensor state — coerce to None so the entity reads "unknown"
+        # rather than "", and so _skip_environment_sensor can drop value-less
+        # variables entirely. See ISS-260608-env-sensor-empty-state.
+        for env in self.ds["environment"].values():
+            value = env.get("value")
+            if value is None or (isinstance(value, str) and value.strip() == ""):
+                env["value"] = None
+
     # ---------------------------
     #   get_captive
     # ---------------------------

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -112,6 +112,7 @@ def _skip_sensor(config_entry, entity_description, data, uid) -> bool:
         or _skip_binary_sensor(config_entry, entity_description, data, uid)
         or _skip_device_tracker(config_entry, entity_description)
         or _skip_poe_sensor(config_entry, entity_description, data, uid)
+        or _skip_environment_sensor(entity_description, data, uid)
     )
 
 
@@ -170,6 +171,23 @@ def _skip_poe_sensor(config_entry, entity_description, data, uid) -> bool:
         return True
 
     return False
+
+
+def _skip_environment_sensor(entity_description, data, uid) -> bool:
+    """Skip environment sensors whose RouterOS variable carries no value.
+
+    `/system/script/environment` lists global script variables, some of which are
+    transient (e.g. ``defconfMode`` set by the default-config script, then cleared)
+    and RAM-only — wiped on reboot. A value-less variable yields a sensor that is
+    empty now and orphaned/unavailable once the variable disappears, so only expose
+    variables that actually hold a value. (get_environment already coerces empty
+    values to None; the string check guards direct/legacy data.)
+    See ISS-260608-env-sensor-empty-state.
+    """
+    if entity_description.data_path != "environment":
+        return False
+    value = data[uid].get(entity_description.data_attribute)
+    return value is None or (isinstance(value, str) and value.strip() == "")
 
 
 # ---------------------------

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,29 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260614-fix-env-sensor-empty-state — environment sensor empty value → None + skip value-less vars
+
+**Date:** 2026-06-14
+**Branch:** `fix/env-sensor-empty-state` → PR to `dev`
+**Status:** In Review (target stable `v2.3.19`)
+
+### What changed
+- `coordinator.py` — `get_environment()` now coerces empty/whitespace variable values to `None` after parsing `/system/script/environment`, so the sensor reads `unknown` instead of the invalid `''` state (incl. when a live entity's variable later empties).
+- `entity.py` — new `_skip_environment_sensor()` wired into `_skip_sensor()`; skips entity creation for value-less environment variables so transient/RAM-only globals don't create orphan-prone entities.
+- `tests/test_coordinator.py` — `test_environment_empty_value_coerced_to_none`.
+- `tests/test_entity.py` — `test_skip_environment_sensor_when_value_none` / `_empty_string` / `_whitespace` / `test_no_skip_environment_sensor_when_value_present`.
+
+### Why
+Resolves `ISS-260608-env-sensor-empty-state`. Confirmed live (2026-06-14) via the `ha-query` MCP + SSH: `sensor.mikrotik_hapax3_environment_defconfmode` was stuck `unavailable`/`restored` because `defconfMode` is a RouterOS global *script* variable — RAM-only, wiped on reboot (hap_ax3 rebooted ~06-13; `/system/script/environment` now empty). Empty-string is not a valid HA state; coercing to `None` fixes the state-convention inconsistency, and skipping value-less variables avoids creating the orphan-prone entity in the first place.
+
+### Verification
+Full pytest suite green: **621 passed, 5 skipped** (py3.14 in Docker on the Ubuntu/WSL2 runner). New tests confirmed collected+passing: `test_environment_empty_value_coerced_to_none` (coordinator) + 4× `test_skip_environment_sensor_*` (entity). `code-simplifier` + `silent-failure-hunter` agents: PASS (no changes recommended). Live behaviour validated via `ha-query` MCP + SSH cross-check (per the internal validation doc `config/docs/internal/2026-06-14-mikrotik-sensor-validation-v2.3.19-beta.2.md`). CI (py3.13 + 3.14) to confirm on push.
+
+### Release ops
+Lands on `dev`; ships in stable `v2.3.19` (no manifest bump in this CR — version bump is the release step `2.3.19-beta.2 → 2.3.19`).
+
+---
+
 ## CR-260608-release-v2.3.19-beta.2 — pre-release for validation of the v2.3.19 roll-up
 
 **Date:** 2026-06-08

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -114,13 +114,18 @@ On networks with many clients or multiple DHCP servers, distinct entities receiv
 **Type:** Bug (state quality)
 **Priority:** Low
 **Created:** 2026-06-08
-**Status:** 🟡 Open
+**Status:** 🟢 Fixed on branch `fix/env-sensor-empty-state` (CR-260614-fix-env-sensor-empty-state) — target v2.3.19
 
 **Symptom:**
 A `*_environment_<name>` sensor reports an empty string (`''`) as its state when the corresponding RouterOS environment variable exists but is empty (observed: `environment_defconfMode`). Empty-string is not a valid HA state convention — HA expects `None` → `unknown`/`unavailable`. On other routers where the same variable has no value the sensor correctly reads `unavailable`, so the behaviour is inconsistent.
 
-**Fix:**
-In the environment sensor's value path, return `None` (or set unavailable) when the variable value is empty/missing, so the entity reports `unknown`/`unavailable` rather than `''`.
+**Root cause (confirmed live 2026-06-14):** `defconfMode` is a RouterOS global *script* variable (`/system/script/environment`) — RAM-only, set by the default-config script and wiped on reboot. SSH to hap_ax3 confirmed the env table is now empty (`env_count=0`; device rebooted ~06-13), so the once-`''` entity is now an orphaned `unavailable`/`restored` registry entry.
+
+**Fix (two parts):**
+- `coordinator.get_environment` coerces empty/whitespace values to `None`, so the entity reads `unknown` rather than `''` (incl. when a live entity's variable later goes empty).
+- `entity._skip_environment_sensor` skips entity creation for value-less variables, so transient/empty globals don't create orphan-prone entities in the first place.
+- Tests: `test_environment_empty_value_coerced_to_none` (coordinator), `test_skip_environment_sensor_*` (entity).
+- Residual: a *pre-existing* orphan entity must be deleted once in HA (no integration auto-removal). The broader "transient non-empty global orphans on reboot" class is out of scope (would need entity cleanup, tracked separately if it recurs).
 
 ---
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2622,6 +2622,28 @@ def test_environment_basic_parsing():
     assert coordinator.ds["environment"]["count"]["value"] == "42"
 
 
+def test_environment_empty_value_coerced_to_none():
+    """Empty / whitespace env values are coerced to None, real values kept.
+
+    Empty-string is not a valid HA sensor state; coercing to None makes the
+    entity read 'unknown' and lets _skip_environment_sensor drop value-less
+    variables. See ISS-260608-env-sensor-empty-state.
+    """
+    coordinator = make_coordinator(
+        api_responses={
+            "/system/script/environment": [
+                {"name": "defconfMode", "value": ""},
+                {"name": "spaced", "value": "   "},
+                {"name": "real", "value": "yes"},
+            ],
+        }
+    )
+    coordinator.get_environment()
+    assert coordinator.ds["environment"]["defconfMode"]["value"] is None
+    assert coordinator.ds["environment"]["spaced"]["value"] is None
+    assert coordinator.ds["environment"]["real"]["value"] == "yes"
+
+
 # ---------------------------------------------------------------------------
 # Group X: get_kidcontrol() — kid control parsing
 # ---------------------------------------------------------------------------

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -462,6 +462,39 @@ def test_skip_host_tracker_when_option_disabled():
 
 
 # ---------------------------------------------------------------------------
+# Environment sensor tests (ISS-260608-env-sensor-empty-state)
+# ---------------------------------------------------------------------------
+
+
+def test_skip_environment_sensor_when_value_none():
+    """Environment sensor is skipped when the variable value is None."""
+    desc = make_entity_desc(data_path="environment", data_attribute="value")
+    data = {"defconfMode": {"value": None}}
+    assert _skip_sensor(make_config_entry(), desc, data, "defconfMode") is True
+
+
+def test_skip_environment_sensor_when_value_empty_string():
+    """Environment sensor is skipped when the variable value is an empty string."""
+    desc = make_entity_desc(data_path="environment", data_attribute="value")
+    data = {"defconfMode": {"value": ""}}
+    assert _skip_sensor(make_config_entry(), desc, data, "defconfMode") is True
+
+
+def test_skip_environment_sensor_when_value_whitespace():
+    """Whitespace-only environment value is treated as empty."""
+    desc = make_entity_desc(data_path="environment", data_attribute="value")
+    data = {"defconfMode": {"value": "   "}}
+    assert _skip_sensor(make_config_entry(), desc, data, "defconfMode") is True
+
+
+def test_no_skip_environment_sensor_when_value_present():
+    """Environment sensor is created when the variable carries a value."""
+    desc = make_entity_desc(data_path="environment", data_attribute="value")
+    data = {"myVar": {"value": "yes"}}
+    assert _skip_sensor(make_config_entry(), desc, data, "myVar") is False
+
+
+# ---------------------------------------------------------------------------
 # PoE sensor tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Fixes the environment sensor reporting an invalid empty-string (`''`) state and leaving orphaned `unavailable`/`restored` entities. Resolves `ISS-260608-env-sensor-empty-state`. Target: stable **v2.3.19**.
- **`coordinator.get_environment()`** now coerces empty/whitespace variable values to `None` after `parse_api`, so the entity reads `unknown` instead of `''` — including when a live entity's variable later empties.
- **`entity._skip_environment_sensor()`** (wired into `_skip_sensor()`) skips entity creation for value-less variables, so transient/RAM-only globals don't create orphan-prone entities in the first place. Mirrors the sibling `_skip_poe_sensor` pattern.

## Root cause (confirmed live 2026-06-14)
`defconfMode` is a RouterOS global **script** variable (`/system/script/environment`) — RAM-only, set by the default-config script and wiped on reboot. SSH to the hAP ax³ confirmed the env table is now empty (`env_count=0`; device rebooted ~06-13), so the once-`''` entity became an orphaned registry entry. Empty-string isn't a valid HA state; coercing to `None` fixes the state-convention inconsistency, and skipping value-less vars avoids creating the entity at all.

## Post-Deploy Actions
- The **pre-existing orphan** entity (e.g. `sensor.mikrotik_hapax3_environment_defconfmode`) must be **deleted once manually** in HA — no code auto-removes an already-registered entity.

## Test Plan
- [x] Full suite green: **621 passed, 5 skipped** (py3.14, Docker).
- [x] New: `test_environment_empty_value_coerced_to_none` (coordinator); `test_skip_environment_sensor_when_value_none` / `_empty_string` / `_whitespace` / `test_no_skip_environment_sensor_when_value_present` (entity).
- [x] `code-simplifier` + `silent-failure-hunter` reviews: no changes recommended.
- [ ] CI green (py3.13 + 3.14).

Tracking: `ISS-260608-env-sensor-empty-state`, `CR-260614-fix-env-sensor-empty-state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)