### PR TITLE
chore(sonar): ignore S1172 false positive in diagnostics.py

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -36,3 +36,12 @@ sonar.cpd.exclusions=\
   custom_components/mikrotik_router/sensor_types.py,\
   custom_components/mikrotik_router/coordinator.py,\
   tests/**
+
+# Issue ignores
+# python:S1172 — diagnostics.py's `hass` parameter is required by Home Assistant's
+# diagnostics platform signature (HA core calls async_get_config_entry_diagnostics(
+# hass, config_entry) positionally). It is unused in the body but cannot be removed
+# without breaking the contract — a false positive for this rule.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=python:S1172
+sonar.issue.ignore.multicriteria.e1.resourceKey=custom_components/mikrotik_router/diagnostics.py


### PR DESCRIPTION
## Summary
- `python:S1172` flags `hass` as an unused parameter in `diagnostics.py`, but it's the **required first positional arg of Home Assistant's diagnostics platform signature** — HA core calls `async_get_config_entry_diagnostics(hass, config_entry)` positionally. Removing it breaks the contract (a false positive).
- Adds a narrow `sonar.issue.ignore.multicriteria` for `python:S1172` scoped to `diagnostics.py`, so the false positive doesn't recur on each analysis. (The PR-scoped "False Positive" mark on #107 didn't propagate to the main-branch analysis.)

## Test Plan
- [ ] CI green (config-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)