### PR TITLE
fix: reconnect API on each poll after transient disconnect

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -680,6 +680,15 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
     # ---------------------------
     async def _async_update_data(self):
         """Update Mikrotik data"""
+        # Attempt reconnect every poll when disconnected. Without this,
+        # _run_if_enabled skips all API work and reconnect only happens
+        # on the ~4h hwinfo path (via get_access -> query -> connection_check).
+        # connection_check rate-limits attempts via _connection_retry_sec (~58s).
+        if not self.api.connected():
+            await self.hass.async_add_executor_job(self.api.connection_check)
+            if not self.api.connected():
+                self._raise_disconnected()
+
         hwinfo_ran = await self._async_update_hwinfo()
 
         # get_system_resource already ran inside _async_update_hwinfo;

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3563,8 +3563,11 @@ async def test_async_update_data_continues_after_successful_reconnect():
     coordinator.hass = MagicMock()
     coordinator.hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a, **k: fn(*a, **k) if callable(fn) else None)
     coordinator.last_hwinfo_update = datetime.now(timezone.utc)
-    # Skip heavy work: pretend hwinfo should be skipped and keep getters cheap.
+    # Skip heavy work: keep getters cheap.
+    # has_reconnected=True lets _async_update_hwinfo run, which calls the real
+    # get_access; make_coordinator() has no .host, so stub it out.
     coordinator._run_if_enabled = AsyncMock()
+    coordinator.get_access = MagicMock()
     coordinator.async_get_host_hass = AsyncMock()
     coordinator.async_process_host = AsyncMock()
     coordinator._async_update_client_traffic = AsyncMock()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3516,6 +3516,87 @@ async def test_client_traffic_v0_unknown_skips_and_logs(caplog):
 
 
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Group AG1b: reconnect on poll when disconnected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_attempts_reconnect_when_disconnected():
+    """When the API is down, each poll must call connection_check before giving up.
+
+    Without this, _run_if_enabled skips all work and reconnect only happens on the
+    ~4h hwinfo path, leaving entities unavailable after a transient outage.
+    """
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    coordinator = make_coordinator()
+    coordinator.api = MagicMock()
+    coordinator.api.connected.return_value = False
+    coordinator.api.connection_check = MagicMock(return_value=False)
+    coordinator.api.error = "cannot_connect"
+    coordinator.hass = MagicMock()
+    coordinator.hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda fn, *a, **k: fn(*a, **k)
+    )
+
+    with pytest.raises(UpdateFailed, match="Mikrotik Disconnected"):
+        await coordinator._async_update_data()
+
+    coordinator.hass.async_add_executor_job.assert_awaited_once_with(
+        coordinator.api.connection_check
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_continues_after_successful_reconnect():
+    """A successful connection_check lets the normal update path run."""
+    coordinator = make_coordinator()
+    coordinator.api = MagicMock()
+    # First connected() in the reconnect gate is False; later calls True.
+    coordinator.api.connected.side_effect = [False, True] + [True] * 50
+    coordinator.api.connection_check = MagicMock(return_value=True)
+    coordinator.api.has_reconnected = MagicMock(return_value=False)
+    coordinator.api.error = ""
+    coordinator.hass = MagicMock()
+    coordinator.hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda fn, *a, **k: fn(*a, **k) if callable(fn) else None
+    )
+    coordinator.last_hwinfo_update = datetime.now(timezone.utc)
+    # Skip heavy work: pretend hwinfo should be skipped and keep getters cheap.
+    coordinator._run_if_enabled = AsyncMock()
+    coordinator.async_get_host_hass = AsyncMock()
+    coordinator.async_process_host = AsyncMock()
+    coordinator._async_update_client_traffic = AsyncMock()
+    coordinator._check_new_uids = MagicMock(return_value=[])
+    coordinator.option_sensor_poe = False
+    coordinator.support_capsman = False
+    coordinator.support_wireless = False
+    coordinator.support_ppp = False
+    coordinator.support_ups = False
+    coordinator.support_gps = False
+    coordinator.support_container = False
+    coordinator.option_sensor_nat = False
+    coordinator.option_sensor_kidcontrol = False
+    coordinator.option_sensor_mangle = False
+    coordinator.option_sensor_filter = False
+    coordinator.option_sensor_raw = False
+    coordinator.option_sensor_netwatch = False
+    coordinator.option_sensor_ppp = False
+    coordinator.option_sensor_client_captive = False
+    coordinator.option_sensor_simple_queues = False
+    coordinator.option_sensor_environment = False
+    coordinator.option_sensor_container = False
+    coordinator.ds["host_hass"] = {"seed": True}
+
+    result = await coordinator._async_update_data()
+
+    coordinator.hass.async_add_executor_job.assert_any_await(
+        coordinator.api.connection_check
+    )
+    assert result is coordinator.ds
+
+
 # Group AG2: get_ups() — UPS path handling
 # ---------------------------------------------------------------------------
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3516,7 +3516,6 @@ async def test_client_traffic_v0_unknown_skips_and_logs(caplog):
 
 
 # ---------------------------------------------------------------------------
