### PR TITLE
docs: ISS-260813 resolved, CR-260813 merged (PR #123)

### DIFF
--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -8,7 +8,7 @@ Changes listed in reverse chronological order.
 
 **Date:** 2026-08-13
 **Branch:** `fix/reconnect-on-poll` (contributor fork, @sappsys) → PR [#123](https://github.com/jnctech/homeassistant-mikrotik_router/pull/123) to `dev`
-**Status:** In Review
+**Status:** Merged 2026-08-13 — `0427a41` on `dev`
 
 ### What changed
 - `custom_components/mikrotik_router/coordinator.py` — `_async_update_data()` now calls `api.connection_check()` via `async_add_executor_job` when `api.connected()` is False, and raises through `_raise_disconnected()` if the reconnect fails. Recovery no longer depends on the ~4h hwinfo refresh coming due.
@@ -21,11 +21,12 @@ Framed correctly this restores a guard rather than adding a mechanism: every oth
 
 ### Verification
 - Reproduced on clean `dev`: the real `_async_update_data()` with a disconnected API and `last_hwinfo_update` set to now raises `UpdateFailed` with **zero** `connection_check` calls; the patch flips it to one call per poll.
-- Full suite with the patch: **694 passed, 5 skipped, 1 failed** — no regressions; the single failure is the contributor's own new test (read-only `option_sensor_*` property assignment), returned to them along with a `ruff format` miss.
+- Full suite during review: **694 passed, 5 skipped, 1 failed** — no regressions; the single failure was the contributor's own new test (read-only `option_sensor_*` property assignment), returned to them along with a `ruff format` miss. Cleared by @sappsys in `12a48ba` and `c7cc8ea`.
+- Merge gate: full CI green on `c7cc8ea` — Python Tests 3.13 and 3.14 both pass, plus hassfest, format check, leak guard, Bandit, Gitleaks, manifest-drift and HACS-zip checks.
 - `ruff check` clean on `coordinator.py`; `_async_update_data` complexity 9 → 11, inside the ≤15 gate. Blocking call wrapped per ADR-004. `librouteros.connect` defaults to a 10s socket timeout and the 58s `_connection_retry_sec` throttle is untouched, so per-poll executor cost stays bounded.
 
 ### Release ops
-Lands on `dev`; rolls into the open `v2.3.21` beta cycle (no version bump on the fix PR itself). **Merge commit, not squash** — preserves @sappsys's authorship per `CONTRIBUTING.md`; credited here and in the `README.md` / `info.md` "What's New" at stable. Maintainer hardening follows as a separate PR (happy-path + `wrong_login` → `ConfigEntryAuthFailed` coverage, ADR-007 helper extraction), same pattern as #116 → #120. No ADR required.
+Landed on `dev` as `0427a41`; rolls into the open `v2.3.21` beta cycle (no version bump on the fix PR itself). Merged with a **merge commit, not a squash** — all three of @sappsys's commits and their authorship are preserved on `dev` per `CONTRIBUTING.md`; credited here and in the `README.md` / `info.md` "What's New" at stable. Maintainer hardening follows as a separate PR (auth-branch coverage through the new gate, ADR-007 helper extraction), same pattern as #116 → #120. No ADR required.
 
 ---
 

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -12,7 +12,7 @@
 >
 > **NEXT SESSION (lead):**
 > 0. **Merge PR #122** (leak-gate governance-token extension) once CI green; then close ISS-260712(b). Surface ISS-260712(c) history-scrub + (d) `dev` branch-protection decisions to the operator.
-> 1. **PR #123 reconnect-on-poll (`ISS-260813-no-reconnect-until-hwinfo`)** — @sappsys's fix for the coordinator never retrying the API after a transient disconnect. Root cause confirmed and reproduced; code change sound. **Waiting on the contributor** for two test defects (read-only `option_sensor_*` assignment → suite red; `ruff format`); offered to push the fixes to their branch if they'd rather. **Approve the fork CI run** so their next push gets checks. Then merge-commit (not squash), and land the maintainer follow-up: happy-path + `wrong_login` → `ConfigEntryAuthFailed` coverage, ADR-007 `_async_ensure_connected()` extraction. Rolls into the open v2.3.21 beta. CR-260813-reconnect-on-poll.
+> 1. **PR #123 reconnect-on-poll (`ISS-260813-no-reconnect-until-hwinfo`)** — ✅ **Merged 2026-08-13** as `0427a41` (merge commit, @sappsys's three commits and their authorship preserved). Contributor cleared both test defects; full CI green on `c7cc8eae`. **Remaining:** the maintainer hardening PR — coverage for the `wrong_login` → `ConfigEntryAuthFailed` branch *through the new reconnect gate*, plus the ADR-007 `_async_ensure_connected()` extraction. Note the auth mapping itself is **not** a defect: `_raise_disconnected()` already routes `wrong_login` to `ConfigEntryAuthFailed`, so this is a coverage gap only. Rolls into the open v2.3.21 beta. CR-260813-reconnect-on-poll.
 > 2. **LTE field-validation gate (`ENH-260614-lte-modem-info`)** — v2.3.21-beta.1 **stays beta** until **@zvldz or an LTE user** confirms the LTE sensors on real hardware (maintainer fleet has none). On confirmation: **promote to stable** (`dev→master` PR + immediate back-merge, `master ⊆ dev` guard green; GitHub release, not pre-release) and **close ENH-260614**. Ping @zvldz on #116 when he can run the beta.
 > 3. **WireGuard peer sensors (`ENH-260703-wireguard-sensors`)** — **operator-requested: plan next session.** Surface per-peer state from `/interface/wireguard/peers` (last-handshake→connected/stale, endpoint, per-peer rx/tx); today only interface-level tx/rx exists. Scope keying (`public-key`), capability gate, ADR-020, redaction — see the ENH entry.
 > 4. **librouteros cap-lift** — `ENH-260512-librouteros-test-matrix`: 3.4.1 / latest-3.x / expected-fail-4.x CI matrix, then lift `manifest` to `>=4.0,<5` (the floor-bump is the **v2.4.0** trigger).
@@ -53,7 +53,7 @@
 **Type:** Bug (availability / recovery)
 **Priority:** High
 **Created:** 2026-08-13
-**Status:** 🟡 Fix in review — [#123](https://github.com/jnctech/homeassistant-mikrotik_router/pull/123) (@sappsys), CR-260813-reconnect-on-poll
+**Status:** 🟢 Resolved 2026-08-13 — [#123](https://github.com/jnctech/homeassistant-mikrotik_router/pull/123) (@sappsys) merged to `dev` as `0427a41` (merge commit, authorship preserved), CR-260813-reconnect-on-poll. Ships in the open `v2.3.21` beta cycle. Maintainer hardening tracked separately (auth-branch coverage + ADR-007 `_async_ensure_connected()` extraction).
 
 **Symptom:**
 After a transient RouterOS API outage (e.g. an upstream gateway reboot), entities stay `unavailable` even once the network is healthy again. Recovery needs a manual config-entry reload — the integration does not self-heal.


### PR DESCRIPTION
## Summary

Tracking-status update following the merge of #123.

- `docs/ISSUES.md` — `ISS-260813-no-reconnect-until-hwinfo` → **🟢 Resolved 2026-08-13**, recording the merge commit `0427a41`. In-flight item 1 rewritten from "waiting on the contributor" to merged, with the remaining maintainer hardening called out.
- `docs/CHANGE-REGISTER.md` — `CR-260813-reconnect-on-poll` → **Merged 2026-08-13 (`0427a41`)**. Verification section updated: the review-time failure was the contributor's own new test, cleared by `12a48ba` and `c7cc8ea`, and the merge gate records full CI green on `c7cc8ea` (Python Tests 3.13 + 3.14, hassfest, format, leak guard, Bandit, Gitleaks, manifest-drift, HACS zip).

### Scope correction carried in this PR

Both trackers previously scoped the follow-up as adding `wrong_login` → `ConfigEntryAuthFailed` handling. That reads as a defect and it isn't one: `_raise_disconnected()` at `custom_components/mikrotik_router/coordinator.py:674` already maps `wrong_login` to `ConfigEntryAuthFailed`, so @sappsys's change inherits correct reauth behaviour. The real gap is **coverage** — the new reconnect gate exercises only the `UpdateFailed` branch, and nothing reaches the auth branch through it. Both documents now say so.

### Attribution

#123 was merged with a merge commit rather than a squash, per `CONTRIBUTING.md`. Verified on `dev`: `6111fd7`, `12a48ba` and `c7cc8ea` all retain `sappsys` as author.

## Post-Deploy Actions

None. Documentation only — no code, no entity or config-entry impact.

## Test Plan

- [ ] CI green (docs-only; leak guard and markdown checks are the meaningful gates)
- [ ] `python scripts/check_no_homelab_leaks.py` → exit 0 (verified locally before commit)
- [ ] Confirm no homelab specifics entered the public trackers — this PR touches the In-flight block, the exact surface involved in ISS-260712
