### PR TITLE
fix: extend homelab-leak gate to catch internal-coordination tokens (ISS-260712)

### DIFF
--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,25 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260712-leak-gate-governance — extend the homelab-leak gate to catch internal-coordination tokens
+
+**Date:** 2026-07-12
+**Branch:** `fix/leak-gate-governance-tokens` → [PR #122](https://github.com/jnctech/homeassistant-mikrotik_router/pull/122) to `dev`
+**Status:** In Review
+
+### What changed
+- `scripts/check_no_homelab_leaks.py` — added `GOVERNANCE_RE` + `offending_governance()` so the guard flags internal-coordination tokens (private-repo paths, mailbox routing, relay/check/standards artifacts, governance sign-off terms), not just private IPs/MACs. High-precision by design (structured paths / artifact prefixes, never bare words) so legit content — "out-of-band management", the repo's own `CONTRIBUTING.md`, RouterOS "watchdog" — does not false-positive. Docstring updated.
+- `tests/test_check_no_homelab_leaks.py` (new) — pure-stdlib unit tests (no HA/Docker): IP/MAC helpers, every governance pattern (should-flag), and legit-content non-match guards.
+
+### Why
+Follow-up to CR-260712-redact-inflight-leak / ISS-260712: the IP/MAC-only gate let a batch of coordination tokens ship into the public In-flight block silently. This closes ISS-260712 action (b) so it can't recur. Extends both the pre-commit `homelab-leak-check` hook and the CI `homelab-leak` job (shared entry point — no workflow change).
+
+### Verification
+- `python scripts/check_no_homelab_leaks.py` → PASS on the redacted tree (exit 0).
+- Detection logic verified locally by direct import (pytest not in the local env; CI runs the suite). `scripts/` and `tests/` remain out of the gate's scan scope, so the docstring examples and test fixtures don't self-trip.
+
+---
+
 ## CR-260712-redact-inflight-leak — redact homelab IP + estate internals from public `docs/ISSUES.md`
 
 **Date:** 2026-07-12

--- a/scripts/check_no_homelab_leaks.py
+++ b/scripts/check_no_homelab_leaks.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
-"""Fail if private IPs or MAC addresses leak into public, integration-facing files.
+"""Fail if private IPs, MACs, or internal-coordination tokens leak into public files.
 
 This is a public fork. `docs/` (except `docs/internal/`), `custom_components/`,
 `README.md`, and `info.md` are visible to every user and must not carry real
-homelab specifics. This guard scans those tracked files for RFC1918 private IPv4
-addresses and MAC addresses — on this repo, a real one usually means a homelab
-value got pasted into an ADR / ISSUES / CHANGE-REGISTER entry from live evidence.
+homelab specifics. This guard scans those tracked files for:
+  1. RFC1918 private IPv4 addresses and MAC addresses — usually a homelab value
+     pasted into an ADR / ISSUES / CHANGE-REGISTER entry from live evidence.
+  2. Internal-coordination tokens — paths and artifact names from the maintainer's
+     private multi-repo agent-coordination estate (private-repo paths, mailbox
+     routing, relay/check/standards artifacts, ratification terms). These have no
+     place in an integration-facing doc; on 2026-07-12 a batch leaked into the
+     public In-flight block and passed the IP/MAC-only gate silently (ISS-260712).
 
 Allowed (won't fail):
   - Documentation IP ranges: 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24
@@ -13,8 +18,14 @@ Allowed (won't fail):
   - Example MAC OUIs: AA:BB:CC, 00:00:5E (RFC 7042 doc range), DE:AD:BE
   - Any line containing the marker `leak-ok`
 
-`tests/` is intentionally out of scope (fixtures use example data). Use a
-documentation range or a `leak-ok` marker for an intentional public reference.
+The governance patterns are deliberately high-precision (structured paths /
+artifact prefixes, not bare words) so legitimate integration content — e.g.
+"out-of-band management", the repo's own `CONTRIBUTING.md`, RouterOS "watchdog"
+— does not trip them. Add a term here only if it is unambiguously estate-internal.
+
+`tests/` is intentionally out of scope (fixtures use example data), as is
+`scripts/` (this file documents the tokens by example). Use a documentation range
+or a `leak-ok` marker for an intentional public reference.
 
 Exit code 1 (with the offending file:line) on any finding; 0 otherwise.
 """
@@ -39,6 +50,25 @@ ALLOW_MAC_OUI = ("aa:bb:cc", "00:00:5e", "de:ad:be")
 
 IP_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 MAC_RE = re.compile(r"\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b")
+
+# Internal-coordination ("estate") tokens. High-precision by design: structured
+# paths and artifact prefixes, never bare words, so legit integration content
+# (out-of-band management, this repo's own CONTRIBUTING.md, RouterOS watchdog)
+# does not false-positive. See the module docstring and ISS-260712.
+GOVERNANCE_RE = re.compile(
+    r"""
+      ~/oob\b                                       # private estate repo path
+    | \bjnctech/oob\b                               # private estate repo slug
+    | \boob/(?:registry|standards|verification|mailbox|reports|gates|runs|status|prompts|architecture)\b
+    | \bmailbox/(?:to-|from-|read)\b                # estate mailbox routing
+    | \bRELAY-from-\S+-to-\S+                        # estate relay artifacts
+    | \bOOB-CHECK\b                                 # estate check artifacts
+    | \bWATCHDOG-(?:PROMPT|AUDIT|VERIFY)\b          # estate watchdog artifacts
+    | \bSTANDARDS-(?:mikrotik|tandem|config)\b      # standards-intake declarations
+    | \bratif(?:y|ied|ication|ies)\b                # ratification governance term
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
 
 
 def tracked_files() -> list[str]:
@@ -67,6 +97,11 @@ def offending_mac(token: str) -> bool:
     return not token.lower().startswith(ALLOW_MAC_OUI)
 
 
+def offending_governance(line: str) -> list[str]:
+    """Return the estate/coordination tokens found on a line (empty if none)."""
+    return [m.group(0) for m in GOVERNANCE_RE.finditer(line)]
+
+
 def main() -> int:
     findings: list[tuple[str, int, str]] = []
     for path in tracked_files():
@@ -84,19 +119,28 @@ def main() -> int:
             for tok in MAC_RE.findall(line):
                 if offending_mac(tok):
                     findings.append((path, lineno, tok))
+            for tok in offending_governance(line):
+                findings.append((path, lineno, tok))
 
     if findings:
-        print("Homelab-leak check FAILED - private IPs / MACs in public files:\n")
+        print(
+            "Homelab-leak check FAILED - private IPs / MACs / coordination tokens "
+            "in public files:\n"
+        )
         for path, lineno, tok in findings:
             print(f"  {path}:{lineno}: {tok}")
         print(
-            "\nReplace with a documentation range (198.51.100.x), an example MAC "
-            "(AA:BB:CC:DD:EE:NN), or a placeholder. Add a 'leak-ok' marker on the "
-            "line only if the value is genuinely public."
+            "\nReplace an IP/MAC with a documentation range (198.51.100.x) or example "
+            "MAC (AA:BB:CC:DD:EE:NN). Move internal-coordination detail to gitignored "
+            "docs/internal/ and describe it generically here. Add a 'leak-ok' marker "
+            "on the line only if the value is genuinely public."
         )
         return 1
 
-    print("Homelab-leak check passed: no private IPs / MACs in public files.")
+    print(
+        "Homelab-leak check passed: no private IPs / MACs / coordination tokens "
+        "in public files."
+    )
     return 0
 
 

--- a/tests/test_check_no_homelab_leaks.py
+++ b/tests/test_check_no_homelab_leaks.py
@@ -1,0 +1,84 @@
+"""Unit tests for scripts/check_no_homelab_leaks.py.
+
+Pure-stdlib: the script has no Home Assistant dependency, so these run without
+the Docker/HA test image. The module lives in scripts/ (not a package), so it is
+loaded by path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "check_no_homelab_leaks.py"
+_spec = importlib.util.spec_from_file_location("check_no_homelab_leaks", _SCRIPT)
+guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(guard)
+
+
+# --- IP detection ----------------------------------------------------------
+
+
+def test_private_ip_is_offending():
+    assert guard.offending_ip("192.168.88.43") is True
+    assert guard.offending_ip("10.5.4.3") is True
+    assert guard.offending_ip("172.16.0.1") is True
+
+
+def test_documentation_ranges_allowed():
+    assert guard.offending_ip("192.0.2.5") is False
+    assert guard.offending_ip("198.51.100.10") is False
+    assert guard.offending_ip("203.0.113.9") is False
+
+
+def test_placeholder_and_public_ips_allowed():
+    assert guard.offending_ip("10.0.0.1") is False  # documented placeholder default
+    assert guard.offending_ip("0.0.0.0") is False
+    assert guard.offending_ip("255.255.255.255") is False
+    assert guard.offending_ip("8.8.8.8") is False  # public, not private
+    assert guard.offending_ip("not.an.ip.x") is False
+
+
+# --- MAC detection ---------------------------------------------------------
+
+
+def test_real_mac_is_offending():
+    assert guard.offending_mac("B0:F8:93:DE:60:AD") is True
+
+
+def test_example_mac_ouis_allowed():
+    assert guard.offending_mac("AA:BB:CC:DD:EE:01") is False
+    assert guard.offending_mac("00:00:5E:00:53:01") is False
+    assert guard.offending_mac("DE:AD:BE:EF:00:01") is False
+
+
+# --- Governance / coordination tokens (ISS-260712) -------------------------
+
+
+def test_governance_tokens_are_flagged():
+    for line in (
+        "committed to ~/oob following the contract",
+        "pushed to jnctech/oob PRIVATE",
+        "declaration in oob/registry/standards-intake/",
+        "git mv'd the message to mailbox/read/",
+        "relayed via mailbox/to-config/",
+        "see RELAY-from-mikrotik-to-config-topic-2026-07-12.md",
+        "reported by OOB-CHECK-estate-alignment-2026-07-12",
+        "gate WATCHDOG-AUDIT-onboard-renderer passed",
+        "step-5b STANDARDS-mikrotik declaration",
+        "the operator will ratify this next session",
+    ):
+        assert guard.offending_governance(line), f"should flag: {line!r}"
+
+
+def test_legitimate_content_is_not_flagged():
+    """High-precision patterns must not trip on real integration content."""
+    for line in (
+        "Supports out-of-band (OOB) management on the router.",
+        "See the repo's own CONTRIBUTING.md for the contributor guide.",
+        "RouterOS watchdog timer reboots the device on a hang.",
+        "The netwatch probe monitors host reachability.",
+        "192.0.2.1 is a documentation address.",
+        "gratification and ratios are ordinary words",  # substring guard: not 'ratify'
+    ):
+        assert not guard.offending_governance(line), f"false positive: {line!r}"


### PR DESCRIPTION
## Summary
- Extends `scripts/check_no_homelab_leaks.py` (the shared entry point for the pre-commit `homelab-leak-check` hook **and** the CI `homelab-leak` job) to flag internal-coordination/estate tokens, not just private IPs/MACs.
- Motivated by **ISS-260712**: on 2026-07-12 a batch of coordination tokens (private-repo paths, mailbox routing, relay/check/standards artifacts) shipped into the public `docs/ISSUES.md` In-flight block. The private IP tripped the gate; these passed silently because the gate was IP/MAC-only. The HEAD redaction already landed on `dev`; this closes the gate gap so it can't recur.
- Adds `GOVERNANCE_RE` — **high-precision** patterns (structured paths / artifact prefixes, never bare words) so legitimate integration content does **not** false-positive: "out-of-band (OOB) management", the repo's own `CONTRIBUTING.md`, RouterOS "watchdog".
- Adds `tests/test_check_no_homelab_leaks.py` — pure stdlib (no HA/Docker): IP/MAC helpers, every governance pattern (should-flag), and legit-content non-match guards (false-positive protection).

## Notes
- `scripts/` and `tests/` remain out of the gate's scan scope, so the token examples in the script docstring and the test fixtures don't self-trip.
- The `leak-ok` line marker remains the escape hatch for a genuinely-public reference.

## Test Plan
- [ ] CI `homelab-leak` job passes (green on the redacted `dev` tree).
- [ ] `pytest tests/test_check_no_homelab_leaks.py` passes (added; verified locally via direct import — pytest not in the local env).
- [ ] ruff clean (lint job).

Closes ISS-260712 action (b). Remaining ISS-260712 items (history-scrub decision, optional `dev` branch protection) stay open for the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)