### PR TITLE
feat: default-route monitoring sensors (ADR-020, B4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,15 @@ Track netwatch probe status.
 
 ![Netwatch](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/netwatch_tracker.png)
 
+## Route Monitoring *(new)*
+Multi-WAN / failover awareness from `/ip/route`. Enable **Default route monitoring sensors** in the integration options.
+
+For each default route (`0.0.0.0/0` and `::/0`) you get a **connectivity binary_sensor** that follows the route's RouterOS `active` flag — so you can alert when a WAN's default route drops and traffic moves to another uplink. Alongside it, an **active default routes** count sensor per routing-table tells you how many default routes are currently up.
+
+It is correct under policy routing (each routing-table is tracked separately) and ECMP / dual-uplink (multiple defaults in one table). Route comments name the entity when set, otherwise it is named `"{routing-table} via {gateway}"`; a blackhole kill-switch route is labelled `"{routing-table} blackhole"`. Attributes include gateway, immediate gateway, distance, scope and the dynamic/static/blackhole flags.
+
+Only default routes become entities — the full route table is never enumerated, so this stays bounded even on a BGP/OSPF router. The option is off by default. Entity `unique_id`s derive from a stable `routing-table`+`dst-address`+`gateway`+`distance` composite, not the volatile RouterOS `.id`, so they survive reboots. See [ADR-020](docs/decisions/ADR-020-route-monitoring.md).
+
 ## Scripts
 Execute MikroTik Router scripts from Home Assistant via automatically created buttons.
 

--- a/custom_components/mikrotik_router/binary_sensor_types.py
+++ b/custom_components/mikrotik_router/binary_sensor_types.py
@@ -53,6 +53,19 @@ DEVICE_ATTRIBUTES_NETWATCH = [
     "comment",
 ]
 
+DEVICE_ATTRIBUTES_ROUTE = [
+    "dst-address",
+    "routing-table",
+    "gateway",
+    "immediate-gw",
+    "distance",
+    "scope",
+    "dynamic",
+    "static",
+    "blackhole",
+    "comment",
+]
+
 
 @dataclass
 class MikrotikBinarySensorEntityDescription(BinarySensorEntityDescription):
@@ -157,6 +170,24 @@ SENSOR_TYPES: tuple[BinarySensorEntityDescription, ...] = (
         data_uid="host",
         data_reference="host",
         data_attributes_list=DEVICE_ATTRIBUTES_NETWATCH,
+        func="MikrotikBinarySensor",
+    ),
+    MikrotikBinarySensorEntityDescription(
+        key="route",
+        name="Route",
+        icon_enabled="mdi:router-network",
+        icon_disabled="mdi:router-network-wireless",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        ha_group="Routing",
+        ha_connection=DOMAIN,
+        ha_connection_value="Routing",
+        data_path="route",
+        data_attribute="active",
+        data_name="route-label",
+        data_name_prefer=True,
+        data_uid="uniq-id",
+        data_reference="uniq-id",
+        data_attributes_list=DEVICE_ATTRIBUTES_ROUTE,
         func="MikrotikBinarySensor",
     ),
 )

--- a/custom_components/mikrotik_router/config_flow.py
+++ b/custom_components/mikrotik_router/config_flow.py
@@ -70,6 +70,8 @@ from .const import (
     DEFAULT_SENSOR_RAW,
     CONF_SENSOR_CONTAINER,
     DEFAULT_SENSOR_CONTAINER,
+    CONF_SENSOR_ROUTE,
+    DEFAULT_SENSOR_ROUTE,
 )
 from .mikrotikapi import MikrotikAPI
 
@@ -320,6 +322,10 @@ class MikrotikControllerOptionsFlowHandler(OptionsFlowWithConfigEntry):
                     vol.Optional(
                         CONF_SENSOR_CONTAINER,
                         default=self._options.get(CONF_SENSOR_CONTAINER, DEFAULT_SENSOR_CONTAINER),
+                    ): bool,
+                    vol.Optional(
+                        CONF_SENSOR_ROUTE,
+                        default=self._options.get(CONF_SENSOR_ROUTE, DEFAULT_SENSOR_ROUTE),
                     ): bool,
                 },
             ),

--- a/custom_components/mikrotik_router/const.py
+++ b/custom_components/mikrotik_router/const.py
@@ -68,6 +68,8 @@ CONF_SENSOR_RAW = "sensor_raw"
 DEFAULT_SENSOR_RAW = False
 CONF_SENSOR_CONTAINER = "sensor_container"
 DEFAULT_SENSOR_CONTAINER = False
+CONF_SENSOR_ROUTE = "sensor_route"
+DEFAULT_SENSOR_ROUTE = False
 
 TO_REDACT = {
     "ip-address",
@@ -102,4 +104,11 @@ TO_REDACT = {
     "imei",
     "imsi",
     "iccid",
+    "immediate-gw",
+    # Synthetic composites that embed sensitive values (gateway/dst-address for
+    # routes, to-addresses for firewall rules). Redacted as whole strings because
+    # async_redact_data is key-name based and cannot reach values embedded inside
+    # a combined string. See ADR-020.
+    "uniq-id",
+    "route-label",
 }

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -69,6 +69,8 @@ from .const import (
     DEFAULT_SENSOR_RAW,
     CONF_SENSOR_CONTAINER,
     DEFAULT_SENSOR_CONTAINER,
+    CONF_SENSOR_ROUTE,
+    DEFAULT_SENSOR_ROUTE,
 )
 from .apiparser import parse_api
 from .mikrotikapi import MikrotikAPI
@@ -304,6 +306,8 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             "raw": {},
             "container": {},
             "neighbor": {},
+            "route": {},
+            "route_table": {},
         }
 
         self.notified_flags = []
