### PR TITLE
fix: stop dummy-MAC interfaces merging across routers in the device registry

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -128,6 +128,19 @@ def as_local(dattim: datetime) -> datetime:
     return dattim.astimezone(DEFAULT_TIME_ZONE)
 
 
+def _port_mac_for_virtual_iface(mac: str | None, ifname: str, serial: str) -> str:
+    """Build a per-router port-mac token for virtual interfaces.
+
+    Ethernet already has a unique hardware MAC. Virtual ifaces (lo, tunnels)
+    often share an all-zero or empty MAC, which HA's device registry
+    would merge across config entries if used as CONNECTION_NETWORK_MAC.
+    """
+    compact = str(mac or "").replace(":", "").lower()
+    if compact in ("", "000000000000"):
+        return f"{serial}-{ifname}"
+    return f"{mac}-{ifname}"
+
+
 @dataclass
 class MikrotikData:
     """Data for the mikrotik integration."""
@@ -1163,7 +1176,8 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
             if vals["default-name"] == "":
                 iface["default-name"] = vals["name"]
-                iface["port-mac-address"] = f"{vals['port-mac-address']}-{vals['name']}"
+                serial = self.ds.get("routerboard", {}).get("serial-number") or getattr(self, "name", None) or "unknown"
+                iface["port-mac-address"] = _port_mac_for_virtual_iface(vals.get("port-mac-address"), vals["name"], serial)
 
             if iface["type"] == "ether":
                 self._monitor_ethernet_port(vals)

--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import (
     entity_registry as er,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
@@ -275,6 +276,23 @@ _MikrotikCoordinatorT = TypeVar(
 )
 
 
+def _real_network_mac(value: str) -> bool:
+    """True when value is a unique hardware MAC (not lo / empty / serial-prefixed)."""
+    mac_part = (value or "").split("-", 1)[0]
+    compact = mac_part.replace(":", "").lower()
+    if compact in ("", "000000000000"):
+        return False
+    return len(compact) == 12 and all(c in "0123456789abcdef" for c in compact)
+
+
+def _interface_device_ident(serial: str, conn_val: str) -> str:
+    """Stable per-router identity for a dummy-MAC virtual interface."""
+    if conn_val.startswith(f"{serial}-"):
+        return conn_val
+    suffix = conn_val.lstrip("-")
+    return f"{serial}-{suffix}"
+
+
 # ---------------------------
 #   MikrotikEntity
 # ---------------------------
@@ -418,14 +436,29 @@ class MikrotikEntity(CoordinatorEntity[_MikrotikCoordinatorT], Entity):
                 ),
             )
         else:
+            serial = self.coordinator.data["routerboard"]["serial-number"]
+            conn_val = f"{dev_connection_value}"
+            if dev_connection == CONNECTION_NETWORK_MAC and not _real_network_mac(conn_val):
+                ident = _interface_device_ident(serial, conn_val)
+                return DeviceInfo(
+                    connections={(DOMAIN, ident)},
+                    identifiers={(DOMAIN, ident)},
+                    name=f"{self._inst} {dev_group}",
+                    model=f"{self.coordinator.data['resource']['board-name']}",
+                    manufacturer=f"{self.coordinator.data['resource']['platform']}",
+                    via_device=(
+                        DOMAIN,
+                        f"{serial}",
+                    ),
+                )
             return DeviceInfo(
-                connections={(dev_connection, f"{dev_connection_value}")},
+                connections={(dev_connection, conn_val)},
                 name=f"{self._inst} {dev_group}",
                 model=f"{self.coordinator.data['resource']['board-name']}",
                 manufacturer=f"{self.coordinator.data['resource']['platform']}",
                 via_device=(
                     DOMAIN,
-                    f"{self.coordinator.data['routerboard']['serial-number']}",
+                    f"{serial}",
                 ),
             )
 

