### PR TITLE
docs: release validation playbook + review gates

### DIFF
--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -31,6 +31,41 @@
 - **Coverage:** platform wiring files, pure data descriptors, const, exceptions
 - **CPD:** `sensor_types.py`, `coordinator.py`, `tests/` (intentional structural repetition)
 
+## Review Gates
+
+Beyond the mechanical CI gates above, non-trivial changes go through structured
+review before merge. These are process gates (reviewer-run), not CI-enforced.
+
+### Multi-agent audit panels (design & diagnosis)
+
+For non-trivial work — new features, bug root-causing, architectural decisions — the
+change is reasoned through a multi-perspective panel before/with implementation:
+
+- **Recon** — read the actual source; establish the facts.
+- **Review** — assess the approach against existing patterns and ADRs.
+- **Junior-dev questions** — surface the clarifying questions an implementer would ask.
+- **Senior-dev challenge** — adversarially attack the proposal: edge cases, the
+  load-bearing assumption, simpler alternatives.
+
+Governing rule: **cite-or-null** — every factual claim about the code cites its source
+(`file:line`, command/tool output) or is explicitly marked UNVERIFIED. Unknowns are
+reported, never resolved with a plausible guess.
+
+### Specialized review passes (pre-PR)
+
+Changed code is run through focused review agents (see the Pre-PR Checklist):
+
+- **Simplification** (`/simplify`) — clarity, reuse, consistency; no behaviour change.
+- **Silent-failure hunt** — swallowed errors, inadequate fallbacks, masked failures.
+- **Code review** — adherence to the coding standards, ADRs, and project patterns.
+- **Domain reviewer** — `coordinator.py` changes also get the committed
+  `coordinator-reviewer` agent (ADR-010): helper-extraction (ADR-007), attribute
+  filtering (ADR-009), lock discipline, async patterns, UID stability.
+
+Other passes used when relevant: comment-accuracy, type-design, and PR test-coverage
+analysis. For live behaviour validation each release, see
+[Release Validation](release-validation.md).
+
 ## Local Development (Devcontainer)
 
 1. Open the repo in VS Code

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -1,0 +1,124 @@
+# Release Validation
+
+How this integration is validated before a release is tagged. Two complementary,
+**repeatable** layers — the automated test suite (every push, in CI) and a live
+cross-check of every sensor class against a real RouterOS device (each
+release/RC). Both are designed to be re-run identically each cycle, not one-off.
+
+See also [Quality Gates](quality-gates.md).
+
+---
+
+## Layer 1 — Automated tests (CI, every push)
+
+The unit/integration suite runs on every push and pull request; it must be green
+before a release branch is cut.
+
+- **Framework:** `pytest` + `pytest-homeassistant-custom-component`.
+- **Matrix:** Python **3.13** (HA 2026.1–2026.2 runtime) and **3.14** (HA 2026.3+),
+  matching the [CI workflow](../.github/workflows/ci.yml).
+- **Entity golden tests:** deterministic per-platform snapshots of the entities the
+  integration produces from fixed API fixtures — see
+  [ADR-014](decisions/ADR-014-entity-golden-tests.md). These pin entity output
+  (state, unit, device class, attributes) so a regression in any sensor definition
+  fails loudly.
+- **Scope:** the suite drives the coordinator and platforms against **mocked**
+  RouterOS API responses. It proves the parsing/derivation logic is correct for
+  the modelled inputs — it does **not** prove the integration matches a *live*
+  router (that's Layer 2).
+
+Run locally:
+
+```bash
+pytest tests/ -v
+```
+
+The suite needs a Home Assistant test environment (Python 3.13/3.14). If your
+workstation can't host one directly, run it in a matching container, e.g.:
+
+```bash
+docker run --rm -v "$PWD":/work -w /work python:3.14 \
+  bash -c "pip install -q pytest pytest-homeassistant-custom-component \
+           pytest-cov mac-vendor-lookup librouteros && pytest -q"
+```
+
+---
+
+## Layer 2 — Live validation (each release / RC)
+
+The automated suite uses mocked data, so it can't catch a class of issues that only
+appear against real firmware: wrong unit/`device_class`, values that don't match the
+router, entities stuck `unknown`/`unavailable`, or hardware-dependent sensors that
+should (or shouldn't) exist. Layer 2 closes that gap by cross-checking **each sensor
+class** against the device's own values.
+
+### Method (tooling-agnostic)
+
+1. **Home Assistant side** — read each entity's state + attributes (Developer Tools →
+   States, the `/api/states` REST endpoint, or a template). Confirm
+   `unit_of_measurement`, `device_class`, `state_class`, and that no entity is
+   `unknown`/`unavailable` without an explained cause.
+2. **Router side** — read the same value at source via RouterOS (Winbox/WebFig
+   terminal, SSH, or the REST API). The relevant paths per class are below.
+3. **Compare** HA vs router within the tolerances noted.
+
+### Per-class source map
+
+| Sensor class | RouterOS source | Check |
+|---|---|---|
+| temperature / voltage / cpu·switch·board·phy-temp / fan / PSU / power / PoE-in | `/system/health` | value within drift; correct unit + `device_class` |
+| uptime / cpu-load / memory / hdd / client counts | `/system/resource` (+ derived) | `memory`,`hdd` ≈ `(total−free)/total`; uptime matches boot time |
+| interface TX/RX (rate) | `/interface` (live) | non-zero on active links; `data_rate`, measurement |
+| interface TX/RX total | `/interface` `tx-byte`/`rx-byte` | ≈ counter ÷ 1e9 (GB); `total_increasing` |
+| PoE-out status / V / I / P | `/interface/ethernet/poe` (+ `poe monitor`) | status present; V/I/P only when the hardware reports them |
+| DHCP client status / address | `/ip/dhcp-client` | `address` is `unknown` when the client is stopped/PPPoE (correct) |
+| DHCP server status / leases | `/ip/dhcp-server` (+ `/ip/dhcp-server/lease`) | per-server naming; **leases = all lease-table entries** (incl. static), not bound-only |
+| wired / wireless clients | host table (ARP + DHCP + bridge + wireless/CAPsMAN reg) | see derivation note |
+| environment | `/system/script/environment` | only populated when the global variable holds a value |
+| GPS lat/long | `/system/gps` | only on LTE/GPS hardware |
+
+### Tolerances & known semantics (so they aren't re-flagged each run)
+
+- **Measurement drift:** temperatures ±1–2 °C; CPU-load and client counts vary
+  between polls — small differences are expected.
+- **Traffic totals** reset when an interface flaps (check `link-downs`); a large gap
+  there is expected, not a bug.
+- **DHCP "leases"** counts every lease-table entry for the server (bound + waiting +
+  static reservations), not just bound — compare against the full lease list.
+- **Wired/wireless counts are derived**, per-device, from that device's host table
+  (deduped by MAC, only currently-reachable hosts). On an AP `wired ≈ bridge-hosts −
+  wireless-registrations`; on the gateway `wired ≈ reachable ARP entries`. They are a
+  per-device perspective, **not** a network-wide unique total — the same client is
+  counted by every device that sees it.
+- **Environment sensors** track RouterOS global *script* variables, which are RAM-only
+  and cleared on reboot; a value-less variable yields no sensor (by design).
+- **Hardware-dependent classes** (PSU, GPS, switch-temperature, power-consumption,
+  PoE-in, extra fans, PoE-out voltage/current/power) are **correctly absent** when the
+  board doesn't report them. A device that exposes no `/system/health` at all should
+  have no health sensors. Verify absence at the source rather than treating it as a
+  failure.
+
+### Coverage to aim for
+
+Validate against representative hardware/firmware so each path is exercised at least
+once: a routing device (health + DHCP servers), a switch (multiple temps + fan), and
+APs on **both** the legacy `wireless` and the new `wifi` packages. Run at least once
+with a **read-only** Home Assistant user — wireless/CAPsMAN/PPP capability detection
+behaves differently without write access.
+
+---
+
+## Release checklist
+
+- [ ] Automated suite green in CI on **both** Python 3.13 and 3.14.
+- [ ] Live cross-check of every sensor class against router truth on representative
+      hardware (router + switch + AP; legacy + new Wi-Fi; read-only + full-access user).
+- [ ] No entity stuck `unknown`/`unavailable` without an explained cause.
+- [ ] Any discrepancy filed as an issue and fixed before tagging the stable release.
+- [ ] `CHANGE-REGISTER.md` updated.
+
+## Validation log
+
+| Version | Live validation | Outcome |
+|---|---|---|
+| `v2.3.19-beta.2` | Full per-class cross-check against a live multi-device RouterOS deployment (router + switch + APs on legacy & new Wi-Fi; read-only HA user) | All sensor classes report router truth within tolerance. One state-quality issue found and fixed: empty/transient environment variables (`ISS-260608` → [#105](https://github.com/jnctech/homeassistant-mikrotik_router/pull/105)). |

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -111,6 +111,8 @@ behaves differently without write access.
 ## Release checklist
 
 - [ ] Automated suite green in CI on **both** Python 3.13 and 3.14.
+- [ ] Non-trivial changes passed the [Review Gates](quality-gates.md#review-gates) —
+      multi-agent audit panels (design/diagnosis) and the specialized pre-PR review passes.
 - [ ] Live cross-check of every sensor class against router truth on representative
       hardware (router + switch + AP; legacy + new Wi-Fi; read-only + full-access user).
 - [ ] No entity stuck `unknown`/`unavailable` without an explained cause.


### PR DESCRIPTION
## Summary
- Adds `docs/release-validation.md` — the repeatable two-layer validation used before tagging a release:
  - **Layer 1 (CI):** pytest + `pytest-homeassistant-custom-component`, the 3.13/3.14 matrix, ADR-014 entity goldens, with the "proves logic vs *mocked* data" caveat and local/Docker run commands.
  - **Layer 2 (live):** tooling-agnostic cross-check of **every sensor class** against RouterOS source — a per-class source map, tolerances/known-semantics, coverage targets, a release checklist, and a validation log.
- Adds a **Review Gates** section to `docs/quality-gates.md`:
  - **Multi-agent audit panels** (recon → review → junior-dev → senior-dev challenge, governed by cite-or-null).
  - **Specialized pre-PR passes** (`/simplify`, silent-failure hunt, code review, the domain `coordinator-reviewer` agent per ADR-010), cross-linked with the validation doc.

## Why
The repeatable validation/review process existed in practice but wasn't documented for contributors. This captures it. The `v2.3.19-beta.2` live validation (logged in the new doc) is what surfaced and fixed `ISS-260608` (#105).

## Notes
- Docs only — no code/behaviour change.
- Public-safe: methodology only, no environment-specific details.

## Test Plan
- [ ] CI green (docs change; format/validate/hassfest/tests unaffected).
- [x] Internal-leak scan clean (no IPs, serials, MACs, hostnames, tokens, or internal paths).
- [x] Internal links resolve (ADR-014, quality-gates `#review-gates`, CI workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)