@@ -472,6 +476,14 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
     def option_sensor_container(self):
         """Config entry option for container sensors."""
         return self.config_entry.options.get(CONF_SENSOR_CONTAINER, DEFAULT_SENSOR_CONTAINER)
+
+    # ---------------------------
+    #   option_sensor_route
+    # ---------------------------
+    @property
+    def option_sensor_route(self):
+        """Config entry option for default-route monitoring sensors."""
+        return self.config_entry.options.get(CONF_SENSOR_ROUTE, DEFAULT_SENSOR_ROUTE)
 
     # ---------------------------
     #   option_sensor_scripts
@@ -750,6 +762,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             (self.get_raw, self.option_sensor_raw),
             (self.get_netwatch, self.option_sensor_netwatch),
             (self.get_ppp, self.support_ppp and self.option_sensor_ppp),
+            (self.get_route, self.option_sensor_route),
         ]:
             await self._run_if_enabled(func, requires=enabled)
 
@@ -797,6 +810,8 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             "container",
             "environment",
             "netwatch",
+            "route",
+            "route_table",
         }
     )
 
@@ -1741,6 +1756,110 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 },
             ],
         )
+
+    # Default-route destinations (IPv4 and IPv6). get_route filters the full
+    # /ip/route table down to these client-side — see ADR-020.
+    _DEFAULT_DST_ADDRESSES = frozenset({"0.0.0.0/0", "::/0"})
+
+    # ---------------------------
+    #   get_route
+    # ---------------------------
+    def get_route(self) -> None:
+        """Get default-route reachability from Mikrotik.
+
+        Fetches /ip/route and filters to default routes client-side (the API
+        wrapper has no server-side filter), so the coordinator only ever holds
+        the failover-relevant set — never the full table. Builds one entity row
+        per default route plus a per-routing-table active-default count.
+
+        Rebuilt fresh each poll (data={}) rather than merged: the default set is
+        tiny and bounded, and a withdrawn route must drop out of the per-table
+        count immediately instead of lingering. See ADR-020.
+        """
+        source = self.api.query("/ip/route")
+        if source is None:
+            # Query failed (e.g. a transient disconnect — query() returns None on
+            # a dropped connection or an empty result). Keep the prior route state
+            # rather than crashing the poll on a None iteration, mirroring
+            # get_neighbor. The next successful poll rebuilds it.
+            return
+
+        defaults = []
+        for entry in source:
+            if entry.get("dst-address") not in self._DEFAULT_DST_ADDRESSES:
+                continue
+            # Normalise routing-table once (RouterOS v6 / single-table gear omits
+            # it) so the composite key, the parsed field, the label and the count
+            # all agree on "main".
+            if not entry.get("routing-table"):
+                entry["routing-table"] = "main"
+            # Key on a stable synthetic composite, NEVER RouterOS `.id`: `.id` is
+            # reassigned across reboots and route churn (a dynamic default route
+            # renewing on PPPoE/DHCP reconnect — the very failover event this
+            # watches), which would orphan the entity's data binding and freeze it.
+            # The dict key must equal the entity uid, so build the composite on the
+            # raw entry before parse_api keys on it (parse_api reads `key` from the
+            # raw entry; a val_proc field is computed too late to key on). ADR-020 §4.
+            entry["uniq-id"] = self._route_uid(entry)
+            defaults.append(entry)
+
+        routes = parse_api(
+            data={},
+            source=defaults,
+            key="uniq-id",
+            vals=[
+                {"name": "uniq-id"},
+                {"name": "dst-address", "default": "unknown"},
+                {"name": "routing-table", "default": "main"},
+                {"name": "gateway", "default": ""},
+                {"name": "immediate-gw", "default": ""},
+                {"name": "distance", "default": ""},
+                {"name": "scope", "default": ""},
+                {"name": "comment", "default": ""},
+                {"name": "active", "type": "bool", "default": False},
+                {"name": "dynamic", "type": "bool", "default": False},
+                {"name": "static", "type": "bool", "default": False},
+                {"name": "blackhole", "type": "bool", "default": False},
+            ],
+        )
+
+        route_tables: dict = {}
+        for row in routes.values():
+            row["route-label"] = self._route_label(row)
+            table = row["routing-table"]
+            entry = route_tables.setdefault(table, {"routing-table": table, "active-default-count": 0})
+            if row["active"]:
+                entry["active-default-count"] += 1
+
+        self.ds["route"] = routes
+        self.ds["route_table"] = route_tables
+
+    @staticmethod
+    def _route_uid(entry: dict) -> str:
+        """Build the stable composite unique key for a default route (ADR-020 §4).
+
+        routing-table + dst-address + gateway + distance. `distance` distinguishes
+        a primary default from a same-table backup/blackhole; `gateway`
+        distinguishes ECMP peers. routing-table is normalised to `main` by the
+        caller before this runs.
+        """
+        table = entry.get("routing-table", "main")
+        return f"{table}:{entry.get('dst-address', '')}:{entry.get('gateway', '')}:{entry.get('distance', '')}"
+
+    @staticmethod
+    def _route_label(row: dict) -> str:
+        """Compose a display label for a default route.
+
+        Prefers the user's route comment; otherwise names it by routing-table
+        and next hop. A blackhole (kill-switch) route has no gateway, so it is
+        labelled as such rather than "via <empty>". See ADR-020.
+        """
+        if row.get("comment"):
+            return row["comment"]
+        table = row["routing-table"]
+        if row.get("blackhole"):
+            return f"{table} blackhole"
+        return f"{table} via {row['gateway']}"
 
     # ---------------------------
     #   get_system_routerboard

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -30,6 +30,8 @@ from .const import (
     DEFAULT_SENSOR_NETWATCH_TRACKER,
     CONF_SENSOR_POE,
     DEFAULT_SENSOR_POE,
+    CONF_SENSOR_ROUTE,
+    DEFAULT_SENSOR_ROUTE,
 )
 from .coordinator import MikrotikConfigEntry, MikrotikCoordinator, MikrotikTrackerCoordinator
 from .helper import format_attribute
