### PR TITLE
feat: native PoE-out energy sensors (measured + nameplate estimate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
+## What's New — v2.3.20-beta.1
+
+Beta for validating native **PoE-out energy** sensors (#59) on real metering hardware before a stable release.
+
+- **PoE energy for the Energy Dashboard.** Each PoE-out port now exposes an energy sensor (kWh, `total_increasing`) plus a device total, ready to add as a consumption source — no template/Riemann helpers needed. Enable the existing **PoE sensors** option. Counters survive Home Assistant restarts.
+- **Estimated energy for routers without PoE metering.** Some boards (e.g. hAP ax3) power a device but don't report PoE wattage. Where the powered device is uniquely identified via MikroTik Neighbor Discovery, the sensor estimates energy from the device's datasheet rating and labels it `power_source: estimated`. This is a coarse upper-bound estimate, not a measurement. See [ADR-017](docs/decisions/ADR-017-poe-energy-accumulation.md).
+
+> Beta note: PoE-out energy is new and is being validated against metering hardware via this beta. Measured ports report the real integral of `poe-out-power`; estimated ports use a nameplate maximum (actual draw is typically lower). Feedback welcome on #59.
+
 ## What's New — v2.3.19
 
 Stable release rolling up the read-only and quality-scale fixes from the dev cycle since v2.3.18. Validated live against a multi-device RouterOS deployment before tagging.

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -77,6 +77,19 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TIME_ZONE = None
 
+# Nameplate PoE-draw estimates (watts) keyed on the RouterOS `board` string a
+# device advertises via MikroTik Neighbor Discovery (/ip/neighbor). Used ONLY to
+# estimate PoE-out energy for a powered port whose hardware reports no PoE power
+# metering (poe-out-power is None). Each value is the vendor datasheet MAXIMUM
+# (an upper bound — real draw is typically lower), so estimated energy is coarse
+# and is always surfaced with power_source="estimated". Every entry MUST cite its
+# source; do not add a board without a sourced figure. See ADR-017, ENH-260509.
+_POE_DEVICE_NAMEPLATE: dict[str, float] = {
+    # hAP ac² — "Max power consumption without attachments 16 W"
+    # https://mikrotik.com/product/hap_ac2 (verified 2026-06-14)
+    "RBD52G-5HacD2HnD": 16.0,
+}
+
 
 def is_valid_ip(address):
     try:
@@ -288,6 +301,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             "netwatch": {},
             "raw": {},
             "container": {},
+            "neighbor": {},
         }
 
         self.notified_flags = []
@@ -329,6 +343,12 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
         self.last_hwinfo_update = datetime(1970, 1, 1, tzinfo=timezone.utc)
         self.rebootcheck = 0
+
+        # Per-port previous PoE-out power sample (W) for trapezoidal energy
+        # accumulation. Transient (cleared on restart / when a port stops
+        # delivering power) — the durable kWh total lives on the RestoreSensor
+        # entity, not here. See ADR-017.
+        self._poe_energy_last_power: dict[str, float] = {}
 
     # ---------------------------
     #   option_track_iface_clients
@@ -658,6 +678,10 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         if not hwinfo_ran:
             await self._run_if_enabled(self.get_system_resource)
 
+        # Neighbour discovery feeds the PoE energy estimator (interface poll),
+        # so it must run first; only needed when PoE monitoring is enabled.
+        await self._run_if_enabled(self.get_neighbor, requires=self.option_sensor_poe)
+
         for func in [self.get_system_health, self.get_dhcp_client, self.get_interface]:
             await self._run_if_enabled(func)
 
@@ -901,6 +925,111 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 iface[f"{direction}-previous"] = current
                 iface[f"{direction}-total"] = current
 
+    def get_neighbor(self) -> None:
+        """Map interface name -> advertised neighbour board(s) via /ip/neighbor.
+
+        MikroTik Neighbor Discovery lets us identify a device on a PoE-out port
+        (by its `board` model) so we can estimate its draw from the nameplate
+        table when the port reports no PoE power. Only populated when PoE
+        monitoring is enabled (the sole consumer is the energy estimator).
+        """
+        response = self.api.query("/ip/neighbor")
+        if response is None:
+            # Query failed (e.g. a transient disconnect). Keep the prior map so a
+            # one-poll blip does not reset every estimate's accumulation baseline.
+            return
+        self.ds["neighbor"] = {}
+        for entry in response:
+            board = entry.get("board")
+            interfaces = entry.get("interface")
+            if not board or not interfaces:
+                continue
+            # `interface` can be a comma-separated list when the neighbour is
+            # reachable via several local interfaces.
+            for name in str(interfaces).split(","):
+                self.ds["neighbor"].setdefault(name.strip(), []).append(board)
+
+    def _resolve_poe_power(self, iface) -> tuple[float | None, str | None, str | None]:
+        """Resolve a port's PoE-out power for energy accumulation.
+
+        Returns ``(watts, source, model)`` where source is "measured" (the
+        hardware reported poe-out-power), "estimated" (no metering, but the
+        powered port has exactly one neighbour with a known nameplate), or
+        ``(None, None, None)`` when no power can be attributed (null-not-guess:
+        an ambiguous multi-neighbour port or an unknown board yields nothing).
+        """
+        measured = iface.get("poe-out-power")
+        if measured is not None:
+            try:
+                return float(measured), "measured", None
+            except (TypeError, ValueError):
+                # A firmware variant reporting a non-numeric token must not crash
+                # the whole poll - null-not-guess and fall through to estimation.
+                return None, None, None
+
+        # Estimate only while the port is actually delivering power. (type ==
+        # "ether" alone does not imply PoE - non-PoE ports keep status "unknown".)
+        if iface.get("poe-out-status") != "powered-on":
+            return None, None, None
+
+        name = iface.get("default-name") or iface.get("name")
+        boards = self.ds.get("neighbor", {}).get(name, [])
+        if len(boards) != 1:
+            return None, None, None
+
+        watts = _POE_DEVICE_NAMEPLATE.get(boards[0])
+        if watts is None:
+            return None, None, None
+        return watts, "estimated", boards[0]
+
+    def _poe_energy_step(self, uid: str, power_now: float | None) -> float:
+        """Trapezoidal energy increment (Wh) for one port over one poll.
+
+        Uses the configured scan interval as dt (matching
+        _calculate_interface_traffic) so a missed/late poll can never integrate
+        a phantom area, and no wall-clock state must survive restarts. The first
+        sample of a port (and any None power) contributes 0 and resets the prev
+        sample, so energy is never integrated across an unpowered gap. The
+        result is clamped >= 0 to keep the downstream total_increasing monotonic.
+        """
+        prev = self._poe_energy_last_power.get(uid)
+        if power_now is None:
+            self._poe_energy_last_power.pop(uid, None)
+            return 0.0
+        if prev is None:
+            self._poe_energy_last_power[uid] = power_now
+            return 0.0
+        self._poe_energy_last_power[uid] = power_now
+        interval = self.option_scan_interval.seconds
+        return max(0.0, (power_now + prev) / 2 * interval / 3600)
+
+    def _accumulate_poe_energy(self) -> None:
+        """Write per-poll PoE energy increments into the interface/resource data.
+
+        Per ether port, resolve a measured-or-estimated power, integrate one
+        trapezoid step, and stash the increment (Wh) plus its source/model. The
+        device total is the sum of per-port increments. The RestoreSensor
+        entities own the durable kWh totals; this only emits per-poll deltas.
+        See ADR-017.
+        """
+        total_delta = 0.0
+        any_source = False
+        for uid, iface in self.ds["interface"].items():
+            if iface.get("type") != "ether":
+                continue
+            power, source, model = self._resolve_poe_power(iface)
+            delta = self._poe_energy_step(uid, power)
+            iface["poe-out-energy-delta-wh"] = delta
+            iface["poe-out-energy-source"] = source
+            iface["poe-out-energy-model"] = model
+            if source is not None:
+                any_source = True
+                total_delta += delta
+        # None (not 0.0) when no port has attributable energy, so the no-uid
+        # total sensor is not created on routers with PoE enabled but no
+        # measured/estimated PoE-out load.
+        self.ds["resource"]["poe-out-energy-delta-wh"] = total_delta if any_source else None
+
     def get_interface(self) -> None:
         """Get all interfaces data from Mikrotik"""
         self.ds["interface"] = parse_api(
@@ -940,6 +1069,9 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 {"name": "tx", "default": 0.0},
                 {"name": "rx-total", "default": 0.0},
                 {"name": "tx-total", "default": 0.0},
+                {"name": "poe-out-energy-delta-wh", "default": 0.0},
+                {"name": "poe-out-energy-source", "default": None},
+                {"name": "poe-out-energy-model", "default": None},
             ],
             skip=[
                 {"name": "type", "value": "bridge"},
@@ -979,6 +1111,9 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
         # Update virtual interfaces
         self._process_interface_metadata()
+
+        if self.option_sensor_poe:
+            self._accumulate_poe_energy()
 
     def _process_interface_metadata(self) -> None:
         """Post-process interfaces: comments, virtual names, ethernet monitoring, bonding."""

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -156,18 +156,27 @@ _POE_ATTRIBUTES = (
     "poe-out-power",
 )
 _POE_MEASUREMENT_ATTRIBUTES = ("poe-out-voltage", "poe-out-current", "poe-out-power")
+_POE_ENERGY_ATTRIBUTE = "poe-out-energy-delta-wh"
 
 
 def _skip_poe_sensor(config_entry, entity_description, data, uid) -> bool:
     """Skip PoE sensors when disabled or unsupported by hardware."""
-    if entity_description.data_attribute not in _POE_ATTRIBUTES:
+    attr = entity_description.data_attribute
+    if attr not in _POE_ATTRIBUTES and attr != _POE_ENERGY_ATTRIBUTE:
         return False
 
     if not config_entry.options.get(CONF_SENSOR_POE, DEFAULT_SENSOR_POE):
         return True
+
+    if attr == _POE_ENERGY_ATTRIBUTE:
+        # Per-port energy persists through transient power flaps, so it is gated
+        # on an attributable source (measured or estimated) rather than on a
+        # live power reading. See ADR-017.
+        return uid not in data or data[uid].get("poe-out-energy-source") is None
+
     if uid not in data or data[uid].get("poe-out-status") is None:
         return True
-    if entity_description.data_attribute in _POE_MEASUREMENT_ATTRIBUTES and data[uid].get(entity_description.data_attribute) is None:
+    if attr in _POE_MEASUREMENT_ATTRIBUTES and data[uid].get(attr) is None:
         return True
 
     return False

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -14,5 +14,5 @@
         "librouteros>=3.4.1,<4.0",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.19"
+    "version": "2.3.20-beta.1"
 }

--- a/custom_components/mikrotik_router/sensor.py
+++ b/custom_components/mikrotik_router/sensor.py
@@ -6,9 +6,9 @@ from logging import getLogger
 from datetime import date, datetime
 from decimal import Decimal
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import RestoreSensor, SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -36,6 +36,8 @@ async def async_setup_entry(
         "MikrotikSensor": MikrotikSensor,
         "MikrotikInterfaceTrafficSensor": MikrotikInterfaceTrafficSensor,
         "MikrotikClientTrafficSensor": MikrotikClientTrafficSensor,
+        "MikrotikPoEEnergySensor": MikrotikPoEEnergySensor,
+        "MikrotikPoEEnergyTotalSensor": MikrotikPoEEnergyTotalSensor,
     }
     await async_add_entities(hass, config_entry, dispatcher)
 
@@ -91,3 +93,88 @@ class MikrotikClientTrafficSensor(MikrotikSensor):
     def custom_name(self) -> str:
         """Return the name for this entity"""
         return f"{self.entity_description.name}"
+
+
+# ---------------------------
+#   MikrotikPoEEnergySensor
+# ---------------------------
+class MikrotikPoEEnergySensor(MikrotikSensor, RestoreSensor):
+    """PoE-out energy sensor (kWh, total_increasing).
+
+    Integrates the coordinator's per-poll energy increment into a running kWh
+    total. The total is restored across HA restarts via RestoreSensor, so it
+    does NOT reset to zero on reload (the Energy Dashboard would otherwise treat
+    a reset as a new billing cycle). The increment may be measured (real
+    poe-out-power) or estimated (nameplate) — surfaced via the power_source
+    attribute. See ADR-017.
+    """
+
+    def __init__(
+        self,
+        coordinator: MikrotikCoordinator,
+        entity_description,
+        uid: str | None = None,
+    ):
+        super().__init__(coordinator, entity_description, uid)
+        self._accumulated_kwh: float = 0.0
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the accumulated kWh total from the previous run."""
+        await super().async_added_to_hass()
+        last = await self.async_get_last_sensor_data()
+        if last is not None and last.native_value is not None:
+            try:
+                self._accumulated_kwh = float(last.native_value)
+            except (TypeError, ValueError):
+                _LOGGER.warning(
+                    "Could not restore PoE energy total for %s (got %r); starting from 0",
+                    self.entity_description.key,
+                    last.native_value,
+                )
+                self._accumulated_kwh = 0.0
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        # Resolve and accumulate the increment BEFORE super() writes HA state:
+        # the base couples data-refresh and async_write_ha_state(), so deferring
+        # the accumulation past super() would record last poll's total (a one-poll
+        # lag). The duplicated lookup is the deliberate cost of correct ordering.
+        try:
+            fresh = self.coordinator.data[self.entity_description.data_path]
+            if self._uid:
+                fresh = fresh[self._uid]
+        except KeyError:
+            _LOGGER.debug(
+                "Data path %s uid=%s not found, skipping PoE energy update",
+                self.entity_description.data_path,
+                self._uid,
+            )
+            return
+        delta_wh = fresh.get(self.entity_description.data_attribute) or 0.0
+        # Clamp >= 0 so the exposed total is monotonic (total_increasing).
+        self._accumulated_kwh += max(0.0, delta_wh) / 1000
+        super()._handle_coordinator_update()
+
+    @property
+    def native_value(self) -> float:
+        """Return the accumulated energy in kWh."""
+        return round(self._accumulated_kwh, 6)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Expose whether the energy is measured or estimated."""
+        attrs = dict(self._attr_extra_state_attributes or {})
+        source = self._data.get("poe-out-energy-source")
+        if source:
+            attrs["power_source"] = source
+        model = self._data.get("poe-out-energy-model")
+        if model:
+            attrs["estimated_from_model"] = model
+        return attrs
+
+
+# ---------------------------
+#   MikrotikPoEEnergyTotalSensor
+# ---------------------------
+class MikrotikPoEEnergyTotalSensor(MikrotikPoEEnergySensor):
+    """Device-total PoE-out energy — sum of the per-port increments (kWh)."""

--- a/custom_components/mikrotik_router/sensor_types.py
+++ b/custom_components/mikrotik_router/sensor_types.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     UnitOfElectricPotential,
     UnitOfElectricCurrent,
     UnitOfPower,
+    UnitOfEnergy,
 )
 
 from .const import DOMAIN
