### PR TITLE
refactor: extract _async_ensure_connected() and cover the credential branch (ISS-260813)

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -676,18 +676,35 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
         raise UpdateFailed("Mikrotik Disconnected")
 
     # ---------------------------
+    #   _async_ensure_connected
+    # ---------------------------
+    async def _async_ensure_connected(self) -> None:
+        """Reconnect the API when a poll finds it disconnected.
+
+        Without this the poll makes no reconnect attempt at all: _run_if_enabled
+        gates every fetch on api.connected(), and _async_update_hwinfo early-returns
+        inside its 4h window, so the get_access -> query -> connection_check chain
+        that would reconnect is never reached (ISS-260813).
+
+        connection_check() rate-limits attempts internally via _connection_retry_sec
+        (~58s), so this stays cheap per poll. Raises via _raise_disconnected() when
+        the reconnect does not take, which routes invalid credentials to reauth
+        rather than an endless retry.
+        """
+        if self.api.connected():
+            return
+
+        await self.hass.async_add_executor_job(self.api.connection_check)
+
+        if not self.api.connected():
+            self._raise_disconnected()
+
+    # ---------------------------
     #   _async_update_data
     # ---------------------------
     async def _async_update_data(self):
         """Update Mikrotik data"""
-        # Attempt reconnect every poll when disconnected. Without this,
-        # _run_if_enabled skips all API work and reconnect only happens
-        # on the ~4h hwinfo path (via get_access -> query -> connection_check).
-        # connection_check rate-limits attempts via _connection_retry_sec (~58s).
-        if not self.api.connected():
-            await self.hass.async_add_executor_job(self.api.connection_check)
-            if not self.api.connected():
-                self._raise_disconnected()
+        await self._async_ensure_connected()
 
         hwinfo_ran = await self._async_update_hwinfo()
 

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,33 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260813-reconnect-hardening — extract the reconnect gate and cover the credential branch
+
+**Date:** 2026-08-13
+**Branch:** `fix/reconnect-hardening` → PR to `dev`
+**Status:** In Review
+
+### What changed
+- `custom_components/mikrotik_router/coordinator.py` — extracted the reconnect gate @sappsys added in #123 into `_async_ensure_connected()`, called as the first statement of `_async_update_data()`. Pure extraction per ADR-007: same call sequence, same raise behaviour, no functional change.
+- `tests/test_coordinator.py` — new "Group AG1c" (5 tests): the helper's no-op path when already connected, its success path, `wrong_login` → `ConfigEntryAuthFailed` both directly and end-to-end through `_async_update_data()`, and `_raise_disconnected()`'s transient branch.
+
+### Why
+Follow-up to CR-260813-reconnect-on-poll, the maintainer half of the #116 → #120 pattern. Two things were outstanding.
+
+**Complexity.** The gate was inline in `_async_update_data()`, which is already the longest method on the coordinator. ADR-007 constrains future work to the same extract-and-test pattern, so the gate belongs in its own helper rather than adding branches to a 75-line function.
+
+**Coverage.** `_raise_disconnected()` has always mapped `wrong_login` to `ConfigEntryAuthFailed` (`coordinator.py:674`) so HA opens a reauth flow instead of retrying credentials that can never work — but **no test in the suite touched that branch**, before or after #123. The new gate made it newly reachable on every poll, which is exactly when an uncovered auth path is worth pinning down. Note this corrects the follow-up scope recorded in ISS-260813, which framed the auth mapping as missing; it was not, the gap was tests only.
+
+### Verification
+- `ruff check` and `ruff format --check` clean on both changed files, run against the CI-pinned `ruff==0.9.0` rather than a newer local build (ISS-260522-ruff-format-drift / ADR-010).
+- `_async_update_data()` branch-carrying AST nodes drop 13 → 11 with the gate extracted; the helper itself carries 2.
+- Full suite runs in CI (Docker was unavailable locally, so the pytest run is the CI matrix on 3.13/3.14, not a local run).
+
+### Release ops
+Lands on `dev`; rolls into the open `v2.3.21` beta cycle, same cycle as #123. No version bump, no ADR required — ADR-007 already governs the extraction pattern and this follows it rather than amending it.
+
+---
+
 ## CR-260813-reconnect-on-poll — reconnect the API on each poll after a transient disconnect (#123)
 
 **Date:** 2026-08-13

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3591,6 +3591,107 @@ async def test_async_update_data_continues_after_successful_reconnect():
 
 
 # ---------------------------------------------------------------------------
