### PR TITLE
feat: name netwatch entities by their name, not a shared comment (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
+## What's New — v2.3.20-beta.3
+
+- **Netwatch entities named by their netwatch `name`.** If you give each netwatch entry a distinct `name`, Home Assistant now shows that name instead of a shared `comment` — so entries that share a comment are no longer indistinguishable in the entity list, dashboards and automation pickers. Entries without a name fall back to the comment, then to "Netwatch". `unique_id`s are unchanged, so existing entity IDs and automations are preserved. Addresses [#70](https://github.com/jnctech/homeassistant-mikrotik_router/issues/70). See [ADR-018](docs/decisions/ADR-018-netwatch-name-precedence.md).
+
 ## What's New — v2.3.20-beta.2
 
 Beta for validating native **PoE-out energy** sensors (#59) on real metering hardware before a stable release.

--- a/custom_components/mikrotik_router/binary_sensor_types.py
+++ b/custom_components/mikrotik_router/binary_sensor_types.py
@@ -44,6 +44,7 @@ DEVICE_ATTRIBUTES_UPS = [
 
 DEVICE_ATTRIBUTES_NETWATCH = [
     "host",
+    "name",
     "type",
     "interval",
     "port",
@@ -66,6 +67,12 @@ class MikrotikBinarySensorEntityDescription(BinarySensorEntityDescription):
     data_attribute: str = "available"
     data_name: str | None = None
     data_name_comment: bool = False
+    # When True, custom_name prefers a non-empty data_name over the comment,
+    # then falls back to comment, then the static name. Used by netwatch so
+    # entries sharing a comment are disambiguated by their distinct name.
+    # Other platforms' descriptions lack the field, so custom_name reads it
+    # defensively. See ADR-018.
+    data_name_prefer: bool = False
     data_uid: str | None = None
     data_reference: str | None = None
     data_attributes_list: List = field(default_factory=lambda: [])
@@ -132,8 +139,8 @@ SENSOR_TYPES: tuple[BinarySensorEntityDescription, ...] = (
         ha_connection_value="Netwatch",
         data_path="netwatch",
         data_attribute="status",
-        data_name="host",
-        data_name_comment=True,
+        data_name="name",
+        data_name_prefer=True,
         data_uid="host",
         data_reference="host",
         data_attributes_list=DEVICE_ATTRIBUTES_NETWATCH,

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1690,6 +1690,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             key="host",
             vals=[
                 {"name": "host"},
+                {"name": "name"},
                 {"name": "type"},
                 {"name": "interval"},
                 {"name": "port"},

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -326,6 +326,23 @@ class MikrotikEntity(CoordinatorEntity[_MikrotikCoordinatorT], Entity):
 
             return f"{self.entity_description.name}"
 
+        return self._compose_uid_name()
+
+    def _compose_uid_name(self) -> str:
+        """Resolve the display name for a uid-keyed entity (ADR-007 extraction)."""
+        # data_name_prefer surfaces a distinct per-entry data_name over a
+        # (possibly shared) comment, falling back comment -> static name. Used
+        # by netwatch so entries sharing a comment are disambiguated. Other
+        # platforms' descriptions lack the field, so read it defensively.
+        # See ADR-018.
+        if getattr(self.entity_description, "data_name_prefer", False):
+            value = self._data.get(self.entity_description.data_name)
+            if value and value.strip():
+                return f"{value}"
+            if self._data.get("comment"):
+                return f"{self._data['comment']}"
+            return f"{self.entity_description.name}"
+
         if self.entity_description.data_name_comment and self._data.get("comment"):
             return f"{self._data['comment']}"
 

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -14,5 +14,5 @@
         "librouteros>=3.4.1,<4.0",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.20-beta.2"
+    "version": "2.3.20-beta.3"
 }

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,33 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260615-netwatch-naming - name netwatch entities by `name`, not shared `comment` (#70)
+
+**Date:** 2026-06-15
+**Branch:** `feature/netwatch-naming` -> PR to `dev`
+**Status:** In Review
+
+### What changed
+- `entity.py`: extracted the uid-path naming into `_compose_uid_name` (ADR-007; `custom_name` is now a thin dispatcher) and added a first-branch precedence for descriptors with `data_name_prefer=True` -> resolve display name `data_name` (non-empty, whitespace-stripped) -> `comment` -> static `name`, returned **bare** (no suffix). `getattr`-guarded so other platforms are unaffected.
+- `binary_sensor_types.py`: added `data_name_prefer: bool = False` to `MikrotikBinarySensorEntityDescription`; added `"name"` to `DEVICE_ATTRIBUTES_NETWATCH`; netwatch descriptor `data_name="host"` -> `"name"`, `+data_name_prefer=True`, dropped `data_name_comment=True`. `data_uid`/`data_reference` stay `"host"`.
+- `coordinator.py` `get_netwatch`: parse `name` (`{"name": "name"}` in `vals`; `from_entry` defaults `""` for older ROS).
+- Tests: real-typed `_binary_entity_with_real_desc` + parametrized netwatch precedence, IPv6 unique_id, duplicate-name residual, dhcp/switch scope guards (prefer stays off), coordinator name-parse cases.
+- Docs: `ADR-018-netwatch-name-precedence`; `manifest.json` `2.3.20-beta.2` -> `2.3.20-beta.3`; README/info.md What's New; `ENH-260608` -> In Review; filed `ENH-260615-netwatch-host-key-collision`.
+
+### Why
+[#70](https://github.com/jnctech/homeassistant-mikrotik_router/issues/70): users sharing one `comment` across many netwatch entries saw indistinguishable entities. Showing the distinct netwatch `name` (with comment/static fallback) disambiguates them. Bare (no suffix) because `has_entity_name` already prepends the `<inst> Netwatch` device name — a suffix would read "Netwatch ... Netwatch". A new flag (not the ADR-013 `data_name_compose` reorder) was required because the 5 `data_name_comment` switches need comment-first ordering. `unique_id` stays host-derived -> no migration. See ADR-018.
+
+### Verification
+- ruff lint + format clean (container `ruff==0.9.0`).
+- Full suite **669 passed, 5 skipped** (WSL python:3.13); total coverage **88%** (>=80% gate). `binary_sensor_types.py` 100%, `entity.py` 95%.
+- Cognitive complexity (`complexipy`, SonarSource definition): `custom_name` **4**, `_compose_uid_name` **12** — both <=15. The whitespace-strip `and` tipped the in-place form to 16, so the helper was extracted per ADR-007.
+- Live: full `validate-live-sensors` matrix on a RouterOS 7.22 fleet (beta.3 side-load) — name-shown and name-less->comment both confirmed; all sensor classes cross-checked against router ground-truth, 0 integration entities unavailable, no regressions.
+
+### Release ops
+Lands on `dev`; pre-release tag `v2.3.20-beta.3` off `dev` -> `release.yml`. No `dev->master`.
+
+---
+
 ## CR-260614-release-v2.3.20-beta.2 - pre-release rolling up PoE energy + librouteros + deprecation fixes
 
 **Date:** 2026-06-14

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -22,7 +22,7 @@
 > - **Test-catch hardening (retrospective on the deprecation/kwarg bugs — all warnings/silent fallbacks our mocked unit tests can't see):** deprecation-as-failure `setup_integration` test (folded into `ENH-260608` goldens) + `ENH-260614-ha-canary-ci` (non-blocking HA-latest CI lane).
 > - **Goldens BUILD (ADR-014 / `ENH-260608-test-suite-hardening`)** — `setup_integration` fixture → per-path `MockMikrotikAPI` fixtures → per-platform exemplars → drop `sonar-project.properties` exclusions → portable `config/docs/templates/hacs-testing/`. Unlocks the deprecation-as-failure test above.
 > - **Gold/Platinum conformance** — `reconfiguration-flow` + `strict-typing`.
-> - **`ENH-260608-netwatch-naming` (#70)**, **#76** capsman AP-vs-bridge name (@fuecy), **`ISS-260608-cleanup-over-logging`** (#92).
+> - **`ENH-260608-netwatch-naming` (#70)** — 🟢 In Review on `feature/netwatch-naming` for **v2.3.20-beta.3** (ADR-018); spun off **`ENH-260615-netwatch-host-key-collision`** (same-host probe collapse, deferred). · **#76** capsman AP-vs-bridge name (@fuecy), **`ISS-260608-cleanup-over-logging`** (#92).
 > - **Coordinator decomposition — DEFERRED** (would be ADR-016) until a concrete trigger.
 >
 > **Standards:** all PRs target `dev`; `master` release-only via PR + immediate back-merge (guard enforces `master ⊆ dev`). Betas are pre-releases off `dev` (no `dev→master`). Refresh this `## In-flight` at session-end; don't delete merged PR branches immediately (validate race). Live validation each release per `docs/release-validation.md`. **Tooling gotchas:** run tests in Docker (`docker run --rm -v <repo>:/app -v /home/jc/mikrotik-test/.venv:/venv -w /app python:3.14 /venv/bin/python -m pytest`), NOT bare-WSL (dead venv symlink); Edit/Write intermittently EBADF on this OneDrive repo → patch via `C:\tmp` script + WSL `python3`; `manifest.json` is CRLF (`sed` the version line, don't python-rewrite the file).
@@ -105,15 +105,23 @@ On networks with many clients or multiple DHCP servers, distinct entities receiv
 **Type:** Enhancement (entity naming / quality)
 **Priority:** Low
 **Created:** 2026-06-08
-**Status:** 🔵 Filed (follow-up to ENH-260608-entity-naming)
+**Status:** 🟢 In Review — implemented on `feature/netwatch-naming` for v2.3.20-beta.3 (CR-260615-netwatch-naming, ADR-018)
 
 **Request ([jnctech #70](https://github.com/jnctech/homeassistant-mikrotik_router/issues/70)):** with 50+ netwatch entries, many **share a `comment`**, so they collapse to one display name; the user wants the distinct **`name`** field shown instead.
 
-**Same class of bug as ENH-260608-entity-naming, but needs more than its `data_name_compose` flag:**
-- `get_netwatch` (`coordinator.py:~1542`) does **not** parse a `name` field — it must be added to the dataset first.
-- netwatch's descriptor sets `data_name_comment=True`, so the collapse fires via the **comment branch** (`entity.py:302-303`), not (only) the `data_name==data_reference` shortcut. Honoring the request requires a **name-vs-comment precedence decision** that conflicts with current comment-first behaviour.
+**Resolution (ADR-018):** new `data_name_prefer` flag on the binary_sensor description; netwatch now resolves its display name **`name` (non-empty) → `comment` → static "Netwatch"**, bare (no suffix, since `has_entity_name` prepends the `<inst> Netwatch` device). `get_netwatch` parses `name` (`vals`, defaults `""`); `data_reference="host"` kept, so `unique_id`/entity_ids are unchanged. A new flag (not the `data_name_compose` reorder) was needed because the 5 `data_name_comment` switches require comment-first ordering. Scope: **entity display names only** (per-host devices out of scope). Same-host key collision is a separate root → **ENH-260615**.
 
-**Plan:** extend `get_netwatch` to parse `name`; decide precedence (likely `name` when present, else `comment`); reuse the general `data_name_compose` mechanism from ADR-013 where applicable. Separate PR — kept out of ADR-013 to keep that change small and gated.
+---
+
+### ENH-260615-netwatch-host-key-collision — same-host netwatch probes collapse to one entity
+**Type:** Enhancement (entity identity)
+**Priority:** Low
+**Created:** 2026-06-15
+**Status:** 🔵 Filed (split out from ENH-260608-netwatch-naming / #70)
+
+`get_netwatch` keys netwatch on `host` (`coordinator.py:1690`), which is **not unique**: RouterOS allows multiple probes on the same host (different type/port). Two same-host entries resolve to the same uid and overwrite each other in `data[uid]` (`apiparser.py:143`, `_get_uid_from_keys` returns `entry["host"]`) → only **one** HA entity. Live-observed: two netwatch entries (`.id` `*1`/`*2`) on the same `host` surface as a single entity.
+
+This is distinct from #70 (display-name collapse, fixed in ADR-018) — naming cannot fix a genuine key collision. `key_secondary` is an absent-key fallback, not a composite (`apiparser.py:163-171`), so it can't separate same-host rows. RouterOS exposes a unique `.id` (already used as a key elsewhere — `coordinator.py:1277/1567/3095`), but it is **unstable across reorders**, so re-keying changes `unique_id` and needs an **entity-registry migration**. Defer until a concrete need; design the migration first.
 
 ---
 

--- a/docs/decisions/ADR-018-netwatch-name-precedence.md
+++ b/docs/decisions/ADR-018-netwatch-name-precedence.md
@@ -1,0 +1,64 @@
+# ADR-018 — Netwatch entity naming by `name`, with name→comment→static precedence
+
+**Status:** Accepted — implemented on `feature/netwatch-naming` (CR-260615-netwatch-naming).
+**Date:** 2026-06-15
+**Supersedes/relates:** `ENH-260608-netwatch-naming` ([jnctech #70](https://github.com/jnctech/homeassistant-mikrotik_router/issues/70)). Realises the follow-up pre-authored in ADR-013 §Out-of-scope. Gold quality-scale *entity-naming*.
+**Numbering note:** ADR-014 = entity-golden-tests, ADR-017 = poe-energy-accumulation (both on `dev`). **ADR-015 (librouteros salvage renumber) and ADR-016 (coordinator decomposition) are reserved** per `docs/ISSUES.md`. ADR-017 is highest on disk → this takes **018**.
+
+## Context
+
+[#70](https://github.com/jnctech/homeassistant-mikrotik_router/issues/70): a user with 50+ netwatch entries sees many entities show the same display name, because the integration names netwatch entities **comment-first** and the user shares one `comment` across entries while setting a distinct netwatch `name` per entry (ROS 7.22.3). They want the `name` shown.
+
+Two distinct "roll-up" phenomena exist; only **A** is what #70 reports. Both verified live against a RouterOS 7.22 router in the planning session.
+
+### A — display-name collapse (#70's root)
+Distinct `host` values → distinct uids → distinct entities, but `custom_name` returns the shared `comment` (`entity.py:342-343`, fired because the netwatch descriptor set `data_name_comment=True`), so the entities *look* identical. **Live evidence:** a live netwatch entity reported `friendly_name = "<inst> Netwatch <comment>"` — i.e. the device name (`<inst> Netwatch`) + the shared comment. Root = comment-first naming.
+
+### B — true entity collapse (NOT #70, deferred)
+`get_netwatch` keys on `host` (`coordinator.py:1690`), which is **not unique**: two probes on the same host overwrite each other in `data[uid]` (`apiparser.py:143`, `_get_uid_from_keys` returns `entry["host"]`) → genuinely one HA entity. **Live evidence:** a live router had two netwatch entries (`.id` `*1`/`*2`) on the same `host`, surfacing as a single HA entity. Naming cannot fix this. `key_secondary` is an absent-key fallback, not a composite (`apiparser.py:163-171`), so it can't separate them. Tracked as **ENH-260615-netwatch-host-key-collision** (re-keying needs a `unique_id` migration).
+
+### has_entity_name interaction (decides "no suffix")
+`_attr_has_entity_name = True` (`entity.py:284`); the netwatch device is named `f"{self._inst} {dev_group}"` = `<inst> Netwatch` (`entity.py:419`, else branch, `ha_group="Netwatch"`). HA renders `{device} {entity}`. Because the device group is itself "Netwatch", composing the entity name as `"{name} Netwatch"` would render `"<inst> Netwatch <name> Netwatch"` — "Netwatch" twice. So the entity name must be the **bare** `name` (unlike ADR-013's DHCP `"dhcp88 DHCP server"`, where the device is the board name and carries no "DHCP server" token).
+
+### RouterOS `name` availability
+Live: `:put [/tool netwatch get 0 name]` returns empty without error → `name` is a real property, `""` when unset. With `{"name":"name"}` in `vals`, `from_entry` returns `default=""` for absent/empty (`apiparser.py:39-43`), covering older ROS that lacks the property. No `ensure_vals` needed.
+
+## Decision
+
+For descriptors carrying a new `data_name_prefer: bool = False` flag, `custom_name` resolves the display name as **`data_name` (non-empty) → `comment` (non-empty) → static `entity_description.name`**, returning the value **bare** (no composition). Set `data_name_prefer=True` on netwatch only; drop its `data_name_comment=True`. Parse `name` in `get_netwatch`; add `name` to `DEVICE_ATTRIBUTES_NETWATCH`. Keep `data_uid`/`data_reference="host"` so `unique_id` is unchanged.
+
+**Why a new flag, not a reorder:** the 5 firewall/container switches that carry `data_name_comment=True` (`switch_types.py:173/191/209/227/314`) require comment-first ordering; generalising the comment branch would rename them. A narrow opt-in flag avoids that.
+
+**Why not `data_name_compose`:** with `data_reference="host" != data_name="name"`, the `entity.py:351` equality shortcut never fires, so `data_name_compose` is a no-op for netwatch.
+
+**Final fallback is the static label, not the host** (maintainer decision): keeps scope tight to #70 and avoids surprise renames / poor IPv6/DNS display names for name-less+comment-less entries. Those stay as they are today.
+
+## Consequences
+
+**Non-breaking (verified):**
+- `unique_id = f"{inst}-netwatch-{slugify(host)}"` (`entity.py:359-362`, keyed on `data_reference="host"`) is **invariant** under the `data_name` change → existing entity_ids and automations untouched; no registry or config-entry migration.
+- Only the friendly name updates. Who sees a change: (a) entries with a `name` set → now show the name (the fix); (b) name-less but comment-set → unchanged (still the comment); (c) name-less + comment-less → unchanged (static "Netwatch").
+
+**Known residuals (documented, not fixed here):**
+- Two entries with the same `name` on different hosts collide on display name but stay distinct entities (host-derived `unique_id`). Symmetric to the shared-comment footgun; mitigated by setting distinct names.
+- Names refresh on **reload, not live** — `_attr_name` is computed once in `__init__` (`entity.py:303`); `_handle_coordinator_update` refreshes only `self._data`. Pre-existing for all entities.
+- Roll-up B (same-host collapse) → ENH-260615.
+
+## Implementation (applied on `feature/netwatch-naming`)
+1. `coordinator.py` `get_netwatch` (`:1685`): add `{"name": "name"}` to `vals`.
+2. `binary_sensor_types.py`: add `data_name_prefer: bool = False` to `MikrotikBinarySensorEntityDescription`; add `"name"` to `DEVICE_ATTRIBUTES_NETWATCH`; netwatch descriptor `data_name="name"`, `data_name_prefer=True`, drop `data_name_comment`.
+3. `entity.py`: the whitespace-stripped prefer check (`if value and value.strip()`) tipped the in-place `custom_name` to 16 cognitive complexity, so the uid-path naming was extracted into `_compose_uid_name` per ADR-007. `custom_name` is now a thin dispatcher (complexity 4); `_compose_uid_name` holds the prefer block (first branch, `getattr`-guarded) + the legacy comment/compose/static logic (complexity 12). The `MikrotikClientTrafficSensor.custom_name` override is unaffected (it never calls the helper).
+
+## Testing (behaviour, real-typed per ENH-260608-test-suite-hardening)
+- Netwatch precedence, parametrized from the **real `MikrotikBinarySensorEntityDescription`**: name beats a shared comment (positive assertion); name with comment-key absent; name empty → comment; name empty + comment empty/absent → static "Netwatch".
+- `unique_id` host-derived and name-independent, incl. an IPv6 host; duplicate-name-across-hosts residual pinned (distinct unique_ids).
+- Scope guards prove the prefer branch stays **off** for `data_name_comment` switches and `data_name_compose` dhcp sensors (the dhcp guard uses a row with both `name` and a `comment` so a leaked prefer branch would change the output).
+- Coordinator: `name` parsed when present (siblings intact); `""` when absent or present-empty.
+- Live QA via `validate-live-sensors` against a box with a netwatch `name` set before cutting the beta.
+
+## Out of scope
+- Per-host *devices* (the issue title says "device names"; the body asks for the name shown — delivered via entity naming under the shared device). Registry/migration change; not requested in the body.
+- Roll-up B / `host`-key collision → ENH-260615.
+
+## Provenance
+All facts cite code `file:line` on `feature/netwatch-naming` (post `dev` merge of ADR-014/017) or live SSH/recorder queries against a RouterOS 7.22 router, 2026-06-15.

--- a/info.md
+++ b/info.md
@@ -10,6 +10,9 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
+### What's new in v2.3.20-beta.3
+- **Netwatch entities are named by their netwatch `name`** — if you set a distinct `name` on each netwatch entry, that name is now shown in Home Assistant instead of a shared `comment`, so entries that share a comment are no longer indistinguishable. Entries with no name keep showing their comment (or "Netwatch" if neither is set). Your entity IDs and automations are unchanged. Addresses #70.
+
 ### What's new in v2.3.20-beta.2
 Beta validating native **PoE-out energy** sensors (#59) before a stable release.
 - **PoE energy for the Energy Dashboard** — per-port energy sensors (kWh, `total_increasing`) + a device total, restart-persistent. Enable the existing PoE sensors option.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2782,6 +2782,45 @@ def test_netwatch_basic_parsing():
     assert nw["enabled"] is True
 
 
+def test_netwatch_parses_name():
+    """get_netwatch surfaces the netwatch name field, alongside its siblings (#70)."""
+    coordinator = make_coordinator(
+        api_responses={
+            "/tool/netwatch": [
+                {
+                    "host": "1.1.1.1",
+                    "name": "WAN uplink",
+                    "type": "icmp",
+                    "comment": "edge",
+                    "disabled": False,
+                },
+            ],
+        }
+    )
+    coordinator.get_netwatch()
+    nw = coordinator.ds["netwatch"]["1.1.1.1"]
+    assert nw["name"] == "WAN uplink"
+    # the new vals entry must not disturb sibling parsing
+    assert nw["comment"] == "edge"
+    assert nw["enabled"] is True
+
+
+def test_netwatch_name_defaults_empty_when_absent_or_empty():
+    """Absent or present-empty name both resolve to '' (from_entry default), so
+    custom_name falls back to comment/static rather than raising."""
+    coordinator = make_coordinator(
+        api_responses={
+            "/tool/netwatch": [
+                {"host": "1.1.1.1", "type": "icmp"},  # name absent (older ROS)
+                {"host": "2.2.2.2", "name": "", "type": "icmp"},  # name present-empty
+            ],
+        }
+    )
+    coordinator.get_netwatch()
+    assert coordinator.ds["netwatch"]["1.1.1.1"]["name"] == ""
+    assert coordinator.ds["netwatch"]["2.2.2.2"]["name"] == ""
+
+
 # ---------------------------------------------------------------------------
 # Group AA: get_system_routerboard() — routerboard parsing
 # ---------------------------------------------------------------------------

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from homeassistant.const import CONF_NAME
+from homeassistant.util import slugify
 
 from custom_components.mikrotik_router.entity import (
     copy_attrs,
@@ -13,6 +15,9 @@ from custom_components.mikrotik_router.entity import (
 from custom_components.mikrotik_router.coordinator import MikrotikCoordinator
 from custom_components.mikrotik_router.sensor_types import (
     MikrotikSensorEntityDescription,
+)
+from custom_components.mikrotik_router.binary_sensor_types import (
+    MikrotikBinarySensorEntityDescription,
 )
 from custom_components.mikrotik_router.const import (
     CONF_SENSOR_PORT_TRAFFIC,
@@ -41,6 +46,23 @@ def _entity_with_real_desc(data_path, uid, row, **desc_kwargs):
     coord.config_entry = MagicMock()
     coord.config_entry.data = {CONF_NAME: "Mikrotik"}
     desc = MikrotikSensorEntityDescription(data_path=data_path, **desc_kwargs)
+    with patch_coordinator_entity_init():
+        return MikrotikEntity(coord, desc, uid)
+
+
+def _binary_entity_with_real_desc(data_path, uid, row, **desc_kwargs):
+    """Build a MikrotikEntity from a REAL MikrotikBinarySensorEntityDescription.
+
+    netwatch is a binary_sensor, so its naming must be exercised through the
+    real binary-sensor description (not the sensor one) — a renamed/removed
+    field then fails the test instead of silently passing. See ADR-018.
+    The instance name is "Mikrotik" so unique_ids are prefixed "mikrotik-".
+    """
+    coord = MagicMock(spec=MikrotikCoordinator)
+    coord.data = {data_path: {uid: row}}
+    coord.config_entry = MagicMock()
+    coord.config_entry.data = {CONF_NAME: "Mikrotik"}
+    desc = MikrotikBinarySensorEntityDescription(data_path=data_path, **desc_kwargs)
     with patch_coordinator_entity_init():
         return MikrotikEntity(coord, desc, uid)
 
@@ -194,6 +216,25 @@ class TestMikrotikEntityCustomName:
         )
         assert entity.custom_name == "Queue"
 
+    def test_custom_name_compose_ignores_comment_and_prefer(self):
+        """Scope guard (ADR-018): a data_name_compose descriptor that also carries
+        a comment still composes from data_name. Proves the new data_name_prefer
+        branch does not leak onto compose/comment descriptors — if it did, this
+        would return 'dhcp88' (bare) or 'LAN' (comment) instead of the composed
+        label. The sensor description has no data_name_prefer field, so the
+        getattr default keeps the prefer branch off."""
+        entity = _entity_with_real_desc(
+            "dhcp-server",
+            "dhcp88",
+            {"name": "dhcp88", "comment": "LAN", "status": "enabled"},
+            key="dhcp_server_status",
+            name="DHCP server",
+            data_name="name",
+            data_reference="name",
+            data_name_compose=True,
+        )
+        assert entity.custom_name == "dhcp88 DHCP server"
+
     def test_custom_name_with_uid_different_reference_and_name(self):
         """When data_reference != data_name, includes data_name in output."""
         coord = make_mock_coordinator()
@@ -230,6 +271,87 @@ class TestMikrotikEntityCustomName:
             uid="ether1",
         )
         assert entity.custom_name == "ether1"
+
+
+# ---------------------------------------------------------------------------
+# Netwatch name precedence (ENH-260608 / #70 / ADR-018)
+# ---------------------------------------------------------------------------
+
+# Real netwatch descriptor field set (mirrors binary_sensor_types.py).
+NETWATCH_DESC_KW = dict(
+    key="netwatch",
+    name="Netwatch",
+    data_name="name",
+    data_uid="host",
+    data_reference="host",
+    data_name_prefer=True,
+)
+
+
+class TestNetwatchCustomName:
+    """Netwatch resolves name (non-empty) -> comment -> static 'Netwatch'.
+
+    Built from the REAL MikrotikBinarySensorEntityDescription so a renamed
+    field (data_name_prefer, data_name, ...) fails the test. See ADR-018.
+    """
+
+    @pytest.mark.parametrize(
+        "row, expected",
+        [
+            # name present beats a (possibly shared) comment — decisive ordering
+            (
+                {"host": "1.1.1.1", "name": "[NAT64] 1.1.1.1", "comment": "NAT64"},
+                "[NAT64] 1.1.1.1",
+            ),
+            # name present, comment key absent — name short-circuits before .get('comment')
+            ({"host": "1.1.1.1", "name": "X"}, "X"),
+            # name empty -> comment fallback
+            (
+                {
+                    "host": "1.1.1.1",
+                    "name": "",
+                    "comment": "uplink monitor",
+                },
+                "uplink monitor",
+            ),
+            # name empty + comment empty -> static label
+            ({"host": "1.1.1.1", "name": "", "comment": ""}, "Netwatch"),
+            # name empty + comment key missing -> static label (no KeyError)
+            ({"host": "1.1.1.1", "name": ""}, "Netwatch"),
+            # whitespace-only name is treated as empty -> comment fallback
+            ({"host": "1.1.1.1", "name": "   ", "comment": "edge"}, "edge"),
+            # whitespace-only name, no comment -> static label
+            ({"host": "1.1.1.1", "name": "  "}, "Netwatch"),
+        ],
+    )
+    def test_netwatch_name_precedence(self, row, expected):
+        entity = _binary_entity_with_real_desc("netwatch", row["host"], row, **NETWATCH_DESC_KW)
+        assert entity.custom_name == expected
+
+    def test_netwatch_unique_id_is_host_derived_ipv6(self):
+        """unique_id slugifies the host, not the name; survives an IPv6 literal."""
+        row = {"host": "2001:db8::1", "name": "", "comment": ""}
+        entity = _binary_entity_with_real_desc("netwatch", "2001:db8::1", row, **NETWATCH_DESC_KW)
+        assert entity.unique_id == f"mikrotik-netwatch-{slugify('2001:db8::1')}"
+
+    def test_netwatch_unique_id_independent_of_name(self):
+        """Same host, different name -> identical host-derived unique_id."""
+        row_a = {"host": "1.1.1.1", "name": "A"}
+        row_b = {"host": "1.1.1.1", "name": "B"}
+        ent_a = _binary_entity_with_real_desc("netwatch", "1.1.1.1", row_a, **NETWATCH_DESC_KW)
+        ent_b = _binary_entity_with_real_desc("netwatch", "1.1.1.1", row_b, **NETWATCH_DESC_KW)
+        assert ent_a.unique_id == ent_b.unique_id
+        assert ent_a.unique_id == f"mikrotik-netwatch-{slugify('1.1.1.1')}"
+
+    def test_netwatch_duplicate_name_distinct_hosts(self):
+        """Known residual: same name on different hosts collides on display name
+        but the entities stay distinct via the host-derived unique_id."""
+        row1 = {"host": "1.1.1.1", "name": "gw"}
+        row2 = {"host": "2.2.2.2", "name": "gw"}
+        e1 = _binary_entity_with_real_desc("netwatch", "1.1.1.1", row1, **NETWATCH_DESC_KW)
+        e2 = _binary_entity_with_real_desc("netwatch", "2.2.2.2", row2, **NETWATCH_DESC_KW)
+        assert e1.custom_name == e2.custom_name == "gw"
+        assert e1.unique_id != e2.unique_id
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Netwatch entities that shared a `comment` collapsed to one display name. They now resolve their friendly name as **netwatch `name` (non-empty) -> `comment` -> static "Netwatch"**, returned **bare** (no suffix, since `has_entity_name` already prepends the `<inst> Netwatch` device name — a suffix would read "Netwatch ... Netwatch"). Addresses #70.
- New `data_name_prefer` flag on `MikrotikBinarySensorEntityDescription` (netwatch-only opt-in). A new flag — not the ADR-013 `data_name_compose` reorder — was required because the 5 `data_name_comment` switches need comment-first ordering.
- `get_netwatch` now parses `name` (via `vals`; `from_entry` defaults `""` on older ROS, so no `ensure_vals`); `name` added to `DEVICE_ATTRIBUTES_NETWATCH`.
- `entity.custom_name` refactored into a thin dispatcher + `_compose_uid_name` helper (ADR-007) to stay within the <=15 cognitive-complexity gate after the whitespace-strip; whitespace-only names fall through to comment/static.
- `unique_id` stays host-derived (`data_reference="host"` unchanged) -> **no migration; entity_ids and automations preserved**.
- Scope is **entity display names only**; per-host devices and the same-host key-collision (a distinct root) are out of scope -> filed `ENH-260615-netwatch-host-key-collision`.
- Docs: **ADR-018**, manifest `2.3.20-beta.3`, README + info.md What's New, ISSUES (#70 -> In Review), CHANGE-REGISTER `CR-260615`.

## Post-Deploy Actions
- None. No config-entry or entity-registry migration. Users only see a name change for netwatch entries that actually have a `name` set (exactly the #70 request).

## Test Plan
- [x] `pytest tests/` — **669 passed, 5 skipped** (WSL python:3.13); new tests are real-typed + parametrized (name-beats-comment, comment-key-absent, name-empty->comment, empty/whitespace->static, IPv6 unique_id, duplicate-name residual, dhcp/switch scope guards, coordinator name-parse).
- [x] Coverage **88%** (>=80% gate); `binary_sensor_types` 100%, `entity.py` 95%.
- [x] ruff lint + format clean (0.9.0); cognitive complexity `custom_name` 4 / `_compose_uid_name` 12 (<=15).
- [x] **Live-validated on a RouterOS 7.22 router**: a netwatch entry with both a `name` and a `comment` shows the bare name (name beats comment); a name-less entry still shows its comment; `name` attribute exposed; no "Netwatch Netwatch" double-up.
- [x] **Full validate-live-sensors matrix on beta.3** across a 4-device RouterOS fleet — all sensor classes cross-checked against router ground-truth within tolerance; 0 integration entities unavailable; no regressions to ADR-013 DHCP/client naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