-# ---------------------------------------------------------------------------
 # Group AG1b: reconnect on poll when disconnected
 # ---------------------------------------------------------------------------
 
@@ -3536,16 +3535,12 @@ async def test_async_update_data_attempts_reconnect_when_disconnected():
     coordinator.api.connection_check = MagicMock(return_value=False)
     coordinator.api.error = "cannot_connect"
     coordinator.hass = MagicMock()
-    coordinator.hass.async_add_executor_job = AsyncMock(
-        side_effect=lambda fn, *a, **k: fn(*a, **k)
-    )
+    coordinator.hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a, **k: fn(*a, **k))
 
     with pytest.raises(UpdateFailed, match="Mikrotik Disconnected"):
         await coordinator._async_update_data()
 
-    coordinator.hass.async_add_executor_job.assert_awaited_once_with(
-        coordinator.api.connection_check
-    )
+    coordinator.hass.async_add_executor_job.assert_awaited_once_with(coordinator.api.connection_check)
 
 
 @pytest.mark.asyncio
@@ -3553,15 +3548,20 @@ async def test_async_update_data_continues_after_successful_reconnect():
     """A successful connection_check lets the normal update path run."""
     coordinator = make_coordinator()
     coordinator.api = MagicMock()
-    # First connected() in the reconnect gate is False; later calls True.
-    coordinator.api.connected.side_effect = [False, True] + [True] * 50
-    coordinator.api.connection_check = MagicMock(return_value=True)
-    coordinator.api.has_reconnected = MagicMock(return_value=False)
+    # Track link state from connection_check rather than a fixed connected() list.
+    connected = {"value": False}
+
+    def connection_check():
+        connected["value"] = True
+        return True
+
+    coordinator.api.connected.side_effect = lambda: connected["value"]
+    coordinator.api.connection_check = MagicMock(side_effect=connection_check)
+    # Real connect() sets _reconnected; that triggers a full hwinfo refresh.
+    coordinator.api.has_reconnected = MagicMock(return_value=True)
     coordinator.api.error = ""
     coordinator.hass = MagicMock()
-    coordinator.hass.async_add_executor_job = AsyncMock(
-        side_effect=lambda fn, *a, **k: fn(*a, **k) if callable(fn) else None
-    )
+    coordinator.hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a, **k: fn(*a, **k) if callable(fn) else None)
     coordinator.last_hwinfo_update = datetime.now(timezone.utc)
     # Skip heavy work: pretend hwinfo should be skipped and keep getters cheap.
     coordinator._run_if_enabled = AsyncMock()
@@ -3569,34 +3569,25 @@ async def test_async_update_data_continues_after_successful_reconnect():
     coordinator.async_process_host = AsyncMock()
     coordinator._async_update_client_traffic = AsyncMock()
     coordinator._check_new_uids = MagicMock(return_value=[])
-    coordinator.option_sensor_poe = False
-    coordinator.support_capsman = False
-    coordinator.support_wireless = False
-    coordinator.support_ppp = False
-    coordinator.support_ups = False
-    coordinator.support_gps = False
-    coordinator.support_container = False
-    coordinator.option_sensor_nat = False
-    coordinator.option_sensor_kidcontrol = False
-    coordinator.option_sensor_mangle = False
-    coordinator.option_sensor_filter = False
-    coordinator.option_sensor_raw = False
-    coordinator.option_sensor_netwatch = False
-    coordinator.option_sensor_ppp = False
-    coordinator.option_sensor_client_captive = False
-    coordinator.option_sensor_simple_queues = False
-    coordinator.option_sensor_environment = False
-    coordinator.option_sensor_container = False
+    for flag in (
+        "support_capsman",
+        "support_wireless",
+        "support_lte",
+        "support_ppp",
+        "support_ups",
+        "support_gps",
+        "support_container",
+    ):
+        setattr(coordinator, flag, False)
     coordinator.ds["host_hass"] = {"seed": True}
 
     result = await coordinator._async_update_data()
 
-    coordinator.hass.async_add_executor_job.assert_any_await(
-        coordinator.api.connection_check
-    )
+    coordinator.hass.async_add_executor_job.assert_any_await(coordinator.api.connection_check)
     assert result is coordinator.ds
 
 
+# ---------------------------------------------------------------------------
 # Group AG2: get_ups() — UPS path handling
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Proposed change

After a transient RouterOS API outage (e.g. gateway reboot while other routers are reached via that path), entities could stay unavailable until a manual config-entry reload — even once the network was healthy again.

Root cause: once disconnected, `_run_if_enabled` skipped all API work because it requires an already-open connection. `connection_check()` (which already rate-limits reconnect attempts via `_connection_retry_sec` ≈ 58s) was therefore never invoked on normal polls; reconnect only happened on the ~4h hwinfo refresh path (`get_access` → `query` → `connection_check`).

This PR calls `connection_check()` at the start of each `_async_update_data` when disconnected, so recovery happens on the next successful retry without a reload.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

- Verified live against a multi-router setup where two remote gateways became unreachable when the upstream gateway rebooted; after this change the integration recovers without reloading config entries.
- No change to `_connection_retry_sec` (still ~58s).

## Checklist
- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.

Made with [Cursor](https://cursor.com)