### PR TITLE
chore: release v2.3.20-beta.2 (pre-release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
-## What's New — v2.3.20-beta.1
+## What's New — v2.3.20-beta.2
 
 Beta for validating native **PoE-out energy** sensors (#59) on real metering hardware before a stable release.
 
 - **PoE energy for the Energy Dashboard.** Each PoE-out port now exposes an energy sensor (kWh, `total_increasing`) plus a device total, ready to add as a consumption source — no template/Riemann helpers needed. Enable the existing **PoE sensors** option. Counters survive Home Assistant restarts.
 - **Estimated energy for routers without PoE metering.** Some boards (e.g. hAP ax3) power a device but don't report PoE wattage. Where the powered device is uniquely identified via MikroTik Neighbor Discovery, the sensor estimates energy from the device's datasheet rating and labels it `power_source: estimated`. This is a coarse upper-bound estimate, not a measurement. See [ADR-017](docs/decisions/ADR-017-poe-energy-accumulation.md).
+
+- **Also folded in since beta.1:** correct librouteros `login_method` handling (`ISS-260417`) and a cleanup of HA `device_tracker` + config-flow reload deprecations (clears the HA 2026.12 / 2027.6 removal deadlines and the log warnings).
 
 > Beta note: PoE-out energy is new and is being validated against metering hardware via this beta. Measured ports report the real integral of `poe-out-power`; estimated ports use a nameplate maximum (actual draw is typically lower). Feedback welcome on #59.
 

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -14,5 +14,5 @@
         "librouteros>=3.4.1,<4.0",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.20-beta.1"
+    "version": "2.3.20-beta.2"
 }

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,24 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260614-release-v2.3.20-beta.2 - pre-release rolling up PoE energy + librouteros + deprecation fixes
+
+**Date:** 2026-06-14
+**Branch:** `chore/release-v2.3.20-beta.2` -> PR to `dev`
+**Status:** Pre-release - tag `v2.3.20-beta.2` cut from `dev` for maintainer testing (folds the post-beta.1 dev changes); precedes stable `v2.3.20`.
+
+### What changed
+- `manifest.json` `2.3.20-beta.1 -> 2.3.20-beta.2`; README / info.md What's New updated.
+- Rolls up everything landed on `dev` since beta.1: PoE-out energy (CR-260614-poe-energy-sensors), librouteros `login_method` fix (CR-260614-librouteros-login-method), HA deprecations cleanup (CR-260614-ha-deprecations-cleanup), connect-contract test (CR-260614-connect-contract-test).
+
+### Why
+A current pre-release for the maintainer to validate the full `dev` state on the live fleet before stable `v2.3.20` (and so @Dillton can test against the latest).
+
+### Release ops
+Lands on `dev`; cut **pre-release** tag `v2.3.20-beta.2` off `dev` -> `release.yml` (trigger `release: published`) builds the zip. No `dev->master`.
+
+---
+
 ## CR-260614-connect-contract-test - pin librouteros.connect() call contract
 
 **Date:** 2026-06-14

--- a/info.md
+++ b/info.md
@@ -10,10 +10,11 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
-### What's new in v2.3.20-beta.1
+### What's new in v2.3.20-beta.2
 Beta validating native **PoE-out energy** sensors (#59) before a stable release.
 - **PoE energy for the Energy Dashboard** — per-port energy sensors (kWh, `total_increasing`) + a device total, restart-persistent. Enable the existing PoE sensors option.
 - **Estimated energy on non-metering hardware** — where a PoE-out port powers a device that has no wattage reading, energy is estimated from the device's datasheet rating (via Neighbor Discovery) and labelled `power_source: estimated` — a coarse upper bound, not a measurement.
+- **Folded in since beta.1** — librouteros `login_method` correctness (`ISS-260417`) + HA deprecation cleanup (device_tracker `ScannerEntity`, config-flow reload).
 
 ### What's new in v2.3.19
 Stable release rolling up the read-only and quality-scale fixes since v2.3.18. Validated live against a multi-device RouterOS deployment before tagging.


### PR DESCRIPTION
## Summary
Pre-release bump so the maintainer can validate the **full current `dev` state** on the live fleet before stable `v2.3.20`. Folds in everything since `v2.3.20-beta.1`:
- PoE-out energy sensors (`CR-260614-poe-energy-sensors`)
- librouteros `login_method` fix (`CR-260614-librouteros-login-method`, ISS-260417)
- HA deprecations cleanup (`CR-260614-ha-deprecations-cleanup`, #495 / ISS-260614)
- connect-contract test (`CR-260614-connect-contract-test`)

`manifest.json` `2.3.20-beta.1 → 2.3.20-beta.2`; README/info What's New updated.

## Release ops
Lands on `dev`; then cut **pre-release** tag `v2.3.20-beta.2` off `dev` → `release.yml` builds the zip. No `dev→master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)