@@ -113,7 +115,19 @@ def _skip_sensor(config_entry, entity_description, data, uid) -> bool:
         or _skip_device_tracker(config_entry, entity_description)
         or _skip_poe_sensor(config_entry, entity_description, data, uid)
         or _skip_environment_sensor(entity_description, data, uid)
+        or _skip_route_sensor(config_entry, entity_description)
     )
+
+
+def _skip_route_sensor(config_entry, entity_description) -> bool:
+    """Skip route entities (per-route binary_sensor and per-table count) when disabled.
+
+    Both share the opt-in gate; the fetch is already gated in the coordinator,
+    so this only guards entity creation when the option is off. See ADR-020.
+    """
+    if entity_description.data_path not in ("route", "route_table"):
+        return False
+    return not config_entry.options.get(CONF_SENSOR_ROUTE, DEFAULT_SENSOR_ROUTE)
 
 
 def _skip_interface_traffic(config_entry, entity_description, data, uid) -> bool:

--- a/custom_components/mikrotik_router/sensor_types.py
+++ b/custom_components/mikrotik_router/sensor_types.py
@@ -1116,6 +1116,24 @@ SENSOR_TYPES: tuple[MikrotikSensorEntityDescription, ...] = (
         data_reference="name",
         data_attributes_list=DEVICE_ATTRIBUTES_DHCP_SERVER,
     ),
+    MikrotikSensorEntityDescription(
+        key="route_active_defaults",
+        name="Active default routes",
+        icon="mdi:call-split",
+        native_unit_of_measurement="routes",
+        device_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        ha_group="Routing",
+        ha_connection=DOMAIN,
+        ha_connection_value="Routing",
+        data_path="route_table",
+        data_attribute="active-default-count",
+        data_name="routing-table",
+        data_name_compose=True,
+        data_uid="routing-table",
+        data_reference="routing-table",
+    ),
 )
 
 SENSOR_SERVICES = []

--- a/custom_components/mikrotik_router/strings.json
+++ b/custom_components/mikrotik_router/strings.json
@@ -92,7 +92,8 @@
                     "sensor_filter": "Filter switches",
                     "sensor_poe": "PoE port sensors",
                     "sensor_raw": "Firewall RAW switches",
-                    "sensor_container": "Container sensors and switches"
+                    "sensor_container": "Container sensors and switches",
+                    "sensor_route": "Default route monitoring sensors"
                 },
                 "title": "Mikrotik Router options (2/2)",
                 "description": "Enable sensors and switches"

--- a/custom_components/mikrotik_router/translations/en.json
+++ b/custom_components/mikrotik_router/translations/en.json
@@ -92,7 +92,8 @@
                     "sensor_netwatch_tracker": "Netwatch tracker sensors",
                     "sensor_poe": "PoE port sensors",
                     "sensor_raw": "Firewall RAW switches",
