### PR TITLE
chore: guard against homelab IP/MAC leaks; redact ADR-013 MACs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,25 @@ jobs:
       - name: Run ruff (format check)
         run: ruff format --check custom_components/mikrotik_router tests
 
+  homelab-leak:
+    name: Homelab leak guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.13"
+
+      - name: Scan public files for private IPs / MACs
+        # Guards docs/ (excl. internal), custom_components/, README, info.md.
+        # See scripts/check_no_homelab_leaks.py. Originated after a homelab IP/MAC
+        # leaked into ADR docs from live-validation evidence.
+        run: python scripts/check_no_homelab_leaks.py
+
   tests:
     name: Python Tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,12 @@ repos:
       - id: check-merge-conflict
       - id: no-commit-to-branch
         args: [--branch, master]
+
+  - repo: local
+    hooks:
+      - id: homelab-leak-check
+        name: No homelab IPs/MACs in public files
+        entry: python scripts/check_no_homelab_leaks.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,30 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260616-leak-guardrail - redact leaked homelab MACs + add private-IP/MAC guard
+
+**Date:** 2026-06-16
+**Branch:** `chore/leak-guardrail` -> PR to `dev`
+**Status:** In Review
+
+### What changed
+- `scripts/check_no_homelab_leaks.py` (new) - fails if RFC1918 private IPv4 or MAC addresses appear in public, integration-facing files (`docs/` except `docs/internal/`, `custom_components/`, `README.md`, `info.md`). Allows documentation IP ranges, the `10.0.0.1` placeholder, example MAC OUIs (`AA:BB:CC`, `00:00:5E`), and an inline `leak-ok` marker. `tests/` is out of scope (example fixtures).
+- `.pre-commit-config.yaml` - local `homelab-leak-check` hook.
+- `.github/workflows/ci.yml` - new `homelab-leak` job (blocks merge on a finding).
+- `docs/decisions/ADR-013-entity-naming-disambiguation.md` - redacted six real client MAC addresses (live-validation evidence) to example `AA:BB:CC:DD:EE:0x` values. Behaviour/decision unchanged.
+
+### Why
+A homelab IP and client MACs leaked into ADR/ISSUES docs from pasted live-validation evidence (the IP/ADR-018 leak was caught and scrubbed in the #70 branch before merge; ADR-013's MACs were already on `dev`). This adds an automated guard so it cannot recur, and cleans the one remaining public occurrence. Note: redaction fixes the files going forward; the MACs remain in prior git history (purge requires a separate history rewrite).
+
+### Verification
+- `python scripts/check_no_homelab_leaks.py` passes on this branch (0 findings); fails (exit 1) with the offending `file:line` when a private IP/MAC is present (verified against the pre-redaction ADR-013).
+- ruff/bandit unaffected (script lives under `scripts/`, outside the scanned trees).
+
+### Release ops
+Lands on `dev`. No version bump (tooling/docs only).
+
+---
+
 ## CR-260614-release-v2.3.20-beta.2 - pre-release rolling up PoE energy + librouteros + deprecation fixes
 
 **Date:** 2026-06-14

--- a/docs/decisions/ADR-013-entity-naming-disambiguation.md
+++ b/docs/decisions/ADR-013-entity-naming-disambiguation.md
@@ -15,9 +15,9 @@ Distinct entities collapse to identical friendly names → Home Assistant disamb
 
 **Live evidence (REFUTES the brief's "named after the interface"):**
 ```
-device_tracker.lwip0    mac=B0:F8:93:DE:60:AD  host_name="lwip0"  interface="bridge"  source=dhcp
-device_tracker.lwip0_2  mac=C0:F8:53:9C:E6:E3  host_name="lwip0"  interface="bridge"  source=dhcp
-… _3 38:2C:E5:5F:79:4A, _4 C0:F8:53:9D:16:A0, _5 C0:F8:53:9C:EB:A8, _6 FC:3C:D7:EA:04:C4
+device_tracker.lwip0    mac=AA:BB:CC:DD:EE:01  host_name="lwip0"  interface="bridge"  source=dhcp
+device_tracker.lwip0_2  mac=AA:BB:CC:DD:EE:02  host_name="lwip0"  interface="bridge"  source=dhcp
+… _3 AA:BB:CC:DD:EE:03, _4 AA:BB:CC:DD:EE:04, _5 AA:BB:CC:DD:EE:05, _6 AA:BB:CC:DD:EE:06
 ```
 `host-name == "lwip0"` but `interface == "bridge"` — **not equal**. `"lwip0"` is the **DHCP hostname these devices report** (`lwIP` is the lightweight embedded TCP/IP stack; ESP8266/ESP32-class IoT devices default their hostname to `lwip0`). So this is a **non-unique reported hostname**, not interface-based naming. The coordinator already falls back to MAC (`_hostname_from_dhcp` → `return uid`, `coordinator.py:2593`) but only when `host-name == "unknown"` (`:2548`); a non-unique-but-present hostname slips through. The only stable distinguisher among the colliding hosts is the **MAC** (IP is dynamic; interface/source/host-name are identical).
 
@@ -44,7 +44,7 @@ At the **end of `async_process_host()`** (called at `coordinator.py:676`, *befor
 2. For each host whose `host-name` is shared by **more than one** host, set the display name to **`"{host-name} ({mac-address})"`** (maintainer's chosen format — keep the reported name, append the MAC to disambiguate).
 3. Unique real hostnames are left unchanged. Empty/`unknown` already resolves to the MAC via the existing fallback — unchanged.
 
-This fixes both client families with one change, at the source ("one owner per fact"). `device_tracker.lwip0` → `lwip0 (B0:F8:93:DE:60:AD)`; its traffic sensors → `lwip0 (B0:F8:93:DE:60:AD) LAN TX`, etc.
+This fixes both client families with one change, at the source ("one owner per fact"). `device_tracker.lwip0` → `lwip0 (AA:BB:CC:DD:EE:01)`; its traffic sensors → `lwip0 (AA:BB:CC:DD:EE:01) LAN TX`, etc.
 
 > **Insertion point is load-bearing (independent review catch).** `client_traffic` inherits `host-name` at **two** sites, gated by firmware in `_async_update_client_traffic` (`:761-767`): **v<7 → `process_accounting`/`_init_accounting_hosts`** (copy at `:2736`) and **v≥7 → `process_kid_control_devices`** (copy at `:2911`). The live v2.3.18/RouterOS-7 box uses the **`:2911`** path. The pass must therefore run at the end of `async_process_host` (before `:691`) so it precedes **both** copies — *not* inside `process_accounting`, which would silently miss every RouterOS-7 install. `device_tracker` reads `host[uid]` directly, so it is fixed regardless; only the traffic sensors depend on this ordering.
 

--- a/scripts/check_no_homelab_leaks.py
+++ b/scripts/check_no_homelab_leaks.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Fail if private IPs or MAC addresses leak into public, integration-facing files.
+
+This is a public fork. `docs/` (except `docs/internal/`), `custom_components/`,
+`README.md`, and `info.md` are visible to every user and must not carry real
+homelab specifics. This guard scans those tracked files for RFC1918 private IPv4
+addresses and MAC addresses — on this repo, a real one usually means a homelab
+value got pasted into an ADR / ISSUES / CHANGE-REGISTER entry from live evidence.
+
+Allowed (won't fail):
+  - Documentation IP ranges: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24
+  - The placeholder default 10.0.0.1, plus 0.0.0.0 / 255.255.255.255
+  - Example MAC OUIs: AA:BB:CC, 00:00:5E (RFC 7042 doc range), DE:AD:BE
+  - Any line containing the marker `leak-ok`
+
+`tests/` is intentionally out of scope (fixtures use example data). Use a
+documentation range or a `leak-ok` marker for an intentional public reference.
+
+Exit code 1 (with the offending file:line) on any finding; 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import subprocess
+import sys
+
+INCLUDE_PREFIXES = ("docs/", "custom_components/", "README.md", "info.md")
+EXCLUDE_PREFIXES = ("docs/internal/",)
+ALLOW_MARKER = "leak-ok"
+
+ALLOW_IPS = {"0.0.0.0", "10.0.0.1", "255.255.255.255"}
+DOC_NETS = [
+    ipaddress.ip_network(n)
+    for n in ("192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24")
+]
+ALLOW_MAC_OUI = ("aa:bb:cc", "00:00:5e", "de:ad:be")
+
+IP_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+MAC_RE = re.compile(r"\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b")
+
+
+def tracked_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", "-z"], capture_output=True, text=True, check=True
+    ).stdout
+    files = [f for f in out.split("\0") if f]
+    return [
+        f
+        for f in files
+        if f.startswith(INCLUDE_PREFIXES) and not f.startswith(EXCLUDE_PREFIXES)
+    ]
+
+
+def offending_ip(token: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(token)
+    except ValueError:
+        return False
+    if str(addr) in ALLOW_IPS or any(addr in net for net in DOC_NETS):
+        return False
+    return addr.is_private
+
+
+def offending_mac(token: str) -> bool:
+    return not token.lower().startswith(ALLOW_MAC_OUI)
+
+
+def main() -> int:
+    findings: list[tuple[str, int, str]] = []
+    for path in tracked_files():
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                lines = fh.read().splitlines()
+        except OSError:
+            continue
+        for lineno, line in enumerate(lines, 1):
+            if ALLOW_MARKER in line:
+                continue
+            for tok in IP_RE.findall(line):
+                if offending_ip(tok):
+                    findings.append((path, lineno, tok))
+            for tok in MAC_RE.findall(line):
+                if offending_mac(tok):
+                    findings.append((path, lineno, tok))
+
+    if findings:
+        print("Homelab-leak check FAILED - private IPs / MACs in public files:\n")
+        for path, lineno, tok in findings:
+            print(f"  {path}:{lineno}: {tok}")
+        print(
+            "\nReplace with a documentation range (198.51.100.x), an example MAC "
+            "(AA:BB:CC:DD:EE:NN), or a placeholder. Add a 'leak-ok' marker on the "
+            "line only if the value is genuinely public."
+        )
+        return 1
+
+    print("Homelab-leak check passed: no private IPs / MACs in public files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds **`scripts/check_no_homelab_leaks.py`** — fails if RFC1918 private IPv4 or MAC addresses appear in **public, integration-facing files** (`docs/` except `docs/internal/`, `custom_components/`, `README.md`, `info.md`). Allows documentation IP ranges (192.0.2/198.51.100/203.0.113), the `10.0.0.1` placeholder, example MAC OUIs (`AA:BB:CC`, `00:00:5E`), and an inline `leak-ok` marker. `tests/` is out of scope (example fixtures).
- Wires it as a **pre-commit hook** (`homelab-leak-check`) and a **CI job** (`homelab-leak`) so a leak blocks the commit and the merge.
- **Redacts six real client MAC addresses** in `ADR-013` (pasted from live-validation evidence) to example `AA:BB:CC:DD:EE:0x` values — the ADR's decision and behaviour are unchanged.

### Context
During #70's live validation, a homelab IP and the DNS-failover/Pi-hole comment leaked into ADR-018 / ISSUES — caught and scrubbed in the #70 branch before merge. A scan then found ADR-013's client MACs were already on `dev`. This adds an automated guard so it can't recur and cleans the remaining occurrence.

## Post-Deploy Actions
- None for users. Maintainer note: redaction fixes the files **going forward**; the old MACs remain in prior git history — purging them fully needs a separate history rewrite (decide separately, as it rewrites `master`/`dev`).

## Test Plan
- [x] `python scripts/check_no_homelab_leaks.py` → passes (0 findings) on this branch.
- [x] Verified it **fails (exit 1)** with the offending `file:line` against the pre-redaction ADR-013 (the six MACs).
- [x] Documentation IPs, `10.0.0.1`, and example `AA:BB:CC` MACs are not flagged.
- [x] ruff/bandit unaffected (script lives under `scripts/`, outside the scanned trees).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
