### PR TITLE
chore: cut v2.3.21-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
+## What's New — v2.3.21-beta.2
+
+Adds a recovery fix to the open v2.3.21 beta cycle. Everything from beta.1 below still applies.
+
+- **The integration now recovers on its own after a transient API outage.** Previously, if the RouterOS API dropped — an upstream gateway reboot, a path outage, a PoE toggle — entities could stay `unavailable` until you manually reloaded the config entry. Worst case that was up to ~4 hours, because the only code path that reconnected was the 4-hourly hardware-info refresh. Each poll now attempts a reconnect, so recovery is automatic. Invalid credentials still correctly raise a reauth prompt rather than retrying forever. Thanks to **@sappsys** for finding and fixing this ([#123](https://github.com/jnctech/homeassistant-mikrotik_router/pull/123)).
+
 ## What's New — v2.3.21-beta.1
 
 Beta rolling up **LTE modem support** plus an integration-wide entity-reliability fix. **Beta-gated:** LTE is validated on contributor hardware (a MikroTik Chateau) — please report back if you run it. The reliability fix was live-validated on a multi-device deployment with no regressions.

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -14,5 +14,5 @@
         "librouteros>=3.4.1,<4.0",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.21-beta.1"
+    "version": "2.3.21-beta.2"
 }

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,34 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260814-release-v2321-beta2 — cut v2.3.21-beta.2
+
+**Date:** 2026-08-14
+**Branch:** `chore/release-v2.3.21-beta.2` → PR to `dev`
+**Status:** In Review
+
+### What changed
+- `custom_components/mikrotik_router/manifest.json` — version `2.3.21-beta.1` → `2.3.21-beta.2`. Edited in place to preserve the file's CRLF line endings (18 CRLFs before and after).
+- `README.md` / `info.md` — new "What's New" section for beta.2, crediting @sappsys for [#123](https://github.com/jnctech/homeassistant-mikrotik_router/pull/123).
+
+### Why
+Rolls the reconnect-on-poll recovery fix into the open `v2.3.21` beta cycle. The user-visible change is that a transient RouterOS API outage no longer strands entities as `unavailable` until a manual config-entry reload — worst case previously ~4h, bounded by the hardware-info refresh interval.
+
+Only the recovery fix is called out in the release notes. `CR-260813-reconnect-hardening` (helper extraction + credential-branch coverage) and `CR-260712-leak-gate-governance` (CI/pre-commit tooling) also ride in this cut but are not user-visible, so they stay out of "What's New".
+
+### Why still beta
+`ENH-260614-lte-modem-info` gates promotion: v2.3.21 stays beta until @zvldz or another LTE user confirms the LTE sensors on real hardware, since the maintainer fleet has none. The reconnect fix does not change that gate.
+
+### Verification
+- Full suite on merged `dev` (`a815128`): **707 passed, 5 skipped** — run in Docker on the docker host, not just CI.
+- Live baseline captured before side-load: **507 integration entities**, 4 `unavailable` / 15 `unknown`, all accounted for as correct-by-design (12 stateless script buttons; 3 `dhcp_address` on PPPoE/stopped clients; `sensor.mikrotik_rx` / `sensor.mikrotik_tx` / `device_tracker.mikrotik` are known pre-existing orphans).
+- Side-loaded to the live HA host and verified `manifest.json` reports `2.3.21-beta.2`; post-restart entity diff and `/validate-live-sensors` results recorded against that baseline.
+
+### Release ops
+Tag `v2.3.21-beta.2` on `dev` after merge; GitHub release marked **pre-release**. No `dev → master` promotion — that waits on the LTE gate. Live-validation detail stays in gitignored `docs/internal/`.
+
+---
+
 ## CR-260813-reconnect-hardening — extract the reconnect gate and cover the credential branch
 
 **Date:** 2026-08-13

--- a/info.md
+++ b/info.md
@@ -10,6 +10,10 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
+### What's new in v2.3.21-beta.2
+Adds a recovery fix to the open v2.3.21 beta cycle; everything in beta.1 below still applies.
+- **Self-recovery after a transient API outage** — if the RouterOS API dropped (gateway reboot, path outage, PoE toggle), entities could stay `unavailable` until you reloaded the config entry, worst case ~4h. Each poll now attempts a reconnect. Bad credentials still raise a reauth prompt rather than retrying forever. Thanks @sappsys (#123).
+
 ### What's new in v2.3.21-beta.1
 Beta: **LTE modem sensors** + an integration-wide entity-reliability fix. LTE is beta-gated on contributor hardware; the fix was live-validated with no regressions.
 - **LTE modem sensors** — signal (RSSI/RSRP/RSRQ/SINR/CQI), operator, connection, session uptime, and modem firmware for routers with an `/interface/lte`. Conditional on LTE hardware. IMEI/IMSI/ICCID collected but disabled by default + redacted. Thanks @zvldz for the implementation + live validation on a MikroTik Chateau. Implements tomaae #249. See ADR-019.


### PR DESCRIPTION
## Summary

Cuts **v2.3.21-beta.2**, rolling the reconnect-on-poll recovery fix into the open v2.3.21 beta cycle.

- `manifest.json` — `2.3.21-beta.1` → `2.3.21-beta.2`, edited in place so the file keeps its CRLF line endings (18 before, 18 after).
- `README.md` / `info.md` — new "What''s New" section for beta.2, crediting @sappsys for #123.
- `docs/CHANGE-REGISTER.md` — `CR-260814-release-v2321-beta2`.

Only the recovery fix appears in the release notes. #127 (helper extraction) and #125 (leak-gate tooling) also ride in this cut but are not user-visible.

**Stays beta.** `ENH-260614-lte-modem-info` gates promotion — v2.3.21 does not go stable until @zvldz or another LTE user confirms the LTE sensors on real hardware. The reconnect fix does not change that gate.

## Verification

- Full suite on merged `dev` (`a815128`): **707 passed, 5 skipped**, run in Docker on the docker host.
- **Live baseline → side-load → re-measure** on the real HA deployment (4 controllers):

| | Baseline (beta.1) | After beta.2 |
|---|---|---|
| Integration entities | 507 | **507** |
| `unavailable` | 4 | **4** |
| `unknown` | 15 | **15** |
| Entities gained / lost | — | **0 / 0** |

The `unavailable`/`unknown` **entity set is byte-identical** pre and post, not merely the same count. All 19 are correct-by-design: 12 stateless script buttons, 3 `dhcp_address` on PPPoE/stopped clients, and the known pre-existing `sensor.mikrotik_rx` / `sensor.mikrotik_tx` / `device_tracker.mikrotik` orphans.

- Deployed `manifest.json` on the HA host confirms `2.3.21-beta.2`; HA core came back 20s after restart and all 507 entities repopulated within a 43s window.

## Post-Deploy Actions

None for users. Maintainer, after merge: tag `v2.3.21-beta.2` on `dev` and publish the GitHub release **marked pre-release**. No `dev → master` promotion.

## Test Plan

- [ ] CI green
- [x] Entity parity vs baseline (507/507, identical bad-state set)
- [x] Deployed version reports `2.3.21-beta.2`
- [ ] Observe self-recovery in the wild — the fix''s actual purpose is unprovable without inducing an outage; see caveat
- [ ] Promote to stable only once the LTE gate clears

### Open caveat (read before tagging)

Spot-checking `last_reported` after deploy showed **mixed freshness** across entities — e.g. at 22:33:56Z, `hapax3 cpu_load` had reported at 22:33:25 while `hapax3 memory_usage` still read 22:28:55. The pattern is per-entity, not per-controller, and appears on all four controllers.

I **cannot attribute this to beta.2**: the baseline captured `state` and `last_updated` but not `last_reported`, so there is no before-picture to compare against. A regression is also implausible on inspection — the added code is a no-op while connected (`_async_ensure_connected()` returns immediately when `api.connected()` is true, which `test_ensure_connected_is_noop_when_already_connected` pins), so it cannot affect write cadence on a healthy link. Most likely HA''s identical-state write behaviour, not the integration.

Flagging rather than silently passing it. Worth a `last_reported`-aware baseline on the next cut.