### PR TITLE
test: pin librouteros.connect() call contract + file deprecation-catch follow-ups

### DIFF
--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,24 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260614-connect-contract-test - pin librouteros.connect() call contract
+
+**Date:** 2026-06-14
+**Branch:** `test/connect-contract-assertions` -> PR to `dev`
+**Status:** In Review
+
+### What changed
+- `tests/test_mikrotikapi.py` - `TestConnectKwargs` pins the exact kwargs passed to `librouteros.connect()` (positional creds; `{encoding, login_method, port}` + `ssl_wrapper` under SSL; the pre-3.0 `login_methods` name must never be passed). Complements `TestLoginMethod`.
+- `docs/ISSUES.md` - test-hardening follow-ups filed: deprecation-as-failure setup test (under ENH-260608-test-suite-hardening) + `ENH-260614-ha-canary-ci`.
+
+### Why
+Retrospective on the bugs swept from upstream (ScannerEntity #495, config-flow double-reload ISS-260614, librouteros `login_methods` ISS-260417): all three slipped because they are warnings / silent fallbacks at mocked seams against a single pinned HA. This pins the one external-lib call contract that silently drops bad kwargs; the structural catches (real-setup deprecation test, HA-latest canary lane) are filed for the test-hardening track.
+
+### Verification
+656 passed, 5 skipped (py3.14 Docker; +2 contract tests); ruff clean.
+
+---
+
 ## CR-260614-ha-deprecations-cleanup - clear HA device_tracker + config-flow reload deprecations
 
 **Date:** 2026-06-14

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -181,6 +181,16 @@ Expose LTE modem cell metrics (RSSI/RSRP/RSRQ/SINR, registration status, operato
 
 ---
 
+### ENH-260614-ha-canary-ci — non-blocking CI lane against HA latest/dev to surface deprecations early
+**Type:** Enhancement (CI / test quality)
+**Priority:** Medium
+**Created:** 2026-06-14
+**Status:** 🔵 Filed
+
+The suite pins one HA version (whatever `pytest-homeassistant-custom-component` resolves), so a deprecation introduced upstream — e.g. `ScannerEntity` in HA 2026.6 (#495) — isn't seen until a user reports log noise. Add a **non-blocking** (`continue-on-error`) CI matrix lane that installs the newest HA (or HA `dev`) and runs the suite, surfacing new deprecations/removals the day they ship. Pairs with `ENH-260523-ha-release-watch` (release-notes watcher) but operates at the test level; treat a red canary as an early-warning signal to file a deprecation ISS, not a PR blocker.
+
+---
+
 ### ENH-260608-test-suite-hardening — migrate tests to spec'd mocks, parametrize, behaviour assertions
 **Type:** Enhancement (test quality)
 **Priority:** **High — pre-release deliverable** (maintainer 2026-06-08: must land before the next release)
@@ -197,6 +207,7 @@ The suite leans on unspecced `MagicMock` (yes-man) coordinators/descriptions, ne
 - [ ] **Goldens build — implement ADR-014** (the durable target): syrupy wiring → `setup_integration` fixture → deterministic per-path `MockMikrotikAPI` fixtures (make-or-break) → sensor exemplar → expand per platform → drop `sonar-project.properties` platform exclusions → portable `config/docs/templates/hacs-testing/` template. **Next-session focus.**
 - [ ] (OPTIONAL — superseded by ADR-014 goldens) `conftest.py::make_mock_coordinator` `spec=MikrotikCoordinator` bridge; do only as a quick win before goldens land
 - [ ] remaining (orthogonal): T4 parametrize clusters, T6 fixtures, T3 `make_coordinator` `object.__new__`
+- [ ] **Deprecation-as-failure** (retrospective on ScannerEntity #495 / config-flow double-reload ISS-260614 / librouteros ISS-260417 — all warnings/silent fallbacks our mocked unit tests can't see): once the `setup_integration` fixture lands, add a test that loads the entry through HA and asserts `caplog` has no `deprecated` / `will be removed` records; investigate whether `pytest-homeassistant-custom-component` can promote HA deprecation reports to errors. Pin external-lib call contracts at every mock seam (done for `librouteros.connect` — `TestConnectKwargs`/`TestLoginMethod`; extend to remaining seams).
 
 ---
 

--- a/tests/test_mikrotikapi.py
+++ b/tests/test_mikrotikapi.py
@@ -556,3 +556,35 @@ class TestLoginMethod:
         from custom_components.mikrotik_router.mikrotikapi import _login_plain
 
         assert self._connect_kwargs("bogus")["login_method"] is _login_plain
+
+
+# --- librouteros.connect() call contract ---
+
+
+class TestConnectKwargs:
+    """Pin the exact kwargs passed to librouteros.connect() so a silently-renamed
+    or dropped kwarg (the `login_methods`->`login_method` class of bug, where the
+    old name is accepted-then-ignored by **kwargs) fails loudly here instead of
+    only surfacing as wrong behaviour against a real router. See ISS-260417."""
+
+    def _call(self, **api_kwargs):
+        from unittest.mock import patch as _patch
+
+        api = make_api(**api_kwargs)
+        with _patch("custom_components.mikrotik_router.mikrotikapi.librouteros.connect") as mock_connect:
+            mock_connect.return_value = MagicMock()
+            api.connect()
+        return mock_connect.call_args
+
+    def test_positional_credentials_and_kwarg_set_no_ssl(self):
+        args, kwargs = self._call(use_ssl=False, port=8728)
+        assert args == ("10.0.0.1", "admin", "admin")
+        assert set(kwargs) == {"encoding", "login_method", "port"}
+        assert kwargs["port"] == 8728
+        # the pre-3.0 plural name must never be passed (it is silently ignored)
+        assert "login_methods" not in kwargs
+
+    def test_includes_ssl_wrapper_under_ssl(self):
+        _, kwargs = self._call(use_ssl=True)
+        assert "ssl_wrapper" in kwargs
+        assert "login_methods" not in kwargs


### PR DESCRIPTION
## Summary
Retrospective hardening after sweeping upstream issues turned up three bugs our suite *structurally couldn't catch* — ScannerEntity ([#495](https://github.com/tomaae/homeassistant-mikrotik_router/issues/495)), the config-flow double-reload (`ISS-260614`), and the librouteros `login_methods` kwarg (`ISS-260417`). All three are **warnings or silent fallbacks at mocked seams against a single pinned HA**, so green unit tests sailed past them.

- **`TestConnectKwargs`** — pins the exact kwargs passed to `librouteros.connect()` (positional creds; `{encoding, login_method, port}`, `+ssl_wrapper` under SSL; the pre-3.0 `login_methods` name must **never** be passed). This makes the "accepted-then-ignored by `**kwargs`" class of bug fail loudly. Complements `TestLoginMethod`.
- **Files the structural catches** rather than half-doing them:
  - Deprecation-as-failure setup test — added to `ENH-260608-test-suite-hardening` (rides the `setup_integration` / ADR-014 work; asserts no `deprecated` log lines once the integration is loaded through HA).
  - `ENH-260614-ha-canary-ci` — a non-blocking CI lane against HA latest/`dev` to surface new deprecations the day they ship.

## Why this approach
The contract-pin (this PR) is the cheap, immediate catch for the librouteros class. The other two classes (deprecated import/setup) genuinely need HA's real setup path, which is exactly the test-hardening track already on the roadmap — so they're filed there, not faked with a mock that wouldn't have caught them anyway.

## Verification
- **656 passed, 5 skipped** (py3.13/3.14 in CI); ruff clean.

## Post-Deploy Actions
- None (test + docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)