@@ -351,6 +352,50 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
         data_uid="",
         data_reference="default-name",
         data_attributes_list=DEVICE_ATTRIBUTES_IFACE_POE,
+    ),
+    # Per-port PoE-out energy (kWh) for the Energy Dashboard. Non-diagnostic so
+    # it is selectable as an energy source; ENERGY/TOTAL_INCREASING accumulated
+    # by the RestoreSensor entity from the coordinator's per-poll increment.
+    # See ADR-017, ENH-260509.
+    MikrotikSensorEntityDescription(
+        key="poe_out_energy",
+        name="PoE out energy",
+        icon="mdi:lightning-bolt-circle",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=3,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=None,
+        ha_group="data__default-name",
+        ha_connection=CONNECTION_NETWORK_MAC,
+        ha_connection_value="data__port-mac-address",
+        data_path="interface",
+        data_attribute="poe-out-energy-delta-wh",
+        data_name="default-name",
+        data_uid="",
+        data_reference="default-name",
+        data_attributes_list=DEVICE_ATTRIBUTES_IFACE_POE,
+        func="MikrotikPoEEnergySensor",
+    ),
+    # Device-total PoE-out energy (sum of per-port increments). No-uid sensor on
+    # the System device; only created when at least one port has attributable
+    # (measured or estimated) PoE-out energy.
+    MikrotikSensorEntityDescription(
+        key="poe_out_energy_total",
+        name="PoE out energy total",
+        icon="mdi:lightning-bolt-circle",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        suggested_display_precision=3,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=None,
+        ha_group="System",
+        data_path="resource",
+        data_attribute="poe-out-energy-delta-wh",
+        data_name="",
+        data_uid="",
+        data_reference="",
+        func="MikrotikPoEEnergyTotalSensor",
     ),
     MikrotikSensorEntityDescription(
         key="system_fan1-speed",

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,30 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260614-poe-energy-sensors — native PoE-out energy sensors (measured + nameplate estimate)
+
+**Date:** 2026-06-14
+**Branch:** `feature/poe-energy-sensors` -> PR to `dev`
+**Status:** In Review — ships beta-gated as **v2.3.20-beta.1** for @Dillton to validate on metering hardware.
+
+### What changed
+- `coordinator.py` — per-poll trapezoidal PoE-out energy accumulation (`_poe_energy_step`, `_accumulate_poe_energy`, `_resolve_poe_power`) writing a Wh increment into `ds["interface"][uid]` / `ds["resource"]`; new `get_neighbor()` (`/ip/neighbor` -> interface->board map) + `_POE_DEVICE_NAMEPLATE` table for estimating non-metering hardware; transient `_poe_energy_last_power` state; energy keys in `get_interface` ensure_vals; accumulation + neighbour fetch gated on `option_sensor_poe`.
+- `sensor.py` — `MikrotikPoEEnergySensor` / `MikrotikPoEEnergyTotalSensor` (`RestoreSensor`) own the restart-persistent kWh total; `power_source` (measured|estimated) + `estimated_from_model` attributes.
+- `sensor_types.py` — per-port `poe_out_energy` + device-total `poe_out_energy_total` descriptors (ENERGY / TOTAL_INCREASING / kWh, non-diagnostic).
+- `entity.py` — `_skip_poe_sensor` gates the energy sensor on `CONF_SENSOR_POE` + an attributable source.
+- `manifest.json` — `2.3.19 -> 2.3.20-beta.1`. ADR-017; tests (coordinator + entity + sensor, real-typed).
+
+### Why
+Resolves `ENH-260509-poe-energy` (#59). RouterOS exposes only instantaneous PoE power; this integrates it to Energy-Dashboard-compatible kWh. Metering hardware gets a measured total; non-metering hardware (e.g. the maintainer's ax3->ac2, verified live 2026-06-14 to report no PoE power) gets a clearly-labelled nameplate estimate via neighbour discovery. Maintainer HW can't validate accuracy -> beta-gated.
+
+### Verification
+Full suite **651 passed, 5 skipped** (py3.14 in Docker). ruff clean; coordinator-reviewer PASS; silent-failure-hunter findings applied (non-numeric-power guard, neighbour-map retain-on-failure, corrupted-restore warning); code-simplifier reviewed (one finding rejected — would introduce a one-poll-lag in recorded state). Live cross-check on the ax3 (estimated path) is a beta task; measured-path accuracy is @Dillton.
+
+### Release ops
+Lands on `dev`; cut **pre-release** tag `v2.3.20-beta.1` off `dev` (not dev->master) -> `release.yml` builds the zip.
+
+---
+
 ## CR-260614-release-v2.3.19 — stable v2.3.19 + branch-sync gate
 
 **Date:** 2026-06-14

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -134,7 +134,7 @@ A `*_environment_<name>` sensor reports an empty string (`''`) as its state when
 **Type:** Enhancement (new sensors)
 **Priority:** Medium
 **Created:** 2026-05-09
-**Status:** 🟡 Open — **G0 design panel done 2026-06-14.** Recommend **Option A** (power sensors + Riemann/Utility-Meter blueprint); native energy is the turnkey alternative, beta-gated. Target **v2.3.20-beta** (not v2.4.0). Scoped notes on retained branch `docs/enh-260509-poe-energy`.
+**Status:** 🟢 Implemented on `feature/poe-energy-sensors` (ADR-017, CR-260614-poe-energy-sensors) — native measured **and** nameplate-estimate energy. Ships **v2.3.20-beta.1** (pre-release); awaiting @Dillton validation on metering hardware before stable. (G0 panel 2026-06-14 recommended the Option A blueprint; maintainer chose the turnkey native path, beta-gated.)
 
 **Summary:**
 Native per-port PoE-out **energy** sensors (kWh, `total_increasing`) derived from the existing PoE-out **power** reading, so users get Energy-dashboard-compatible consumption without template sensors. Detail/scoping notes live on the retained branch `docs/enh-260509-poe-energy` (commit `339932e`, +22 lines to ISSUES); the reserved beta name `v2.4.0-beta` is earmarked for this feature. `[branch contents verified 2026-06-14; full design UNVERIFIED — to be scoped next session]`

--- a/docs/decisions/ADR-017-poe-energy-accumulation.md
+++ b/docs/decisions/ADR-017-poe-energy-accumulation.md
@@ -1,0 +1,50 @@
+# ADR-017 — PoE-out energy accumulation (measured + nameplate estimate)
+
+**Status:** Accepted — implemented on `feature/poe-energy-sensors` (CR-260614-poe-energy-sensors). Ships beta-gated as `v2.3.20-beta.1` for live validation on metering hardware.
+**Date:** 2026-06-14
+**Supersedes/relates:** `ENH-260509-poe-energy` (#59). G0 design panel 2026-06-14.
+**Numbering note:** ADR-014 is the highest on disk. **ADR-015** is reserved (librouteros salvage renumber) and **ADR-016** is reserved (coordinator decomposition) per `docs/ISSUES.md`. This feature therefore takes **017**.
+
+## Context
+
+[#59](https://github.com/jnctech/homeassistant-mikrotik_router/issues/59) (@Dillton) asks for native PoE-out **energy** (kWh) sensors for the HA Energy Dashboard so users don't hand-build Integration/Utility-Meter helpers. RouterOS exposes only **instantaneous** PoE-out power (`/interface/ethernet/poe monitor` → `poe-out-power`, W), no energy accumulator — so energy must be integrated in-integration.
+
+Two hardware realities, both **verified live 2026-06-14**:
+- **Metering hardware** reports a real `poe-out-power` per port (e.g. @Dillton's box). Here energy = trapezoidal integral of the measured power.
+- **Non-metering hardware** powers a device but reports no power: the maintainer's hAP ax3 ether1 is `poe-out-status: powered-on` with **no** `poe-out-power/voltage/current` fields at all (`/interface/ethernet/poe/monitor [find] once`). For these, the only attribution is a **nameplate estimate** of the downstream device — identifiable via MikroTik Neighbor Discovery (`/ip/neighbor` → `board`; ether1 → `RBD52G-5HacD2HnD` = hAP ac²). Multi-neighbour ports (e.g. ether2 → rb4011 + CRS310) are **not** attributable.
+
+The maintainer cannot self-validate accuracy (null PoE power), hence the beta gate on reporter hardware.
+
+## Decision
+
+### 1. Ownership — entity owns the durable total; coordinator emits per-poll deltas
+Entities are created **after** the first coordinator poll (`entity.py:_run_entity_setup_loop`), so a coordinator-held running total would advance from 0 before any RestoreSensor could seed it — losing energy on every restart. Therefore:
+- The **coordinator** holds only transient `self._poe_energy_last_power[uid]` (W) and writes a per-poll increment `ds["interface"][uid]["poe-out-energy-delta-wh"]` (Wh), plus a device-total delta into `ds["resource"]`.
+- The **entity** (`MikrotikPoEEnergySensor(MikrotikSensor, RestoreSensor)`) owns the durable `_accumulated_kwh`, restores it on `async_added_to_hass` via `async_get_last_sensor_data()`, and adds each poll's delta. No state is ever written back into the coordinator.
+
+### 2. Integration — trapezoid over the configured scan interval
+`delta_wh = max(0.0, (p_now + p_prev) / 2 * interval / 3600)`, `interval = option_scan_interval.seconds` — mirroring `_calculate_interface_traffic` (`coordinator.py`). Using the **configured** interval (not measured wall-clock elapsed) means a missed/late poll or a restart can never integrate a phantom area: no `last_ts` state, nothing to survive restarts. The first sample of a port (no prev) and any `None` power contribute **0** and clear the prev sample, so energy is never integrated across an unpowered gap.
+
+### 3. Monotonicity — `total_increasing` proven non-decreasing
+Both the coordinator step and the entity accumulation clamp the increment `>= 0`, and the entity only ever does `_accumulated_kwh += increment`, so the exposed value cannot decrease — a port going `None`→present, a clock-skew negative dt, or a restart (first post-restart delta is 0) never produce a backward step that HA would read as a meter reset.
+
+### 4. Device-total — sum of per-poll deltas, as its own RestoreSensor
+RouterOS exposes no aggregate PoE energy register `[UNVERIFIED — Dillton]`, so the device total is the sum of per-port increments accumulated by a second RestoreSensor (`MikrotikPoEEnergyTotalSensor`, no-uid, `data_path="resource"`). It accumulates the **same delta source** as the per-port sensors (not `sum(entity.native_value)`), so total and per-port stay consistent across restarts. The resource delta is `None` (not `0.0`) when no port has attributable energy, so the total is not created on PoE-enabled routers with no PoE-out load.
+
+### 5. Measured vs estimated — labelled, never conflated
+`_resolve_poe_power` returns `(watts, source, model)`: measured `poe-out-power` when present; else, for a `powered-on` port with **exactly one** neighbour whose `board` is in `_POE_DEVICE_NAMEPLATE`, the nameplate watts (`source="estimated"`, `model=board`); else `(None, None, None)` (null-not-guess — ambiguous/unknown ports get no sensor). The entity surfaces `power_source` (+ `estimated_from_model`) as attributes. Nameplate values are the vendor datasheet **maximum** (an upper bound; real draw is lower), each entry citing its source — estimated energy is explicitly coarse.
+
+### 6. entity_category = None
+The energy descriptors omit `entity_category` (existing PoE sensors are `DIAGNOSTIC`) so they are user-facing and selectable as Energy-Dashboard sources. Whether a `DIAGNOSTIC` category disqualifies an entity from the Energy-Dashboard picker is an HA-frontend behaviour **not verifiable in this repo** — `None` is the safe default; confirmed-on-live is a beta task.
+
+### 7. Opt-in reuses `CONF_SENSOR_POE`
+No new toggle — energy is meaningless without PoE monitoring. Neighbour discovery (`get_neighbor`) and accumulation only run when `option_sensor_poe` is set.
+
+## Consequences
+- New `unique_id`s only (`poe_out_energy-<port>`, `poe_out_energy_total`); no migration; existing entities/automations untouched.
+- New net pattern for the repo (RestoreSensor; only `MikrotikSwitch` used `RestoreEntity` before).
+- `_handle_coordinator_update` accumulates **before** `super()` writes HA state (the base couples refresh+write); the duplicated data lookup is the deliberate cost of correct ordering (deferring it past `super()` would record a one-poll-stale total).
+- A failed `/ip/neighbor` query retains the prior neighbour map (no estimate-baseline reset on a transient disconnect); a non-numeric `poe-out-power` null-not-guesses rather than crashing the poll.
+
+## Residual risks (only reporter metering hardware closes)
+Energy-Dashboard pickability with `entity_category=None`; trapezoidal accuracy vs a true inline meter; restore correctness across a real HA restart; device-total fidelity; and **nameplate accuracy** (datasheet max ≠ actual draw — an upper-bound estimate, labelled as such).

--- a/info.md
+++ b/info.md
@@ -10,6 +10,11 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
+### What's new in v2.3.20-beta.1
+Beta validating native **PoE-out energy** sensors (#59) before a stable release.
+- **PoE energy for the Energy Dashboard** — per-port energy sensors (kWh, `total_increasing`) + a device total, restart-persistent. Enable the existing PoE sensors option.
+- **Estimated energy on non-metering hardware** — where a PoE-out port powers a device that has no wattage reading, energy is estimated from the device's datasheet rating (via Neighbor Discovery) and labelled `power_source: estimated` — a coarse upper bound, not a measurement.
+
 ### What's new in v2.3.19
 Stable release rolling up the read-only and quality-scale fixes since v2.3.18. Validated live against a multi-device RouterOS deployment before tagging.
 - **Read-only users now get wireless / CAPsMAN / PPP data** — on RouterOS 7.x, an HA user without write/policy/reboot rights previously saw zero wireless clients. The firmware version is now read from `/system/resource`, so capability detection works without granting write access. Thanks to @ahharvey for the fix and wifi-qcom testing. Addresses #82.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5228,3 +5228,145 @@ def test_readonly_capability_cascade_unblocked_end_to_end():
     assert coordinator.support_wireless is True
     assert coordinator._wifimodule == "wifi"
     assert coordinator.support_capsman is False
+
+
+# ---------------------------------------------------------------------------
+# Group: PoE-out energy accumulation (ADR-017 / ENH-260509)
+# ---------------------------------------------------------------------------
+
+
+def _poe_coordinator(interface=None, neighbor=None, scan_interval=30):
+    """Coordinator wired for the PoE energy helpers (real methods, no __init__)."""
+    coordinator = make_coordinator(options={CONF_SCAN_INTERVAL: scan_interval})
+    coordinator._poe_energy_last_power = {}
+    coordinator.ds["interface"] = interface or {}
+    coordinator.ds["neighbor"] = neighbor or {}
+    return coordinator
+
+
+def test_poe_energy_step_first_sample_returns_zero():
+    """The first sample of a port has no previous power, so it integrates 0."""
+    coordinator = _poe_coordinator()
+    assert coordinator._poe_energy_step("ether1", 10.0) == 0.0
+    assert coordinator._poe_energy_last_power["ether1"] == 10.0
+
+
+def test_poe_energy_step_trapezoid():
+    """Second sample integrates the trapezoid over one scan interval."""
+    coordinator = _poe_coordinator(scan_interval=30)
+    coordinator._poe_energy_last_power["ether1"] = 10.0
+    # (10 + 20) / 2 * 30 / 3600 = 15 * 30 / 3600 = 0.125 Wh
+    assert coordinator._poe_energy_step("ether1", 20.0) == pytest.approx(0.125)
+    assert coordinator._poe_energy_last_power["ether1"] == 20.0
+
+
+def test_poe_energy_step_none_clears_state():
+    """A None power (port unplugged/disabled) integrates 0 and forgets the prev sample."""
+    coordinator = _poe_coordinator()
+    coordinator._poe_energy_last_power["ether1"] = 10.0
+    assert coordinator._poe_energy_step("ether1", None) == 0.0
+    assert "ether1" not in coordinator._poe_energy_last_power
+
+
+def test_resolve_poe_power_prefers_measured():
+    """A real poe-out-power reading is used directly (source=measured)."""
+    coordinator = _poe_coordinator()
+    iface = {"poe-out-power": 12.1, "poe-out-status": "powered-on", "default-name": "ether1"}
+    assert coordinator._resolve_poe_power(iface) == (12.1, "measured", None)
+
+
+def test_resolve_poe_power_estimates_from_single_neighbor():
+    """No metering but a powered port with one known neighbour -> nameplate estimate."""
+    coordinator = _poe_coordinator(neighbor={"ether1": ["RBD52G-5HacD2HnD"]})
+    iface = {"poe-out-power": None, "poe-out-status": "powered-on", "default-name": "ether1"}
+    assert coordinator._resolve_poe_power(iface) == (16.0, "estimated", "RBD52G-5HacD2HnD")
+
+
+def test_resolve_poe_power_no_estimate_for_ambiguous_multi_neighbor():
+    """A port with more than one neighbour cannot be attributed (null-not-guess)."""
+    coordinator = _poe_coordinator(neighbor={"ether2": ["RB4011iGS+5HacQ2HnD", "CRS310-8G+2S+"]})
+    iface = {"poe-out-power": None, "poe-out-status": "powered-on", "default-name": "ether2"}
+    assert coordinator._resolve_poe_power(iface) == (None, None, None)
+
+
+def test_resolve_poe_power_no_estimate_for_unknown_board():
+    """A single neighbour whose board is not in the nameplate table yields no estimate."""
+    coordinator = _poe_coordinator(neighbor={"ether1": ["RB-SOME-UNKNOWN-BOARD"]})
+    iface = {"poe-out-power": None, "poe-out-status": "powered-on", "default-name": "ether1"}
+    assert coordinator._resolve_poe_power(iface) == (None, None, None)
+
+
+def test_resolve_poe_power_no_estimate_when_not_powered():
+    """Estimate only while the port is actually delivering power."""
+    coordinator = _poe_coordinator(neighbor={"ether1": ["RBD52G-5HacD2HnD"]})
+    iface = {"poe-out-power": None, "poe-out-status": "waiting-for-load", "default-name": "ether1"}
+    assert coordinator._resolve_poe_power(iface) == (None, None, None)
+
+
+def test_accumulate_poe_energy_device_total_sums_ports():
+    """Device-total delta equals the sum of the per-port increments (no double-count)."""
+    interface = {
+        "ether1": {"type": "ether", "poe-out-power": 10.0, "poe-out-status": "powered-on", "default-name": "ether1"},
+        "ether2": {"type": "ether", "poe-out-power": 20.0, "poe-out-status": "powered-on", "default-name": "ether2"},
+    }
+    coordinator = _poe_coordinator(interface=interface, scan_interval=30)
+    # Seed previous samples so this poll integrates a non-zero trapezoid.
+    coordinator._poe_energy_last_power = {"ether1": 10.0, "ether2": 20.0}
+    coordinator._accumulate_poe_energy()
+    d1 = interface["ether1"]["poe-out-energy-delta-wh"]
+    d2 = interface["ether2"]["poe-out-energy-delta-wh"]
+    assert d1 == pytest.approx(10.0 * 30 / 3600)
+    assert d2 == pytest.approx(20.0 * 30 / 3600)
+    assert coordinator.ds["resource"]["poe-out-energy-delta-wh"] == pytest.approx(d1 + d2)
+    assert interface["ether1"]["poe-out-energy-source"] == "measured"
+
+
+def test_accumulate_poe_energy_total_none_when_no_source():
+    """A PoE-enabled router with no attributable PoE-out load leaves the total uncreated."""
+    interface = {"ether1": {"type": "ether", "default-name": "ether1"}}
+    coordinator = _poe_coordinator(interface=interface)
+    coordinator._accumulate_poe_energy()
+    assert coordinator.ds["resource"]["poe-out-energy-delta-wh"] is None
+    assert interface["ether1"]["poe-out-energy-source"] is None
+
+
+def test_accumulate_poe_energy_skips_non_ether_ports():
+    """Only ether ports are integrated; wlan/bridge are left untouched."""
+    interface = {"wlan1": {"type": "wlan"}}
+    coordinator = _poe_coordinator(interface=interface)
+    coordinator._accumulate_poe_energy()
+    assert "poe-out-energy-delta-wh" not in interface["wlan1"]
+
+
+def test_get_neighbor_builds_interface_board_map():
+    """get_neighbor maps each interface (incl. comma-listed) to advertised board(s)."""
+    coordinator = make_coordinator(
+        api_responses={
+            "/ip/neighbor": [
+                {"interface": "ether1", "board": "RBD52G-5HacD2HnD", "identity": "hap_ac2"},
+                {"interface": "ether2,bridge", "board": "CRS310-8G+2S+", "identity": "csr310"},
+                {"interface": "ether3"},  # missing board -> skipped
+            ]
+        }
+    )
+    coordinator.get_neighbor()
+    assert coordinator.ds["neighbor"] == {
+        "ether1": ["RBD52G-5HacD2HnD"],
+        "ether2": ["CRS310-8G+2S+"],
+        "bridge": ["CRS310-8G+2S+"],
+    }
+
+
+def test_get_neighbor_retains_prior_map_on_query_failure():
+    """A failed/None /ip/neighbor query keeps the previous map (no estimate reset)."""
+    coordinator = make_coordinator(api_responses={"/ip/neighbor": None})
+    coordinator.ds["neighbor"] = {"ether1": ["RBD52G-5HacD2HnD"]}
+    coordinator.get_neighbor()
+    assert coordinator.ds["neighbor"] == {"ether1": ["RBD52G-5HacD2HnD"]}
+
+
+def test_resolve_poe_power_non_numeric_measured_yields_no_value():
+    """A non-numeric poe-out-power reading null-not-guesses instead of crashing."""
+    coordinator = _poe_coordinator()
+    iface = {"poe-out-power": "n/a", "poe-out-status": "powered-on", "default-name": "ether1"}
+    assert coordinator._resolve_poe_power(iface) == (None, None, None)

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -901,3 +901,45 @@ def test_no_skip_netwatch_when_enabled():
     data = {"8.8.8.8": {"status": "up"}}
     cfg = make_config_entry({CONF_SENSOR_NETWATCH_TRACKER: True})
     assert _skip_sensor(cfg, desc, data, "8.8.8.8") is False
+
+
+# ---------------------------------------------------------------------------
+# PoE-out energy sensor gating (ADR-017 / ENH-260509)
+# ---------------------------------------------------------------------------
+
+
+def _energy_desc():
+    """Real per-port PoE energy description (only data_attribute is read by skip)."""
+    return MikrotikSensorEntityDescription(
+        key="poe_out_energy",
+        data_attribute="poe-out-energy-delta-wh",
+        func="MikrotikPoEEnergySensor",
+    )
+
+
+def test_skip_poe_energy_sensor_when_option_disabled():
+    """Per-port energy sensor is skipped when CONF_SENSOR_POE is False."""
+    data = {"ether1": {"poe-out-energy-source": "measured"}}
+    cfg = make_config_entry({CONF_SENSOR_POE: False})
+    assert _skip_sensor(cfg, _energy_desc(), data, "ether1") is True
+
+
+def test_skip_poe_energy_sensor_when_no_attributable_source():
+    """No measured or estimated source -> no energy sensor (null-not-guess)."""
+    data = {"ether1": {"poe-out-energy-source": None}}
+    cfg = make_config_entry({CONF_SENSOR_POE: True})
+    assert _skip_sensor(cfg, _energy_desc(), data, "ether1") is True
+
+
+def test_no_skip_poe_energy_sensor_when_measured():
+    """A measured source creates the energy sensor."""
+    data = {"ether1": {"poe-out-energy-source": "measured"}}
+    cfg = make_config_entry({CONF_SENSOR_POE: True})
+    assert _skip_sensor(cfg, _energy_desc(), data, "ether1") is False
+
+
+def test_no_skip_poe_energy_sensor_when_estimated():
+    """An estimated source (nameplate) also creates the energy sensor."""
+    data = {"ether1": {"poe-out-energy-source": "estimated"}}
+    cfg = make_config_entry({CONF_SENSOR_POE: True})
+    assert _skip_sensor(cfg, _energy_desc(), data, "ether1") is False

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,15 +15,23 @@ shape when reworking the other test modules:
     poke or assert internal representation.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from homeassistant.const import CONF_HOST, CONF_NAME, UnitOfElectricCurrent
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    UnitOfElectricCurrent,
+    UnitOfEnergy,
+)
 
 from custom_components.mikrotik_router.coordinator import MikrotikCoordinator
 from custom_components.mikrotik_router.sensor import (
     MikrotikClientTrafficSensor,
+    MikrotikPoEEnergySensor,
+    MikrotikPoEEnergyTotalSensor,
     MikrotikSensor,
 )
 from custom_components.mikrotik_router.sensor_types import (
@@ -223,3 +231,184 @@ def test_dhcp_client_sensor_reads_attribute(dhcp_client_data, attribute, expecte
     )
     sensor = _build_sensor(dhcp_client_data, desc, uid="ether1")
     assert sensor.native_value == expected
+
+
+# ---------------------------------------------------------------------------
+# PoE-out energy sensors (ADR-017 / ENH-260509)
+# ---------------------------------------------------------------------------
+
+
+def _build_energy_sensor(data, description, *, cls=MikrotikPoEEnergySensor, uid=None):
+    """Build a PoE energy sensor with HA write/added-to-hass machinery stubbed."""
+    coordinator = _coordinator(data)
+    with patch_coordinator_entity_init():
+        sensor = cls(coordinator, description, uid)
+    sensor.async_write_ha_state = MagicMock()
+    return sensor
+
+
+def _energy_description(**overrides):
+    overrides.setdefault("key", "poe_out_energy")
+    overrides.setdefault("name", "PoE out energy")
+    overrides.setdefault("device_class", SensorDeviceClass.ENERGY)
+    overrides.setdefault("state_class", SensorStateClass.TOTAL_INCREASING)
+    overrides.setdefault("native_unit_of_measurement", UnitOfEnergy.KILO_WATT_HOUR)
+    overrides.setdefault("data_path", "interface")
+    overrides.setdefault("data_attribute", "poe-out-energy-delta-wh")
+    overrides.setdefault("data_name", "default-name")
+    overrides.setdefault("data_reference", "default-name")
+    overrides.setdefault("func", "MikrotikPoEEnergySensor")
+    return MikrotikSensorEntityDescription(**overrides)
+
+
+def test_poe_energy_descriptor_pins():
+    """Energy descriptor must stay ENERGY / TOTAL_INCREASING / kWh and NON-diagnostic
+    (entity_category None) so the Energy Dashboard can select it. See ADR-017."""
+    desc = next(s for s in SENSOR_TYPES if s.key == "poe_out_energy")
+    assert desc.device_class == SensorDeviceClass.ENERGY
+    assert desc.state_class == SensorStateClass.TOTAL_INCREASING
+    assert desc.native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
+    assert desc.entity_category is None
+    assert desc.func == "MikrotikPoEEnergySensor"
+
+
+def test_poe_energy_total_descriptor_pins():
+    """Device-total energy descriptor pins (no-uid System sensor)."""
+    desc = next(s for s in SENSOR_TYPES if s.key == "poe_out_energy_total")
+    assert desc.device_class == SensorDeviceClass.ENERGY
+    assert desc.state_class == SensorStateClass.TOTAL_INCREASING
+    assert desc.native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
+    assert desc.entity_category is None
+    assert desc.data_path == "resource"
+    assert desc.data_reference == ""
+    assert desc.func == "MikrotikPoEEnergyTotalSensor"
+
+
+def test_poe_energy_native_value_accumulates_increments():
+    """native_value is the running kWh total of the per-poll Wh increments."""
+    data = {"interface": {"ether1": {"default-name": "ether1", "poe-out-energy-delta-wh": 0.0}}}
+    sensor = _build_energy_sensor(data, _energy_description(), uid="ether1")
+    assert sensor.native_value == 0.0
+
+    for delta_wh in (500.0, 500.0):  # 0.5 kWh each
+        data["interface"]["ether1"]["poe-out-energy-delta-wh"] = delta_wh
+        sensor._handle_coordinator_update()
+    assert sensor.native_value == pytest.approx(1.0)
+
+
+def test_poe_energy_is_monotonic_across_zero_deltas():
+    """total_increasing must never decrease, even when a port stops drawing (delta 0)."""
+    data = {"interface": {"ether1": {"default-name": "ether1", "poe-out-energy-delta-wh": 0.0}}}
+    sensor = _build_energy_sensor(data, _energy_description(), uid="ether1")
+    seen = []
+    for delta_wh in (100.0, 0.0, 0.0, 100.0):
+        data["interface"]["ether1"]["poe-out-energy-delta-wh"] = delta_wh
+        sensor._handle_coordinator_update()
+        seen.append(sensor.native_value)
+    assert seen == sorted(seen)
+    assert seen[-1] == pytest.approx(0.2)
+
+
+def test_poe_energy_negative_delta_is_clamped():
+    """A negative increment (clock skew guard) does not roll the total back."""
+    data = {"interface": {"ether1": {"default-name": "ether1", "poe-out-energy-delta-wh": 1000.0}}}
+    sensor = _build_energy_sensor(data, _energy_description(), uid="ether1")
+    sensor._handle_coordinator_update()
+    before = sensor.native_value
+    data["interface"]["ether1"]["poe-out-energy-delta-wh"] = -5000.0
+    sensor._handle_coordinator_update()
+    assert sensor.native_value == before
+
+
+async def test_poe_energy_restore_seeds_accumulator(monkeypatch):
+    """On restart the accumulated kWh is restored, not reset to zero."""
+    data = {"interface": {"ether1": {"default-name": "ether1", "poe-out-energy-delta-wh": 0.0}}}
+    sensor = _build_energy_sensor(data, _energy_description(), uid="ether1")
+    # Stop the HA RestoreEntity/Coordinator added-to-hass chain at the boundary.
+    monkeypatch.setattr(
+        "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+        AsyncMock(),
+    )
+    last = MagicMock()
+    last.native_value = 1.5
+    sensor.async_get_last_sensor_data = AsyncMock(return_value=last)
+
+    await sensor.async_added_to_hass()
+    assert sensor.native_value == pytest.approx(1.5)
+
+    # The first post-restore poll has no prior power (delta 0) and must not reset.
+    sensor._handle_coordinator_update()
+    assert sensor.native_value == pytest.approx(1.5)
+
+
+async def test_poe_energy_no_restore_starts_at_zero(monkeypatch):
+    """With no previous state the counter starts at zero."""
+    data = {"interface": {"ether1": {"default-name": "ether1", "poe-out-energy-delta-wh": 0.0}}}
+    sensor = _build_energy_sensor(data, _energy_description(), uid="ether1")
+    monkeypatch.setattr(
+        "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+        AsyncMock(),
+    )
+    sensor.async_get_last_sensor_data = AsyncMock(return_value=None)
+    await sensor.async_added_to_hass()
+    assert sensor.native_value == 0.0
+
+
+@pytest.mark.parametrize(
+    "source, model, expect_model",
+    [
+        ("measured", None, False),
+        ("estimated", "RBD52G-5HacD2HnD", True),
+    ],
+)
+def test_poe_energy_power_source_attribute(source, model, expect_model):
+    """The power_source attribute distinguishes measured from estimated energy."""
+    row = {"default-name": "ether1", "poe-out-energy-delta-wh": 0.0, "poe-out-energy-source": source, "poe-out-energy-model": model}
+    data = {"interface": {"ether1": row}}
+    sensor = _build_energy_sensor(data, _energy_description(), uid="ether1")
+    attrs = sensor.extra_state_attributes
+    assert attrs["power_source"] == source
+    assert ("estimated_from_model" in attrs) is expect_model
+
+
+def test_poe_energy_total_reads_resource_delta():
+    """The no-uid device-total sensor accumulates the resource-level increment."""
+    data = {"resource": {"poe-out-energy-delta-wh": 250.0}}
+    desc = _energy_description(
+        key="poe_out_energy_total",
+        data_path="resource",
+        data_name="",
+        data_reference="",
+        func="MikrotikPoEEnergyTotalSensor",
+    )
+    sensor = _build_energy_sensor(data, desc, cls=MikrotikPoEEnergyTotalSensor)
+    sensor._handle_coordinator_update()
+    assert sensor.native_value == pytest.approx(0.25)
+
+
+async def test_poe_energy_restore_with_unparseable_value_starts_zero(monkeypatch):
+    """A restored state that is not a number falls back to zero, not a crash."""
+    data = {"interface": {"ether1": {"default-name": "ether1", "poe-out-energy-delta-wh": 0.0}}}
+    sensor = _build_energy_sensor(data, _energy_description(), uid="ether1")
+    monkeypatch.setattr(
+        "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+        AsyncMock(),
+    )
+    last = MagicMock()
+    last.native_value = "not-a-number"
+    sensor.async_get_last_sensor_data = AsyncMock(return_value=last)
+    await sensor.async_added_to_hass()
+    assert sensor.native_value == 0.0
+
+
+def test_poe_energy_update_skips_when_uid_missing():
+    """A coordinator update for a uid no longer present is skipped without error."""
+    data = {"interface": {"ether1": {"default-name": "ether1", "poe-out-energy-delta-wh": 100.0}}}
+    sensor = _build_energy_sensor(data, _energy_description(), uid="ether1")
+    sensor._handle_coordinator_update()
+    before = sensor.native_value
+    # Port disappears from the dataset entirely.
+    data["interface"].pop("ether1")
+    sensor._handle_coordinator_update()
+    assert sensor.native_value == before
+    sensor.async_write_ha_state.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds native **PoE-out energy** sensors (kWh, `total_increasing`) for the HA Energy Dashboard, resolving `ENH-260509` ([#59](https://github.com/jnctech/homeassistant-mikrotik_router/issues/59)). Per-port `poe_out_energy` + a device-total `poe_out_energy_total`; no template/Riemann helpers needed.
- RouterOS exposes only instantaneous PoE power, so energy is integrated in-integration (trapezoidal, over the configured scan interval; mirrors `_calculate_interface_traffic`).
- **Two paths, labelled via a `power_source` attribute:**
  - **measured** — real `poe-out-power` from metering hardware (e.g. @Dillton's box).
  - **estimated** — for boards that power a device but report no PoE wattage (e.g. the maintainer's ax3 → ac2, verified live), a nameplate datasheet-max estimate attributed via MikroTik Neighbor Discovery, **only** when a powered port has exactly one known neighbour (null-not-guess otherwise). Coarse upper bound, never presented as measured.
- **Architecture (ADR-017):** the `RestoreSensor` entity owns the restart-persistent kWh total; the coordinator is stateless across restarts and emits only a per-poll Wh delta (avoids the restore race where entities are created after the first poll). Monotonic by construction. Opt-in via the existing **PoE sensors** (`CONF_SENSOR_POE`) toggle. Non-diagnostic so the Energy Dashboard can select it.

## Why beta
Maintainer hardware reports null PoE power, so measured-path accuracy and restore behaviour can't be self-validated — ships **beta-gated as `v2.3.20-beta.1`** for @Dillton to validate on metering hardware.

## Review gates
- **Tests:** 30 new (coordinator + entity + sensor, real-typed/spec'd per the standing rule) — **651 passed, 5 skipped** (py3.14 in Docker). ruff clean.
- **coordinator-reviewer:** PASS (ADR-007 complexity ≤15, ADR-009, lock discipline, KeyError invariant).
- **silent-failure-hunter:** findings applied — non-numeric `poe-out-power` guard, neighbour-map retain-on-failure, corrupted-restore warning.
- **code-simplifier:** reviewed; one finding rejected (would introduce a one-poll lag in recorded state — guarded with a comment).
- Docs: ADR-017, `CR-260614-poe-energy-sensors`, ISSUES status, README/info "What's New".

## Post-Deploy Actions
- None for merge. To use: enable **PoE sensors** in the integration options.

## Test Plan
- [ ] CI green on py3.13 + py3.14.
- [ ] Cut pre-release `v2.3.20-beta.1` off `dev`; @Dillton validates measured energy + restart-restore on metering hardware.
- [ ] Live cross-check the **estimated** path on the maintainer's ax3 (ether1 → ac2): sensor accumulates, `power_source: estimated`, `estimated_from_model: RBD52G-5HacD2HnD`.
- [ ] Confirm the energy sensor is selectable in the Energy Dashboard picker (verifies `entity_category=None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)