-                    "sensor_container": "Container sensors and switches"
+                    "sensor_container": "Container sensors and switches",
+                    "sensor_route": "Default route monitoring sensors"
                 },
                 "title": "Mikrotik Router options (2\/2)",
                 "description": "Enable sensors and switches"

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,35 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260907-route-monitoring — implement default-route monitoring (B4)
+
+**Date:** 2026-09-07
+**Branch:** `feature/route-monitoring` → PR to `dev`
+**Status:** In Review
+
+### What changed
+- `custom_components/mikrotik_router/coordinator.py` — new `get_route()` getter (path `/ip/route`) with `_route_label()` helper. Filters the route table to default routes (`0.0.0.0/0`, `::/0`) **client-side** (the API wrapper has no server-side filter), so the coordinator only ever holds the failover-relevant set. Builds one row per default route plus a per-routing-table active-default count. Registered in the gated getter list behind the new `option_sensor_route`; `"route"`/`"route_table"` added to `self.ds` and `_ENTITY_UID_PATHS`.
+- `custom_components/mikrotik_router/const.py` — `CONF_SENSOR_ROUTE` / `DEFAULT_SENSOR_ROUTE = False`. Added `"uniq-id"` and `"route-label"` to `TO_REDACT`.
+- `custom_components/mikrotik_router/binary_sensor_types.py` — per-default-route `binary_sensor` (`data_attribute="active"`), `ha_group="Routing"`, keyed by the composite `uniq-id`, `DEVICE_ATTRIBUTES_ROUTE`.
+- `custom_components/mikrotik_router/sensor_types.py` — `route_active_defaults` count sensor, one per routing-table.
+- `custom_components/mikrotik_router/entity.py` — `_skip_route_sensor()` gates both route paths on `CONF_SENSOR_ROUTE`.
+- `custom_components/mikrotik_router/config_flow.py`, `strings.json`, `translations/en.json` — the opt-in toggle + label.
+- `tests/` — 20 new tests (`get_route` parse/filter/composite-UID/multi-table/ECMP/blackhole/fresh-rebuild; entity naming/unique_id/skip-gating; descriptor pins + is_on/native_value).
+
+### Why
+FEATURE-POLL B4, user-voted (`ENH-260907-route-monitoring`). Surfaces multi-WAN failover awareness as HA entities: a per-default-route `active` binary_sensor (which WAN dropped) and a per-table active-default count (how many are up). Correct under policy routing and ECMP. Implements [ADR-020](decisions/ADR-020-route-monitoring.md).
+
+### Design notes
+- **Stable keying.** The ds dict, the `parse_api` `key=`, and the entity `data_reference` are all the synthetic composite `routing-table`+`dst-address`+`gateway`+`distance` — never the RouterOS `.id` (reassigned on reboot and dynamic-route churn). Because `parse_api` reads `key=` from the raw entry (a `val_proc` field is computed too late to key on), the composite is injected onto each raw entry before parsing, so the ds key equals the entity uid and the binding survives an `.id` reassignment. Keying on `.id` here would silently freeze the entity when a dynamic default route renews — the exact failover event this feature watches (ADR-020 §4).
+- **Fresh rebuild each poll** (`data={}`) rather than merge: the default set is tiny and bounded, and a withdrawn route must drop out of the per-table count immediately rather than linger stale.
+- **Diagnostics redaction.** The synthetic `uniq-id` and `route-label` embed the gateway IP, which key-based `async_redact_data` cannot reach inside a combined string, so both are added to `TO_REDACT`. This also closes the pre-existing `to-addresses` leak in the nat/mangle `uniq-id`.
+
+### Verification
+- Suite **727 passed, 5 deselected** (`pytest -m "not integration"`); ruff clean on all changed files. New `get_route`/`_route_label` region fully covered.
+- Live validation on RB4011 (policy routing: `main` + `wg_us` + blackhole), CRS310 (2 defaults) and a single-table device is a release-time gate (per ADR-020 test plan), tracked under `ENH-260907`.
+
+---
+
 ## CR-260907-release-v2321 — cut v2.3.21 stable
 
 **Date:** 2026-09-07

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -11,7 +11,7 @@
 > **Release validated.** Fresh `/validate-live-sensors` on the deployed beta.2 (2026-09-07): **501 integration entities**, every sensor class cross-checked against router ground-truth within tolerance, **0 phantom LTE entities**; bad-state set benign (documented orphans + by-design `unknown`). Stable == beta.2 code + version bump only. Internal report in gitignored config docs.
 >
 > **NEXT SESSION (lead):**
-> 1. **Route monitoring (`ENH-260907-route-monitoring`, FEATURE-POLL B4)** — user-voted. Surface `/ip/route`: active/default-route presence + gateway reachability for multi-WAN failover awareness. Scope + capability gate + ADR before coding.
+> 1. **Route monitoring (`ENH-260907-route-monitoring`, FEATURE-POLL B4)** — 🟠 **implemented** on `feature/route-monitoring` (ADR-020, CR-260907-route-monitoring), PR to `dev`; 20 tests green. Remaining: live validation on RB4011/CRS310/single-table at release time.
 > 2. **WireGuard peer sensors (`ENH-260703-wireguard-sensors`, FEATURE-POLL B2)** — operator-requested. Per-peer state from `/interface/wireguard/peers` (last-handshake→connected/stale, endpoint, per-peer rx/tx); today only interface-level tx/rx exists. Scope keying (`public-key`), capability gate, ADR-021, redaction — see the ENH entry.
 > 3. **librouteros cap-lift** — `ENH-260512-librouteros-test-matrix`: 3.4.1 / latest-3.x / expected-fail-4.x CI matrix, then lift `manifest` to `>=4.0,<5` (the floor-bump is the **v2.4.0** trigger).
 > 4. **Gold/Platinum** — `reconfiguration-flow` (Gold) may be decoupled from the deferred coordinator decomposition; `strict-typing` (Platinum) stays gated on it (would-be ADR-016). Author a `quality_scale.yaml` to make the remaining gaps auditable.
@@ -50,7 +50,7 @@
 **Type:** Enhancement
 **Priority:** Medium
 **Created:** 2026-09-07