--- a/docs/decisions/ADR-NEXT-dummy-mac-device-identity.md
+++ b/docs/decisions/ADR-NEXT-dummy-mac-device-identity.md
@@ -1,0 +1,32 @@
+# ADR-NEXT: Per-router identity for dummy-MAC virtual interfaces
+
+**Date:** 2026-08-14
+**Status:** Proposed
+**Numbering note:** Next unused on `dev` is 022; 015/016 remain reserved. File as `ADR-NEXT` for maintainer numbering at merge.
+
+## Context
+
+Interface entities use `ha_connection=CONNECTION_NETWORK_MAC` with `ha_connection_value=data__port-mac-address`. For virtual interfaces (`default-name == ""`) the coordinator previously set `port-mac-address` to `{mac}-{ifname}`.
+
+RouterOS `lo` always reports an all-zero MAC. Some tunnels report an empty MAC. Every router therefore produced the same connection token (`{all-zero-mac}-lo`, `-wireguard1`, …). Home Assistant's device registry merges on `connections`, so multiple MikroTik config entries collapsed those interfaces onto one device. `via_device` then followed whichever router last wrote the entry.
+
+Real ethernet/wifi MACs are already unique and are not in scope.
+
+## Decision
+
+1. **Coordinator.** For virtual interfaces whose MAC is empty or all-zero, set `port-mac-address` to `{serial}-{ifname}`. Virtual interfaces that do have a hardware MAC keep `{mac}-{ifname}`.
+2. **Entity `device_info`.** If the connection type is `CONNECTION_NETWORK_MAC` but the value is not a real 12-hex MAC, register `(DOMAIN, {serial}-{ifname})` as both `identifiers` and `connections` instead of a MAC connection. `via_device` remains `(DOMAIN, serial)`.
+3. **Do not double-prefix.** When the coordinator has already produced `{serial}-{ifname}`, the entity uses that token as-is.
+4. **Leave unique_ids unchanged.** Entity unique_ids already include the config-entry name plus interface name; this is a device-registry identity fix only.
+
+## Alternatives Considered
+
+- **Serial in identifiers only, keep the shared MAC connection.** HA still merges on `connections`, so the collision remains.
+- **Skip `lo` / tunnel entities.** Hides the bug rather than fixing identity; users who want those sensors still collide.
+- **HA device-registry cleanup / migration.** Existing merged devices are sticky and may need a one-time remove+reload; that is an operator step, not a data-format migration, and is documented on the PR rather than automated here.
+
+## Consequences
+
+- Each router's `lo` (and empty-MAC tunnels) becomes its own device, `via` the parent router.
+- Already-merged registry devices will not split on upgrade until the merged device (or its all-zero-MAC `lo` connection) is removed and the integration reloads.
+- Diagnostics still redact serials (`TO_REDACT`); the new connection token is an internal registry key, not a new user-facing unique_id.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -13,6 +13,7 @@ from custom_components.mikrotik_router.apiparser import (
 from custom_components.mikrotik_router.coordinator import (
     MikrotikCoordinator,
     _parse_uptime_to_seconds,
+    _port_mac_for_virtual_iface,
     as_local,
     utc_from_timestamp,
 )
@@ -2046,6 +2047,61 @@ def test_interface_virtual_interface_naming():
     iface = coordinator.ds["interface"]["vlan100"]
     assert iface["default-name"] == "vlan100"
     assert "vlan100" in iface["port-mac-address"]
+
+
+def test_port_mac_for_virtual_iface_dummy_and_empty():
+    """Dummy/empty MACs are serial-prefixed; real MACs keep the hardware address."""
+    assert _port_mac_for_virtual_iface("00:00:00:00:00:00", "lo", "HGR1234567") == "HGR1234567-lo"
+    assert _port_mac_for_virtual_iface("", "wireguard1", "HGR1234567") == "HGR1234567-wireguard1"
+    assert _port_mac_for_virtual_iface(None, "pppoe-out1", "HGR1234567") == "HGR1234567-pppoe-out1"
+    assert _port_mac_for_virtual_iface("AA:BB:CC:DD:EE:01", "vlan100", "HGR1234567") == "AA:BB:CC:DD:EE:01-vlan100"
+
+
+def test_interface_loopback_dummy_mac_uses_serial():
+    """lo always reports 00:00:00:00:00:00; port-mac must include the router serial."""
+    coordinator = make_coordinator(
+        options={CONF_SENSOR_PORT_TRAFFIC: False},
+        api_responses={
+            "/interface": [
+                {
+                    ".id": "*1",
+                    "name": "lo",
+                    "type": "loopback",
+                    "disabled": False,
+                    "mac-address": "00:00:00:00:00:00",
+                }
+            ],
+            "/interface/ethernet": [],
+        },
+    )
+    coordinator.ds["routerboard"]["serial-number"] = "HGR1234567"
+    coordinator.get_interface()
+    iface = coordinator.ds["interface"]["lo"]
+    assert iface["default-name"] == "lo"
+    assert iface["port-mac-address"] == "HGR1234567-lo"
+
+
+def test_interface_empty_mac_tunnel_uses_serial():
+    """Tunnels with an empty MAC are serial-prefixed so they do not collide across routers."""
+    coordinator = make_coordinator(
+        options={CONF_SENSOR_PORT_TRAFFIC: False},
+        api_responses={
+            "/interface": [
+                {
+                    ".id": "*1",
+                    "name": "wireguard1",
+                    "type": "wg",
+                    "disabled": False,
+                    "mac-address": "",
+                }
+            ],
+            "/interface/ethernet": [],
+        },
+    )
+    coordinator.ds["routerboard"]["serial-number"] = "HGR1234567"
+    coordinator.get_interface()
+    iface = coordinator.ds["interface"]["wireguard1"]
+    assert iface["port-mac-address"] == "HGR1234567-wireguard1"
 
 
 def test_interface_bonding_detected():

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -4,22 +4,27 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from homeassistant.const import CONF_NAME
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.util import slugify
 
 from custom_components.mikrotik_router.entity import (
     copy_attrs,
     _skip_sensor,
+    _real_network_mac,
+    _interface_device_ident,
     MikrotikEntity,
     MikrotikInterfaceEntityMixin,
 )
 from custom_components.mikrotik_router.coordinator import MikrotikCoordinator
 from custom_components.mikrotik_router.sensor_types import (
     MikrotikSensorEntityDescription,
+    SENSOR_TYPES,
 )
 from custom_components.mikrotik_router.binary_sensor_types import (
     MikrotikBinarySensorEntityDescription,
 )
 from custom_components.mikrotik_router.const import (
+    DOMAIN,
     CONF_SENSOR_PORT_TRAFFIC,
     CONF_SENSOR_PORT_TRACKER,
     CONF_SENSOR_NETWATCH_TRACKER,
@@ -439,6 +444,82 @@ class TestMikrotikEntityDeviceInfo:
         )
         info = entity.device_info
         assert "via_device" in info
+
+
+def _iface_traffic_desc():
+    """Real interface traffic description (ha_connection = MAC via port-mac-address)."""
+    return next(d for d in SENSOR_TYPES if d.key == "traffic_tx")
+
+
+def test_real_network_mac_rejects_dummy_and_serial_tokens():
+    """Only a 12-hex hardware MAC counts; lo / empty / serial-prefixed tokens do not."""
+    assert _real_network_mac("AA:BB:CC:DD:EE:01") is True
+    assert _real_network_mac("AA:BB:CC:DD:EE:01-vlan100") is True
+    assert _real_network_mac("00:00:00:00:00:00") is False
+    assert _real_network_mac("00:00:00:00:00:00-lo") is False
+    assert _real_network_mac("-wireguard1") is False
+    assert _real_network_mac("HGR1234567-lo") is False
+    assert _real_network_mac("") is False
+
+
+def test_interface_device_ident_does_not_double_prefix_serial():
+    """Coordinator already prefixes dummy MACs with serial; entity must not do it again."""
+    assert _interface_device_ident("HGR1234567", "HGR1234567-lo") == "HGR1234567-lo"
+    assert _interface_device_ident("HGR1234567", "00:00:00:00:00:00-lo") == "HGR1234567-00:00:00:00:00:00-lo"
+    assert _interface_device_ident("HGR1234567", "-wireguard1") == "HGR1234567-wireguard1"
+
+
+class TestDummyMacInterfaceDeviceInfo:
+    """Virtual ifaces with dummy MACs must not share CONNECTION_NETWORK_MAC across routers."""
+
+    def _entity(self, serial, port_mac, uid="lo", name="RouterA"):
+        desc = _iface_traffic_desc()
+        coord = make_mock_coordinator(name=name)
+        coord.data["routerboard"]["serial-number"] = serial
+        coord.data["interface"] = {
+            uid: {
+                "name": uid,
+                "default-name": uid,
+                "type": "loopback",
+                "port-mac-address": port_mac,
+            }
+        }
+        with patch_coordinator_entity_init():
+            return MikrotikEntity(coord, desc, uid)
+
+    def test_loopback_uses_domain_connection_not_mac(self):
+        entity = self._entity("HGR1234567", "HGR1234567-lo")
+        info = entity.device_info
+        ident = (DOMAIN, "HGR1234567-lo")
+        assert info["connections"] == {ident}
+        assert info["identifiers"] == {ident}
+        assert CONNECTION_NETWORK_MAC not in {c[0] for c in info["connections"]}
+        assert info["via_device"] == (DOMAIN, "HGR1234567")
+
+    def test_two_routers_do_not_share_loopback_identity(self):
+        a = self._entity("HGR1234567", "HGR1234567-lo", name="RouterA").device_info
+        b = self._entity("HGR7654321", "HGR7654321-lo", name="RouterB").device_info
+        assert a["identifiers"] != b["identifiers"]
+        assert a["connections"] != b["connections"]
+        assert a["via_device"] != b["via_device"]
+
+    def test_ethernet_still_uses_network_mac(self):
+        desc = _iface_traffic_desc()
+        coord = make_mock_coordinator()
+        coord.data["interface"] = {
+            "ether1": {
+                "name": "ether1",
+                "default-name": "ether1",
+                "type": "ether",
+                "port-mac-address": "AA:BB:CC:DD:EE:01",
+            }
+        }
+        with patch_coordinator_entity_init():
+            entity = MikrotikEntity(coord, desc, "ether1")
+        info = entity.device_info
+        assert info["connections"] == {(CONNECTION_NETWORK_MAC, "AA:BB:CC:DD:EE:01")}
+        assert "identifiers" not in info
+        assert info["via_device"] == (DOMAIN, "HGR1234567")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Proposed change

On RouterOS, `lo` always reports an all-zero MAC, and some tunnels report an empty MAC. For virtual interfaces (`default-name == ""`) the coordinator currently sets `port-mac-address` to `{mac}-{ifname}`, so every router’s loopback becomes the same connection token.

Home Assistant’s device registry merges on `connections`. With more than one MikroTik config entry, all `lo` (and empty-MAC tunnel) entities land on a single device. `via_device` then follows whichever router last wrote the device.

This PR:
- prefixes dummy/empty MACs with the router serial (`{serial}-{ifname}`) instead of the shared MAC
- registers those interfaces with `(DOMAIN, {serial}-{ifname})` identifiers/connections instead of `CONNECTION_NETWORK_MAC`
- leaves real ethernet/wifi MACs unchanged
- does not change entity unique_ids

Existing merged registry devices will not split on their own. After upgrade, remove the merged device (or its all-zero-MAC `lo` connection) and reload so entities rebind.

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

- Rebuilt on current upstream `dev` (post **v2.3.21**). Supersedes stale closed PR #129.
- Live-validated on a multi-entry setup (gateways, CRS switches, hAP ax²). After the change, each router has its own `lo` with `via_device` pointing at that router; empty-MAC tunnels split the same way. Ethernet devices were unaffected.
- ADR attached as `ADR-NEXT` (device-identity); next unused on `dev` is **022** — happy for you to number it at merge.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.

Made with [Cursor](https://cursor.com)