### PR TITLE
docs: file ISS-260813 + CR-260813 for reconnect-on-poll (#123)

### DIFF
--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,31 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260813-reconnect-on-poll — reconnect the API on each poll after a transient disconnect (#123)
+
+**Date:** 2026-08-13
+**Branch:** `fix/reconnect-on-poll` (contributor fork, @sappsys) → PR [#123](https://github.com/jnctech/homeassistant-mikrotik_router/pull/123) to `dev`
+**Status:** In Review
+
+### What changed
+- `custom_components/mikrotik_router/coordinator.py` — `_async_update_data()` now calls `api.connection_check()` via `async_add_executor_job` when `api.connected()` is False, and raises through `_raise_disconnected()` if the reconnect fails. Recovery no longer depends on the ~4h hwinfo refresh coming due.
+- `tests/test_coordinator.py` — new "Group AG1b" covering the disconnected-poll and successful-reconnect paths.
+
+### Why
+`ISS-260813-no-reconnect-until-hwinfo`: once disconnected, the coordinator's poll made no reconnect attempt at all. `_run_if_enabled()` gates on `api.connected()`, so every fetch was skipped, and `_async_update_hwinfo()` early-returned inside its 4h window — leaving the `get_access` → `query` → `connection_check` chain, the only reconnect path on that code path, untaken. Entities stayed `unavailable` until a manual config-entry reload.
+
+Framed correctly this restores a guard rather than adding a mechanism: every other API entry point in `mikrotikapi.py` already opens with `connection_check()`, and `MikrotikTrackerCoordinator`'s separate API instance self-heals during the same outage precisely because `arp_ping` carries it. It also converts two known disconnect causes — `ISS-260507-ups-empty-path` and the #64 PoE-toggle disconnect — from permanent-until-reload into self-recovering.
+
+### Verification
+- Reproduced on clean `dev`: the real `_async_update_data()` with a disconnected API and `last_hwinfo_update` set to now raises `UpdateFailed` with **zero** `connection_check` calls; the patch flips it to one call per poll.
+- Full suite with the patch: **694 passed, 5 skipped, 1 failed** — no regressions; the single failure is the contributor's own new test (read-only `option_sensor_*` property assignment), returned to them along with a `ruff format` miss.
+- `ruff check` clean on `coordinator.py`; `_async_update_data` complexity 9 → 11, inside the ≤15 gate. Blocking call wrapped per ADR-004. `librouteros.connect` defaults to a 10s socket timeout and the 58s `_connection_retry_sec` throttle is untouched, so per-poll executor cost stays bounded.
+
+### Release ops
+Lands on `dev`; rolls into the open `v2.3.21` beta cycle (no version bump on the fix PR itself). **Merge commit, not squash** — preserves @sappsys's authorship per `CONTRIBUTING.md`; credited here and in the `README.md` / `info.md` "What's New" at stable. Maintainer hardening follows as a separate PR (happy-path + `wrong_login` → `ConfigEntryAuthFailed` coverage, ADR-007 helper extraction), same pattern as #116 → #120. No ADR required.
+
+---
+
 ## CR-260712-redact-inflight-leak — redact homelab IP + estate internals from public `docs/ISSUES.md`
 
 **Date:** 2026-07-12

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -12,10 +12,11 @@
 >
 > **NEXT SESSION (lead):**
 > 0. **Merge PR #122** (leak-gate governance-token extension) once CI green; then close ISS-260712(b). Surface ISS-260712(c) history-scrub + (d) `dev` branch-protection decisions to the operator.
-> 1. **LTE field-validation gate (`ENH-260614-lte-modem-info`)** — v2.3.21-beta.1 **stays beta** until **@zvldz or an LTE user** confirms the LTE sensors on real hardware (maintainer fleet has none). On confirmation: **promote to stable** (`dev→master` PR + immediate back-merge, `master ⊆ dev` guard green; GitHub release, not pre-release) and **close ENH-260614**. Ping @zvldz on #116 when he can run the beta.
-> 2. **WireGuard peer sensors (`ENH-260703-wireguard-sensors`)** — **operator-requested: plan next session.** Surface per-peer state from `/interface/wireguard/peers` (last-handshake→connected/stale, endpoint, per-peer rx/tx); today only interface-level tx/rx exists. Scope keying (`public-key`), capability gate, ADR-020, redaction — see the ENH entry.
-> 3. **librouteros cap-lift** — `ENH-260512-librouteros-test-matrix`: 3.4.1 / latest-3.x / expected-fail-4.x CI matrix, then lift `manifest` to `>=4.0,<5` (the floor-bump is the **v2.4.0** trigger).
-> 4. **Stale-debt sweep** — write the deferred `ISS-260512-librouteros-concurrency-adr` (Open, doc-only); reconcile stale statuses.
+> 1. **PR #123 reconnect-on-poll (`ISS-260813-no-reconnect-until-hwinfo`)** — @sappsys's fix for the coordinator never retrying the API after a transient disconnect. Root cause confirmed and reproduced; code change sound. **Waiting on the contributor** for two test defects (read-only `option_sensor_*` assignment → suite red; `ruff format`); offered to push the fixes to their branch if they'd rather. **Approve the fork CI run** so their next push gets checks. Then merge-commit (not squash), and land the maintainer follow-up: happy-path + `wrong_login` → `ConfigEntryAuthFailed` coverage, ADR-007 `_async_ensure_connected()` extraction. Rolls into the open v2.3.21 beta. CR-260813-reconnect-on-poll.
+> 2. **LTE field-validation gate (`ENH-260614-lte-modem-info`)** — v2.3.21-beta.1 **stays beta** until **@zvldz or an LTE user** confirms the LTE sensors on real hardware (maintainer fleet has none). On confirmation: **promote to stable** (`dev→master` PR + immediate back-merge, `master ⊆ dev` guard green; GitHub release, not pre-release) and **close ENH-260614**. Ping @zvldz on #116 when he can run the beta.
+> 3. **WireGuard peer sensors (`ENH-260703-wireguard-sensors`)** — **operator-requested: plan next session.** Surface per-peer state from `/interface/wireguard/peers` (last-handshake→connected/stale, endpoint, per-peer rx/tx); today only interface-level tx/rx exists. Scope keying (`public-key`), capability gate, ADR-020, redaction — see the ENH entry.
+> 4. **librouteros cap-lift** — `ENH-260512-librouteros-test-matrix`: 3.4.1 / latest-3.x / expected-fail-4.x CI matrix, then lift `manifest` to `>=4.0,<5` (the floor-bump is the **v2.4.0** trigger).
+> 5. **Stale-debt sweep** — write the deferred `ISS-260512-librouteros-concurrency-adr` (Open, doc-only); reconcile stale statuses.
 >
 > **Cross-repo coordination (no integration-code impact):** downstream Home Assistant dashboard/config consumers were advised out-of-band of the `wireguard1`→`wg_home` sensor rename (repoint cards, delete orphaned `wireguard1_*` entities). Coordination and session detail live in gitignored `docs/internal/`.
 >
@@ -47,6 +48,30 @@
 ---
 
 ## Active
+
+### ISS-260813-no-reconnect-until-hwinfo — coordinator never retries the API after a transient disconnect
+**Type:** Bug (availability / recovery)
+**Priority:** High
+**Created:** 2026-08-13
+**Status:** 🟡 Fix in review — [#123](https://github.com/jnctech/homeassistant-mikrotik_router/pull/123) (@sappsys), CR-260813-reconnect-on-poll
+
+**Symptom:**
+After a transient RouterOS API outage (e.g. an upstream gateway reboot), entities stay `unavailable` even once the network is healthy again. Recovery needs a manual config-entry reload — the integration does not self-heal.
+
+**Root cause:**
+`MikrotikCoordinator._async_update_data()` is the only path that reaches the API without a `connection_check()` guard. Every entry point in `mikrotikapi.py` opens with one — `query` (:176), `set_value` (:231), `arp_ping` (:324), and four others — but the poll never gets that far. `_run_if_enabled()` gates on `api.connected()` and skips every fetch while disconnected, and `_async_update_hwinfo()` early-returns inside its 4h window, so the `get_access` → `query` → `connection_check` path that would reconnect is never taken. The poll then raises `UpdateFailed` having made no reconnect attempt. Worst case the integration stays down for ~4h from the last successful hwinfo refresh (after which `last_hwinfo_update` stops advancing, so every subsequent poll retries).
+
+`_connection_retry_sec` (58s) is not the blocker: `api.disconnect()` zeroes `_connection_epoch`, so an attempt would be permitted immediately if one were made.
+
+**Reproduced (2026-08-13):** driving the real `_async_update_data()` on `dev` with a disconnected API and `last_hwinfo_update` set to now raises `UpdateFailed("Mikrotik Disconnected")` with zero `connection_check` calls and zero executor jobs dispatched.
+
+**Contrast:** `MikrotikTrackerCoordinator` holds a separate `MikrotikAPI` instance whose `arp_ping` carries the guard, so it reconnects normally during the same outage. The two coordinators differ in recoverability, which is what makes this a missing guard rather than a missing feature.
+
+**Relationship to other issues:** this is the *recovery* half of `ISS-260507-ups-empty-path` and the [#64](https://github.com/jnctech/homeassistant-mikrotik_router/issues/64) PoE-toggle disconnect. It fixes neither cause, but it stops both from being permanent until a reload.
+
+**Fix (in review):** [#123](https://github.com/jnctech/homeassistant-mikrotik_router/pull/123) calls `connection_check()` in the executor at the top of each poll when disconnected, raising via `_raise_disconnected()` if it fails. Contributor patch verified locally: no regressions (694 passed, 5 skipped), complexity 9 → 11 (gate ≤15), blocking call correctly in the executor (ADR-004). Two test defects returned to the contributor (read-only `option_sensor_*` property assignment; `ruff format`). Maintainer follow-up to add connected-happy-path and `wrong_login` → `ConfigEntryAuthFailed` coverage, plus an ADR-007 helper extraction. No ADR — behavioural fix, not a data-format/entity-identity/API-contract change.
+
+---
 
 ### ENH-260703-wireguard-sensors — WireGuard peer/handshake status sensors
 **Type:** Enhancement (new sensors)


### PR DESCRIPTION
## Proposed change

Tracking docs for the coordinator's failure to retry the API after a transient disconnect, and registration of the incoming contributor fix in [#123](https://github.com/jnctech/homeassistant-mikrotik_router/pull/123) (@sappsys).

**`docs/ISSUES.md`**
- New `ISS-260813-no-reconnect-until-hwinfo` at the top of `## Active`. `MikrotikCoordinator._async_update_data()` is the only path that reaches the API without a `connection_check()` guard — `_run_if_enabled()` gates on `api.connected()` so every fetch is skipped while disconnected, and `_async_update_hwinfo()` early-returns inside its 4h window, leaving the `get_access` → `query` → `connection_check` chain untaken. Entities stay `unavailable` until a manual config-entry reload. Records the reproduction, the `MikrotikTrackerCoordinator` contrast (its separate API instance self-heals because `arp_ping` carries the guard), and the relationship to `ISS-260507-ups-empty-path` / #64 — this is the recovery half of both.
- `## In-flight` NEXT SESSION gains a `#123` item at position 1 (subsequent items renumbered 2–5), flagging that the contributor holds two test defects and the fork CI run needs approval.

**`docs/CHANGE-REGISTER.md`**
- New `CR-260813-reconnect-on-poll`, status **In Review**, with the verification record and the merge-commit/credit plan.

## Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation

## Additional information

Docs only — no code, no version bump, no ADR (the underlying fix is behavioural, not a data-format/entity-identity/API-contract/migration change).

Raised as a PR rather than a direct push to `dev`, per `ISS-260712` — the direct-to-`dev` In-flight refresh precedent is what bypassed the leak gate last time. `scripts/check_no_homelab_leaks.py` passes on this branch.

The code fix itself is **not** in this PR; it stays with @sappsys in #123 so a merge commit preserves their authorship.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Ruff.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tNSuEhSjjzNGmyDAM5sXy

---
_Generated by [Claude Code](https://claude.ai/code/session_013tNSuEhSjjzNGmyDAM5sXy)_