-**Status:** 🟡 Planned — user-voted (FEATURE-POLL B4). **[ADR-020](decisions/ADR-020-route-monitoring.md) Accepted** (design agreed with the maintainer 2026-09-07); ready to implement. **v1 scope:** per-default-route `binary_sensor` (`active` flag) + active-default-count `sensor` per routing-table; opt-in `CONF_SENSOR_ROUTE`; composite UID (`routing-table`+`dst-address`+`gateway`+`distance`, not `.id`); client-side default-route filter. Non-default watch-list deferred to v2. See ADR-020 for the implementation checklist.
+**Status:** 🟠 In Review — implemented on `feature/route-monitoring` (CR-260907-route-monitoring), PR to `dev`. **[ADR-020](decisions/ADR-020-route-monitoring.md) Accepted.** **v1 shipped:** per-default-route `binary_sensor` (`active` flag) + active-default-count `sensor` per routing-table; opt-in `CONF_SENSOR_ROUTE`; composite UID (`routing-table`+`dst-address`+`gateway`+`distance`, not `.id`); client-side default-route filter; `uniq-id`/`route-label` redacted in diagnostics. 20 unit/golden tests, suite green. Non-default watch-list deferred to v2. **Remaining gate:** live validation on RB4011 (policy routing + blackhole) / CRS310 (2 defaults) / single-table device at release time (ADR-020 test plan).
 
 **Ask:**
 A user voted for route monitoring in the feature poll (B4). Surface RouterOS `/ip/route` state in Home Assistant for multi-WAN / failover awareness ("WAN1 route disappeared, traffic on WAN2").

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -260,3 +260,41 @@ class TestLTEConnectionBinarySensor:
             },
         )
         assert entity.icon == "mdi:signal-off"
+
+
+# ---------------------------------------------------------------------------
+# Route monitoring binary_sensor (ADR-020)
+# ---------------------------------------------------------------------------
+
+
+class TestRouteBinarySensor:
+    def test_descriptor_pins(self):
+        """The route sensor is a per-default-route CONNECTIVITY binary_sensor
+        reading `active` out of ds['route'], keyed by the stable composite."""
+        desc = next(s for s in SENSOR_TYPES if s.key == "route")
+        assert desc.device_class == BinarySensorDeviceClass.CONNECTIVITY
+        assert desc.data_path == "route"
+        assert desc.data_attribute == "active"
+        assert desc.data_reference == "uniq-id"
+        assert desc.ha_group == "Routing"
+
+    _ROUTE_OVERRIDES = {
+        "data_path": "route",
+        "data_attribute": "active",
+        "data_name": "route-label",
+        "data_reference": "uniq-id",
+    }
+
+    def test_is_on_true_when_active(self):
+        uid = "main:0.0.0.0/0:10.0.0.1:1"
+        coord = make_mock_coordinator()
+        coord.data["route"] = {uid: {"uniq-id": uid, "route-label": "main via 10.0.0.1", "active": True}}
+        entity = _make_binary_sensor(coordinator=coord, desc_overrides=self._ROUTE_OVERRIDES, uid=uid)
+        assert entity.is_on is True
+
+    def test_is_on_false_when_route_withdrawn(self):
+        uid = "main:0.0.0.0/0:10.0.0.1:1"
+        coord = make_mock_coordinator()
+        coord.data["route"] = {uid: {"uniq-id": uid, "route-label": "main via 10.0.0.1", "active": False}}
+        entity = _make_binary_sensor(coordinator=coord, desc_overrides=self._ROUTE_OVERRIDES, uid=uid)
+        assert entity.is_on is False

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2824,6 +2824,180 @@ def test_netwatch_name_defaults_empty_when_absent_or_empty():
 
 
 # ---------------------------------------------------------------------------