+# Group AG1c: _async_ensure_connected() — the extracted reconnect gate
+#
+# AG1b covers the gate's effect through _async_update_data. These cover the
+# helper directly, plus the credential branch: _raise_disconnected() routes
+# wrong_login to ConfigEntryAuthFailed so HA opens a reauth flow instead of
+# retrying bad credentials forever. Nothing previously reached that branch.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_connected_is_noop_when_already_connected():
+    """A healthy link must not cost an executor round-trip on every poll."""
+    coordinator = make_coordinator()
+    coordinator.api = MagicMock()
+    coordinator.api.connected.return_value = True
+    coordinator.hass = MagicMock()
+    coordinator.hass.async_add_executor_job = AsyncMock()
+
+    await coordinator._async_ensure_connected()
+
+    coordinator.hass.async_add_executor_job.assert_not_awaited()
+    coordinator.api.connection_check.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ensure_connected_returns_when_reconnect_succeeds():
+    """A successful reconnect returns quietly and does not raise."""
+    coordinator = make_coordinator()
+    coordinator.api = MagicMock()
+    connected = {"value": False}
+
+    def connection_check():
+        connected["value"] = True
+        return True
+
+    coordinator.api.connected.side_effect = lambda: connected["value"]
+    coordinator.api.connection_check = MagicMock(side_effect=connection_check)
+    coordinator.hass = MagicMock()
+    coordinator.hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a, **k: fn(*a, **k))
+
+    await coordinator._async_ensure_connected()
+
+    coordinator.hass.async_add_executor_job.assert_awaited_once_with(coordinator.api.connection_check)
+
+
+@pytest.mark.asyncio
+async def test_ensure_connected_raises_auth_failed_on_wrong_login():
+    """Bad credentials must surface as ConfigEntryAuthFailed, not UpdateFailed.
+
+    UpdateFailed would leave HA retrying a login that can never succeed;
+    ConfigEntryAuthFailed starts the reauth flow so the user is prompted.
+    """
+    from homeassistant.exceptions import ConfigEntryAuthFailed
+
+    coordinator = make_coordinator()
+    coordinator.api = MagicMock()
+    coordinator.api.connected.return_value = False
+    coordinator.api.connection_check = MagicMock(return_value=False)
+    coordinator.api.error = "wrong_login"
+    coordinator.hass = MagicMock()
+    coordinator.hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a, **k: fn(*a, **k))
+
+    with pytest.raises(ConfigEntryAuthFailed, match="Invalid Mikrotik username or password"):
+        await coordinator._async_ensure_connected()
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_raises_auth_failed_on_wrong_login():
+    """The credential branch must survive end-to-end through the poll.
+
+    Guards the wiring, not just the helper: a future refactor that swallowed
+    ConfigEntryAuthFailed into UpdateFailed inside _async_update_data would
+    silently disable reauth, and AG1b alone would not catch it.
+    """
+    from homeassistant.exceptions import ConfigEntryAuthFailed
+
+    coordinator = make_coordinator()
+    coordinator.api = MagicMock()
+    coordinator.api.connected.return_value = False
+    coordinator.api.connection_check = MagicMock(return_value=False)
+    coordinator.api.error = "wrong_login"
+    coordinator.hass = MagicMock()
+    coordinator.hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a, **k: fn(*a, **k))
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+def test_raise_disconnected_uses_update_failed_for_transient_errors():
+    """Any error other than wrong_login stays a retryable UpdateFailed."""
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    coordinator = make_coordinator()
+    coordinator.api = MagicMock()
+    coordinator.api.error = "cannot_connect"
+
+    with pytest.raises(UpdateFailed, match="Mikrotik Disconnected"):
+        coordinator._raise_disconnected()
+
+
+# ---------------------------------------------------------------------------
 # Group AG2: get_ups() — UPS path handling
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Maintainer hardening follow-up to #123 (`ISS-260813`), the same pattern as #116 → #120. No behaviour change.

- `custom_components/mikrotik_router/coordinator.py` — extracted the reconnect gate @sappsys added in #123 into **`_async_ensure_connected()`**, called as the first statement of `_async_update_data()`. Pure extraction per **ADR-007**: identical call sequence, identical raise behaviour.
- `tests/test_coordinator.py` — new **Group AG1c**, 5 tests: the helper's no-op path when already connected (a healthy link must not cost an executor round-trip every poll), its success path, `wrong_login` → `ConfigEntryAuthFailed` both directly and end-to-end through `_async_update_data()`, and `_raise_disconnected()`'s transient branch.

### Why

**Complexity.** The gate sat inline in `_async_update_data()`, already the longest method on the coordinator at 75 lines. ADR-007 constrains later work to the same extract-and-test pattern, so the gate belongs in its own helper rather than adding branches to that function. Branch-carrying AST nodes in `_async_update_data()` drop 13 → 11; the helper carries 2.

**Coverage.** `_raise_disconnected()` has always mapped `wrong_login` to `ConfigEntryAuthFailed` (`coordinator.py:674`), so HA opens a reauth flow instead of retrying credentials that can never work — but **no test in the suite touched that branch**, before or after #123. `grep ConfigEntryAuthFailed tests/` returned nothing. #123's gate makes that path reachable on *every* poll rather than only on the ~4h hwinfo refresh, which is precisely when an uncovered auth path is worth pinning down.

### Scope correction

`ISS-260813` recorded this follow-up as adding `wrong_login` → `ConfigEntryAuthFailed` *handling*. That framing was wrong and reads as a defect in @sappsys's change — it isn't one. The mapping already existed and their fix inherits it correctly; the gap was tests only. #126 corrects both trackers.

## Post-Deploy Actions

None. Pure refactor plus tests — no entity, config-entry, or API-contract change, and no version bump. Rolls into the open `v2.3.21` beta cycle alongside #123.

## Test Plan

- [ ] CI Python Tests 3.13 + 3.14 green, including the 5 new AG1c tests
- [ ] Confirm the 2 existing AG1b tests from #123 still pass unchanged — the extraction must not alter behaviour they assert
- [ ] `ruff check` / `ruff format --check` green (verified locally against the CI-pinned `ruff==0.9.0`, per ISS-260522-ruff-format-drift / ADR-010)
- [ ] Live smoke on the deployed HA host: pull the router's API, confirm entities recover without a config-entry reload after a transient disconnect

### Verification caveat

Docker Desktop was down on the authoring machine, so the full pytest suite was **not** run locally — `homeassistant` will not pip-install natively on Windows. Lint, format, the leak gate and the AST complexity measurement were run locally; the test run is the CI matrix. Do not merge on lint-green alone.
