### PR TITLE
chore: clear HA device_tracker + config-flow reload deprecations (ISS-260614, #495)

### DIFF
--- a/custom_components/mikrotik_router/config_flow.py
+++ b/custom_components/mikrotik_router/config_flow.py
@@ -163,7 +163,7 @@ class MikrotikControllerConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             error = await self.hass.async_add_executor_job(self._validate_connection, {**reauth_entry.data, **user_input})
             if not error:
-                return self.async_update_reload_and_abort(reauth_entry, data_updates=user_input)
+                return self.async_update_and_abort(reauth_entry, data_updates=user_input)
             errors["base"] = error
         return self.async_show_form(
             step_id="reauth_confirm",

--- a/custom_components/mikrotik_router/device_tracker.py
+++ b/custom_components/mikrotik_router/device_tracker.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from datetime import timedelta
 from typing import Any, Callable
 
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.const import STATE_NOT_HOME
 from homeassistant.helpers import entity_platform as ep
@@ -15,7 +15,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utcnow
 
-from homeassistant.components.device_tracker.const import SourceType
 
 from .coordinator import MikrotikConfigEntry, MikrotikCoordinator
 from .device_tracker_types import (

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,25 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260614-ha-deprecations-cleanup - clear HA device_tracker + config-flow reload deprecations
+
+**Date:** 2026-06-14
+**Branch:** `chore/ha-deprecations-cleanup` -> PR to `dev`
+**Status:** In Review
+
+### What changed
+- `device_tracker.py` - import `ScannerEntity` and `SourceType` from `homeassistant.components.device_tracker` instead of the deprecated `.config_entry` / `.const` aliases (HA 2026.6 deprecation; alias removed in HA Core 2027.6). Upstream [tomaae#495](https://github.com/tomaae/homeassistant-mikrotik_router/issues/495).
+- `config_flow.py` - reauth uses `async_update_and_abort()` instead of `async_update_reload_and_abort()`; the existing config-entry update listener performs the single reload, ending the deprecated double-reload (HA 2026.6 -> error 2026.12). `ISS-260614`.
+- `tests/test_config_flow.py` - comment refresh (reauth now reloads via the listener).
+
+### Why
+Two HA deprecations logged on 2026.6+: the `ScannerEntity` alias (removed 2027.6) and the update-listener + config-flow-reload double-reload (error 2026.12). Both are deadline-driven and clear real log noise for every user; bundled into one cleanup.
+
+### Verification
+654 passed, 5 skipped (py3.14 Docker); ruff clean. Reauth flow test stays green (abort reason + data update preserved by `async_update_and_abort`).
+
+---
+
 ## CR-260614-librouteros-login-method - pass librouteros login_method callable (auth correctness)
 
 **Date:** 2026-06-14

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -143,11 +143,11 @@ Native per-port PoE-out **energy** sensors (kWh, `total_increasing`) derived fro
 
 ---
 
-### ISS-260614-configflow-reload-deprecation — config-entry listener + reload deprecated (HA 2026.6 → error 2026.12)
+### ISS-260614-configflow-reload-deprecation — HA deprecations: config-flow reload double-reload + ScannerEntity alias
 **Type:** Bug (HA deprecation)
 **Priority:** Medium — hard deadline HA Core **2026.12**
 **Created:** 2026-06-14
-**Status:** 🟡 Open
+**Status:** 🟢 Fixed on `chore/ha-deprecations-cleanup` (CR-260614-ha-deprecations-cleanup) — bundled with the ScannerEntity alias deprecation (upstream #495).
 
 **Symptom:** HA deprecated (2026.6) using a config-entry update listener together with config-flow reload methods (double-reload / race); becomes an **error in 2026.12**. `[verified: developers.home-assistant.io/blog]`
 
@@ -155,7 +155,29 @@ Native per-port PoE-out **energy** sensors (kWh, `total_increasing`) derived fro
 
 **Fix (per HA):** drop the listener and rely on the config-flow reload, **or** switch to `async_update_and_abort()` / set `reload_on_update=False`. Small change; land before 2026.12.
 
+**Resolution:** reauth switched to `async_update_and_abort()` (`config_flow.py`) — the update listener performs the single reload, ending the double-reload. **Bundled (upstream #495, HA 2026.6 → alias removed 2027.6):** `device_tracker.py` now imports `ScannerEntity`/`SourceType` from `homeassistant.components.device_tracker` instead of the deprecated `.config_entry`/`.const` aliases. 654 tests pass.
+
 **Note:** other 2026.x deprecations checked — `FlowHandler.show_advanced_options` (removed 2027.6) not used; MQTT publish-param change N/A. Python 3.14 already the HA runtime (CI covers 3.13/3.14).
+
+---
+
+### ENH-260614-sfp-temperature — expose `sfp-temperature` health sensor (upstream #499)
+**Type:** Enhancement (new sensor)
+**Priority:** Low
+**Created:** 2026-06-14
+**Status:** 🔵 Filed — ported from upstream [tomaae#499](https://github.com/tomaae/homeassistant-mikrotik_router/issues/499)
+
+Some boards (e.g. CRS317-1G-16S+) report `sfp-temperature` in `/system/health`, which the integration does not surface. Add it as a temperature sensor alongside the existing health temps — a small addition to the v7 `health7` consumption + a `sensor_types.py` descriptor (`device_class=temperature`, °C, DIAGNOSTIC). Hardware-gated like the other health sensors; verify the exact field name on a live SFP-equipped board (`/system/health print`) before shipping (no SFP-temp board in the maintainer fleet — csr310 reports cpu/phy/board only).
+
+---
+
+### ENH-260614-lte-modem-info — LTE modem cell-info sensors (upstream #249)
+**Type:** Enhancement (new sensors)
+**Priority:** Medium — high upstream demand (26 comments)
+**Created:** 2026-06-14
+**Status:** 🔵 Filed — ported from upstream [tomaae#249](https://github.com/tomaae/homeassistant-mikrotik_router/issues/249)
+
+Expose LTE modem cell metrics (RSSI/RSRP/RSRQ/SINR, registration status, operator, band/EARFCN, cell-id) for RouterOS LTE interfaces from `/interface/lte/monitor [find] once`, gated on LTE-interface detection + a new `CONF_SENSOR_LTE` opt-in. Neither upstream nor the Csontikka alternative implements this → a genuine differentiator. Needs capability detection, a `get_lte()` coordinator fetch, descriptors, and live validation on LTE hardware (none in the maintainer fleet — contributor/beta gate, like PoE energy). Scope its own ADR if the dataset shape is non-trivial.
 
 ---
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -147,7 +147,7 @@ async def test_reauth_flow_updates_credentials(hass):
     assert result["step_id"] == "reauth_confirm"
 
     # Patch both import sites: config_flow uses MikrotikAPI for the credential
-    # check, and async_update_reload_and_abort reloads the entry, so coordinator
+    # check, and the update listener reloads the entry on the data change, so coordinator
     # async_setup_entry instantiates it too. Without the coordinator patch the
     # real librouteros.connect() reaches the socket layer (HASocketBlockedError);
     # the reload task is scheduled and only runs before teardown on some Python


### PR DESCRIPTION
## Summary
Two HA deprecations logged since 2026.6, bundled into one cleanup:

- **ScannerEntity** ([tomaae#495](https://github.com/tomaae/homeassistant-mikrotik_router/issues/495)) — `device_tracker.py` now imports `ScannerEntity`/`SourceType` from `homeassistant.components.device_tracker` instead of the deprecated `.config_entry` / `.const` aliases. The alias is **removed in HA Core 2027.6**.
- **config-flow double-reload** (`ISS-260614`) — reauth now calls `async_update_and_abort()` instead of `async_update_reload_and_abort()`. The existing config-entry update listener performs the single reload, so the deprecated listener + flow-reload double-reload (**error in HA 2026.12**) is gone. The update listener is kept (it's needed for options-apply).

Also files two upstream-ported enhancements for the backlog: `ENH-260614-sfp-temperature` ([#499](https://github.com/tomaae/homeassistant-mikrotik_router/issues/499)) and `ENH-260614-lte-modem-info` ([#249](https://github.com/tomaae/homeassistant-mikrotik_router/issues/249)).

## Verification
- Full suite: **654 passed, 5 skipped** (py3.13/3.14 in CI); ruff clean.
- Reauth flow test stays green — `async_update_and_abort` preserves the `reauth_successful` abort + the credential data update.
- HA confirms both `ScannerEntity`/`SourceType` (from `device_tracker`) and `async_update_and_abort` exist in the pinned HA.

## Post-Deploy Actions
- None. No user-visible change — clears deprecation warnings from the HA log and beats the 2026.12 / 2027.6 removal deadlines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)