+# Group AZ: get_route() — default-route monitoring (ADR-020)
+# ---------------------------------------------------------------------------
+
+
+def _route(dst="0.0.0.0/0", table="main", gateway="10.0.0.1", distance=1, active=True, **extra):
+    """Build a raw /ip/route source row (librouteros returns flags as bools)."""
+    row = {
+        ".id": extra.pop("id", f"*{table}{distance}"),
+        "dst-address": dst,
+        "routing-table": table,
+        "gateway": gateway,
+        "distance": distance,
+        "active": active,
+    }
+    row.update(extra)
+    return row
+
+
+def test_route_filters_to_default_routes_only():
+    """Only 0.0.0.0/0 and ::/0 become rows; every non-default route is dropped
+    client-side so the coordinator never holds the full table (ADR-020)."""
+    coordinator = make_coordinator(
+        api_responses={
+            "/ip/route": [
+                _route(id="*1"),
+                _route(dst="192.168.88.0/24", id="*2"),  # connected LAN route — excluded
+                _route(dst="10.5.0.0/16", table="main", id="*3"),  # static non-default — excluded
+                _route(dst="::/0", gateway="fe80::1", id="*4"),  # IPv6 default — included
+            ],
+        }
+    )
+    coordinator.get_route()
+    dsts = {row["dst-address"] for row in coordinator.ds["route"].values()}
+    assert dsts == {"0.0.0.0/0", "::/0"}
+
+
+def test_route_dict_keyed_by_composite_not_id():
+    """The ds['route'] key IS the routing-table:dst:gateway:distance composite,
+    not the unstable RouterOS .id. The dict key is what the entity binds to as
+    its uid, so it must be the stable value (ADR-020 §4)."""
+    coordinator = make_coordinator(api_responses={"/ip/route": [_route(table="wg_us", gateway="wg-us", distance=1, id="*7")]})
+    coordinator.get_route()
+    assert set(coordinator.ds["route"].keys()) == {"wg_us:0.0.0.0/0:wg-us:1"}
+    row = coordinator.ds["route"]["wg_us:0.0.0.0/0:wg-us:1"]
+    assert row["uniq-id"] == "wg_us:0.0.0.0/0:wg-us:1"
+
+
+def test_route_entity_binding_survives_id_reassignment():
+    """A dynamic default route renews (PPPoE/DHCP) and RouterOS hands it a new
+    .id, but routing-table/dst/gateway/distance are unchanged: the ds key stays
+    constant, so the entity's uid binding does not break. This is the failure
+    ADR-020 §4 forbids — keying on .id would freeze the entity here."""
+    coordinator = make_coordinator(api_responses={"/ip/route": [_route(table="main", gateway="10.0.0.1", id="*1")]})
+    coordinator.get_route()
+    first_keys = set(coordinator.ds["route"].keys())
+
+    # Next poll: identical route, reassigned .id, and it has just gone inactive.
+    coordinator.api.responses["/ip/route"] = [_route(table="main", gateway="10.0.0.1", id="*9", active=False)]
+    coordinator.get_route()
+    assert set(coordinator.ds["route"].keys()) == first_keys  # binding preserved
+    assert coordinator.ds["route"]["main:0.0.0.0/0:10.0.0.1:1"]["active"] is False
+
+
+def test_route_per_table_active_default_count():
+    """The count sensor tallies active defaults per routing-table — the multi-WAN
+    signal. Inactive defaults are not counted."""
+    coordinator = make_coordinator(
+        api_responses={
+            "/ip/route": [
+                _route(table="main", gateway="10.0.0.1", active=True, id="*1"),
+                _route(table="wg_us", gateway="wg-us", active=True, distance=1, id="*2"),
+                _route(table="wg_us", gateway="", distance=10, active=False, blackhole=True, id="*3"),
+            ]
+        }
+    )
+    coordinator.get_route()
+    tables = coordinator.ds["route_table"]
+    assert tables["main"]["active-default-count"] == 1
+    assert tables["wg_us"]["active-default-count"] == 1  # blackhole is inactive
+
+
+def test_route_ecmp_two_active_defaults_same_table():
+    """Dual-uplink (ECMP): two active defaults in one table count as 2 and stay
+    distinct entities via their gateway-bearing composite (ADR-020)."""
+    coordinator = make_coordinator(
+        api_responses={
+            "/ip/route": [
+                _route(table="main", gateway="10.0.0.1", id="*1"),
+                _route(table="main", gateway="10.0.1.1", id="*2"),
+            ]
+        }
+    )
+    coordinator.get_route()
+    assert coordinator.ds["route_table"]["main"]["active-default-count"] == 2
+    uids = {row["uniq-id"] for row in coordinator.ds["route"].values()}
+    assert uids == {"main:0.0.0.0/0:10.0.0.1:1", "main:0.0.0.0/0:10.0.1.1:1"}
+
+
+def test_route_label_prefers_comment():
+    """route-label uses the user's route comment when set."""
+    coordinator = make_coordinator(api_responses={"/ip/route": [_route(comment="Primary WAN", id="*1")]})
+    coordinator.get_route()
+    assert coordinator.ds["route"]["main:0.0.0.0/0:10.0.0.1:1"]["route-label"] == "Primary WAN"
+
+
+def test_route_label_composes_table_and_gateway_without_comment():
+    """No comment -> '{routing-table} via {gateway}'."""
+    coordinator = make_coordinator(api_responses={"/ip/route": [_route(table="wg_us", gateway="wg-us", comment="", id="*1")]})
+    coordinator.get_route()
+    assert coordinator.ds["route"]["wg_us:0.0.0.0/0:wg-us:1"]["route-label"] == "wg_us via wg-us"
+
+
+def test_route_label_blackhole_has_no_gateway():
+    """A blackhole kill-switch route has no gateway, so it is labelled by table,
+    not 'via <empty>' (ADR-020)."""
+    coordinator = make_coordinator(api_responses={"/ip/route": [_route(table="wg_us", gateway="", distance=10, active=False, blackhole=True, id="*1")]})
+    coordinator.get_route()
+    assert coordinator.ds["route"]["wg_us:0.0.0.0/0::10"]["route-label"] == "wg_us blackhole"
+
+
+def test_route_rebuilt_fresh_drops_withdrawn_routes():
+    """ds['route'] is rebuilt each poll: a withdrawn default disappears (and its
+    count drops) rather than lingering stale (ADR-020)."""
+    coordinator = make_coordinator(
+        api_responses={
+            "/ip/route": [
+                _route(table="main", gateway="10.0.0.1", id="*1"),
+                _route(table="main", gateway="10.0.1.1", id="*2"),
+            ]
+        }
+    )
+    coordinator.get_route()
+    assert coordinator.ds["route_table"]["main"]["active-default-count"] == 2
+
+    # Second poll: the backup uplink route is gone.
+    coordinator.api.responses["/ip/route"] = [_route(table="main", gateway="10.0.0.1", id="*1")]
+    coordinator.get_route()
+    assert len(coordinator.ds["route"]) == 1
+    assert coordinator.ds["route_table"]["main"]["active-default-count"] == 1
+
+
+def test_route_missing_routing_table_defaults_to_main():
+    """RouterOS v6 / single-table gear omits routing-table; default it to 'main'."""
+    coordinator = make_coordinator(api_responses={"/ip/route": [{".id": "*1", "dst-address": "0.0.0.0/0", "gateway": "10.0.0.1", "active": True}]})
+    coordinator.get_route()
+    # No routing-table and no distance in the source -> "main" default, empty distance.
+    row = coordinator.ds["route"]["main:0.0.0.0/0:10.0.0.1:"]
+    assert row["routing-table"] == "main"
+    assert coordinator.ds["route_table"]["main"]["active-default-count"] == 1
+
+
+def test_route_empty_table_yields_no_entities():
+    """No routes at all -> empty dicts, no crash."""
+    coordinator = make_coordinator(api_responses={"/ip/route": []})
+    coordinator.get_route()
+    assert coordinator.ds["route"] == {}
+    assert coordinator.ds["route_table"] == {}
+
+
+def test_route_query_none_keeps_prior_state():
+    """A transient disconnect makes query() return None; get_route must keep the
+    prior route state and not crash on a None iteration (mirrors get_neighbor)."""
+    coordinator = make_coordinator()
+    coordinator.ds["route"] = {"*1": {"active": True, "uniq-id": "main:0.0.0.0/0:10.0.0.1:1"}}
+    coordinator.ds["route_table"] = {"main": {"routing-table": "main", "active-default-count": 1}}
+    coordinator.api.query = MagicMock(return_value=None)
+
+    coordinator.get_route()  # must not raise
+
+    assert coordinator.ds["route"] == {"*1": {"active": True, "uniq-id": "main:0.0.0.0/0:10.0.0.1:1"}}
+    assert coordinator.ds["route_table"]["main"]["active-default-count"] == 1
+
+
+# ---------------------------------------------------------------------------
 # Group AA: get_system_routerboard() — routerboard parsing
 # ---------------------------------------------------------------------------
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -25,6 +25,7 @@ from custom_components.mikrotik_router.const import (
     CONF_SENSOR_NETWATCH_TRACKER,
     CONF_TRACK_HOSTS,
     CONF_SENSOR_POE,
+    CONF_SENSOR_ROUTE,
 )
 from .conftest import (
     make_mock_coordinator,
@@ -1065,3 +1066,66 @@ def test_no_skip_poe_energy_sensor_when_estimated():
     data = {"ether1": {"poe-out-energy-source": "estimated"}}
     cfg = make_config_entry({CONF_SENSOR_POE: True})
     assert _skip_sensor(cfg, _energy_desc(), data, "ether1") is False
+
+
+# ---------------------------------------------------------------------------
+# Route monitoring: naming, unique_id, and skip-gating (ADR-020)
+# ---------------------------------------------------------------------------
+
+# Real route binary_sensor descriptor field set (mirrors binary_sensor_types.py).
+ROUTE_DESC_KW = dict(
+    key="route",
+    name="Route",
+    data_name="route-label",
+    data_uid="uniq-id",
+    data_reference="uniq-id",
+    data_name_prefer=True,
+)
+
+
+class TestRouteCustomName:
+    """A route names itself from its composed label (comment, else table via gw),
+    built from the REAL binary_sensor description so a renamed field fails."""
+
+    def test_label_is_the_display_name(self):
+        row = {"uniq-id": "main:0.0.0.0/0:10.0.0.1:1", "route-label": "Primary WAN"}
+        entity = _binary_entity_with_real_desc("route", row["uniq-id"], row, **ROUTE_DESC_KW)
+        assert entity.custom_name == "Primary WAN"
+
+    def test_unique_id_is_composite_derived(self):
+        """unique_id slugifies the routing-table:dst:gateway:distance composite,
+        not the unstable .id — two ECMP defaults stay distinct."""
+        row_a = {"uniq-id": "main:0.0.0.0/0:10.0.0.1:1", "route-label": "main via 10.0.0.1"}
+        row_b = {"uniq-id": "main:0.0.0.0/0:10.0.1.1:1", "route-label": "main via 10.0.1.1"}
+        ent_a = _binary_entity_with_real_desc("route", row_a["uniq-id"], row_a, **ROUTE_DESC_KW)
+        ent_b = _binary_entity_with_real_desc("route", row_b["uniq-id"], row_b, **ROUTE_DESC_KW)
+        assert ent_a.unique_id == f"mikrotik-route-{slugify('main:0.0.0.0/0:10.0.0.1:1')}"
+        assert ent_a.unique_id != ent_b.unique_id
+
+
+def _route_desc(data_path="route", data_attribute="active"):
+    return make_entity_desc(func="MikrotikBinarySensor", data_path=data_path, data_attribute=data_attribute)
+
+
+def test_skip_route_when_option_disabled():
+    """Route entities are skipped when CONF_SENSOR_ROUTE is off."""
+    data = {"main:0.0.0.0/0:10.0.0.1:1": {"active": True}}
+    cfg = make_config_entry({CONF_SENSOR_ROUTE: False})
+    assert _skip_sensor(cfg, _route_desc(), data, "main:0.0.0.0/0:10.0.0.1:1") is True
+
+
+def test_no_skip_route_when_option_enabled():
+    """Route entities are created when CONF_SENSOR_ROUTE is on."""
+    data = {"main:0.0.0.0/0:10.0.0.1:1": {"active": True}}
+    cfg = make_config_entry({CONF_SENSOR_ROUTE: True})
+    assert _skip_sensor(cfg, _route_desc(), data, "main:0.0.0.0/0:10.0.0.1:1") is False
+
+
+def test_skip_route_table_count_follows_same_gate():
+    """The per-table count sensor shares the route opt-in gate."""
+    data = {"main": {"active-default-count": 2}}
+    cfg = make_config_entry({CONF_SENSOR_ROUTE: False})
+    desc = _route_desc(data_path="route_table", data_attribute="active-default-count")
+    assert _skip_sensor(cfg, desc, data, "main") is True
+    cfg_on = make_config_entry({CONF_SENSOR_ROUTE: True})
+    assert _skip_sensor(cfg_on, desc, data, "main") is False

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -488,3 +488,37 @@ def test_poe_energy_update_skips_when_uid_missing():
     sensor._handle_coordinator_update()
     assert sensor.native_value == before
     sensor.async_write_ha_state.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Route monitoring: per-table active-default-count sensor (ADR-020)
+# ---------------------------------------------------------------------------
+
+
+def test_route_count_descriptor_pins():
+    """The count sensor tallies active default routes per routing-table, keyed
+    by routing-table and composing its name so per-table sensors stay distinct."""
+    desc = next(s for s in SENSOR_TYPES if s.key == "route_active_defaults")
+    assert desc.data_path == "route_table"
+    assert desc.data_attribute == "active-default-count"
+    assert desc.data_reference == "routing-table"
+    assert desc.data_name_compose is True
+    assert desc.state_class == SensorStateClass.MEASUREMENT
+    assert desc.ha_group == "Routing"
+
+
+def test_route_count_native_value():
+    """native_value returns the active-default count for the table."""
+    desc = _description(
+        key="route_active_defaults",
+        data_path="route_table",
+        data_attribute="active-default-count",
+        data_name="routing-table",
+        data_reference="routing-table",
+    )
+    sensor = _build_sensor(
+        {"route_table": {"wg_us": {"routing-table": "wg_us", "active-default-count": 1}}},
+        desc,
+        uid="wg_us",
+    )
+    assert sensor.native_value == 1


### PR DESCRIPTION
## Summary
- Adds **default-route monitoring** (FEATURE-POLL B4, `ENH-260907-route-monitoring`, [ADR-020](docs/decisions/ADR-020-route-monitoring.md)) for multi-WAN / failover awareness.
- **Per-default-route binary_sensor** following the RouterOS `active` flag (which WAN dropped), plus a **per-routing-table active-default-count sensor** (how many are up). New `ha_group="Routing"`.
- Opt-in `CONF_SENSOR_ROUTE` (default off). `get_route()` fetches `/ip/route` and filters to default routes (`0.0.0.0/0`, `::/0`) **client-side**, so the coordinator never holds the full table — bounded even on BGP/OSPF gear.
- Correct under **policy routing** (per routing-table) and **ECMP** (multiple defaults per table). Comment names the entity, else `"{table} via {gateway}"`; a blackhole kill-switch route is `"{table} blackhole"`.
- **Stable keying (ADR-020 §4):** the ds dict, `parse_api` key, and entity `data_reference` are all the synthetic composite `routing-table:dst-address:gateway:distance` — never the RouterOS `.id` (reassigned on reboot / dynamic-route renewal). Keying on `.id` would freeze the entity on the exact failover event this watches; the composite is injected onto the raw entry before `parse_api` keys on it.
- **Robustness / privacy:** `get_route()` guards a `None` query result (transient disconnect) and keeps prior state rather than crashing the poll (mirrors `get_neighbor`); the composite `uniq-id`, `route-label` and `immediate-gw` embed gateway IPs and are added to `TO_REDACT` for diagnostics (also closes the pre-existing `to-addresses` leak in nat/mangle `uniq-id`).

## Post-Deploy Actions
- None. New feature is opt-in and creates no entities until **Default route monitoring sensors** is enabled in the integration options. No migration, no config changes.

## Test Plan
- [x] `pytest -m "not integration"` — 727 passed (21 new route tests: parse/filter, composite key, multi-table, ECMP, blackhole, fresh-rebuild, `None`-guard, `.id`-reassignment survival, naming/unique_id/skip-gating, descriptor pins).
- [x] Ruff clean; cognitive complexity < 15; homelab-leak gate green.
- [x] Reviewed by the coordinator-reviewer and code-reviewer agents; findings (crash-on-disconnect, `.id`-keying freeze, `immediate-gw` redaction) fixed.
- [ ] **Release-time live validation** (per ADR-020 test plan, tracked under `ENH-260907`): RB4011 (policy routing `main` + `wg_us` + blackhole), CRS310 (2 defaults), a single-table device; disable a default route → its binary_sensor flips `off` and the count decrements within one poll.

## Tracking
- `docs/CHANGE-REGISTER.md` → CR-260907-route-monitoring
- `docs/ISSUES.md` → ENH-260907-route-monitoring (In Review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
