### PR TITLE
chore: release v2.3.21-beta.1 (LTE modem sensors + unknown-not-stale)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
+## What's New — v2.3.21-beta.1
+
+Beta rolling up **LTE modem support** plus an integration-wide entity-reliability fix. **Beta-gated:** LTE is validated on contributor hardware (a MikroTik Chateau) — please report back if you run it. The reliability fix was live-validated on a multi-device deployment with no regressions.
+
+- **LTE modem sensors.** Routers with an `/interface/lte` interface now expose signal quality (RSSI, RSRP, RSRQ, SINR, CQI), operator / cell / band info, a connection status, session uptime, and modem firmware. Conditional on LTE hardware — routers without an LTE interface get no new entities. IMEI / IMSI / ICCID are collected but **disabled by default** and redacted from diagnostics. Thanks to **@zvldz** for the implementation and live validation on a MikroTik Chateau (S53UG / Quectel EG18-EA). Implements the long-requested [tomaae#249](https://github.com/tomaae/homeassistant-mikrotik_router/issues/249). See [ADR-019](docs/decisions/ADR-019-lte-modem-sensors.md).
+- **Sensors degrade to `unknown` instead of showing a stale value.** When a data source stops reporting mid-session (e.g. a UPS or LTE modem drops out), the affected sensor / binary_sensor now reads `unknown` rather than silently retaining its last value. Integration-wide reliability fix.
+
 ## What's New — v2.3.20
 
 Stable release rolling up the v2.3.20 beta cycle (beta.1–beta.3). Both new features were validated live: PoE-out energy on real metering hardware ([#59](https://github.com/jnctech/homeassistant-mikrotik_router/issues/59), thanks @Dillton) and netwatch naming on a multi-entry deployment ([#70](https://github.com/jnctech/homeassistant-mikrotik_router/issues/70), thanks @L2jLiga).

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -14,5 +14,5 @@
         "librouteros>=3.4.1,<4.0",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.20"
+    "version": "2.3.21-beta.1"
 }

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,28 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260703-release-v2.3.21-beta.1 — LTE modem sensors + unknown-not-stale (beta)
+
+**Date:** 2026-07-03
+**Branch:** `chore/release-v2.3.21-beta.1` → PR to `dev`; then GitHub **pre-release** tag `v2.3.21-beta.1` off `dev` (no `dev → master` for a beta)
+**Status:** Released (pre-release)
+
+### What changed
+- `manifest.json` version `2.3.20 → 2.3.21-beta.1`.
+- `README.md`, `info.md` — new **What's New — v2.3.21-beta.1** entry (LTE modem sensors, credited to **@zvldz**; the integration-wide `unknown`-not-stale reliability fix).
+
+### Why
+Cut the beta gating **LTE modem sensors** (#116, @zvldz) — beta-first because LTE hardware is absent from the maintainer fleet (see the beta-gate in `docs/release-validation.md`) — bundled with the `unknown`-not-stale base-class fix (#120). Contents already on `dev`: ADR-019 (Accepted), CR-260703-lte-hardening, CR-260703-contributing-adr-numbering.
+
+### Verification
+- Pre-deploy baseline vs post-deploy live validation on the 4-device fleet: **no regressions** — identical unavailable/unknown sets, clean HA log, LTE conditional-creation produced zero phantom entities on non-LTE hardware. Detailed report in the internal `config` repo.
+- CI green on `dev` (3.13 / 3.14) for #116 and #120.
+
+### Release ops
+Branch → PR to `dev` → merge; publish GitHub **pre-release** `v2.3.21-beta.1` off `dev` → `release.yml` builds the HACS zip. No `dev → master`, no back-merge (beta). LTE stays beta until validated on real hardware (contributor/user), then promote to stable and close `ENH-260614`.
+
+---
+
 ## CR-260703-contributing-adr-numbering — CONTRIBUTING guide + ADR-index reconciliation + release/test standards
 
 **Date:** 2026-07-03

--- a/info.md
+++ b/info.md
@@ -10,6 +10,11 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
+### What's new in v2.3.21-beta.1
+Beta: **LTE modem sensors** + an integration-wide entity-reliability fix. LTE is beta-gated on contributor hardware; the fix was live-validated with no regressions.
+- **LTE modem sensors** — signal (RSSI/RSRP/RSRQ/SINR/CQI), operator, connection, session uptime, and modem firmware for routers with an `/interface/lte`. Conditional on LTE hardware. IMEI/IMSI/ICCID collected but disabled by default + redacted. Thanks @zvldz for the implementation + live validation on a MikroTik Chateau. Implements tomaae #249. See ADR-019.
+- **`unknown` instead of stale** — when a source stops reporting mid-session, the sensor reads `unknown` rather than keeping its last value. Integration-wide.
+
 ### What's new in v2.3.20
 Stable release rolling up the v2.3.20 beta cycle. Both new features were validated live — PoE-out energy on real metering hardware (#59, thanks @Dillton) and netwatch naming on a multi-entry deployment (#70, thanks @L2jLiga).
 - **PoE energy for the Energy Dashboard** — per-port energy sensors (kWh, `total_increasing`) + a device total, restart-persistent. Enable the existing PoE sensors option. Addresses #59.


### PR DESCRIPTION
## Summary

Cuts **v2.3.21-beta.1** off `dev`. Beta-gated because LTE hardware is absent from the maintainer fleet — LTE validated on contributor hardware (@zvldz, MikroTik Chateau); the non-LTE reliability fix was live-validated on the 4-device fleet with no regressions.

- `manifest.json` `2.3.20 → 2.3.21-beta.1`
- `README.md` / `info.md` — What's New for v2.3.21-beta.1 (LTE modem sensors, credited to **@zvldz**; the integration-wide `unknown`-not-stale fix)
- CR-260703-release-v2.3.21-beta.1

Contents already on `dev`: LTE modem sensors (#116), the `unknown`-not-stale base-class fix + entity tests (#120), ADR-019 (Accepted).

## Post-Deploy Actions

After merge: publish GitHub **pre-release** tag `v2.3.21-beta.1` off `dev` (no `dev → master` for a beta) → `release.yml` builds the HACS zip.

## Test Plan

- [x] CI green on `dev` for #116 and #120 (pytest 3.13 / 3.14).
- [x] Live validation: pre/post-deploy on the 4-device fleet — no regressions (identical unavailable/unknown sets, clean HA log, zero phantom LTE entities on non-LTE hardware).
- [ ] LTE stays beta until validated on real LTE hardware (contributor/user), then promote to stable + close ENH-260614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)