### PR TITLE
chore: release v2.3.22-beta.1 (route monitoring + WireGuard peers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Monitor and control your entire MikroTik network from Home Assistant. This HACS 
 
 ---
 
+## What's New — v2.3.22-beta.1
+
+Pre-release off `dev` adding two opt-in monitoring features from the feature poll, live-validated on a four-router RouterOS fleet before tagging. Both are **off by default** — enable them in the integration options.
+
+- **Default-route monitoring (multi-WAN / failover awareness).** For each default route (`0.0.0.0/0`, `::/0`) a connectivity binary_sensor follows the route's RouterOS `active` flag, plus a per-routing-table "active default routes" count. Correct under policy routing (each table tracked separately) and ECMP / dual-uplink. Blackhole kill-switch routes are labelled and read inactive. Entity `unique_id`s use a stable `routing-table`+`dst-address`+`gateway`+`distance` composite, not the volatile RouterOS `.id`. Enable **Default route monitoring sensors**. FEATURE-POLL B4. See [ADR-020](docs/decisions/ADR-020-route-monitoring.md).
+- **WireGuard peer sensors.** For each peer: a `connected` binary_sensor (derived from handshake recency), a stable last-handshake timestamp, and per-peer RX/TX totals. Only routers that have WireGuard get these entities; peer identifiers are redacted from diagnostics and the public-key sensor is disabled by default. Enable **WireGuard peer sensors**. FEATURE-POLL B2. See [ADR-021](docs/decisions/ADR-021-wireguard-peer-sensors.md).
+
+Known issue: a blackhole route's `blackhole` attribute currently reads `False` though the router flags it ([#139](https://github.com/jnctech/homeassistant-mikrotik_router/issues/139)) — low impact; the `active` failover signal is correct.
+
 ## What's New — v2.3.21
 
 Stable release rolling up the v2.3.21 beta cycle (beta.1–beta.2). Two contributor-driven additions plus an integration-wide reliability fix, live-validated on a four-controller RouterOS deployment — and the LTE sensors confirmed on real modem hardware by the contributor.

--- a/custom_components/mikrotik_router/manifest.json
+++ b/custom_components/mikrotik_router/manifest.json
@@ -14,5 +14,5 @@
         "librouteros>=3.4.1,<4.0",
         "mac-vendor-lookup>=0.1.12"
     ],
-    "version": "2.3.21"
+    "version": "2.3.22-beta.1"
 }

--- a/docs/CHANGE-REGISTER.md
+++ b/docs/CHANGE-REGISTER.md
@@ -4,6 +4,25 @@ Changes listed in reverse chronological order.
 
 ---
 
+## CR-260908-release-v2.3.22-beta.1 — cut v2.3.22-beta.1 pre-release
+
+**Date:** 2026-09-08
+**Branch:** `chore/release-v2.3.22-beta.1` → PR to `dev`
+**Status:** In Review
+
+### What changed
+- `custom_components/mikrotik_router/manifest.json` — version `2.3.21` → `2.3.22-beta.1`.
+- `README.md`, `info.md` — "What's New — v2.3.22-beta.1" section (route monitoring + WireGuard peers, both opt-in).
+- `docs/ISSUES.md` — In-flight refreshed: B4/B2 merged to `dev`, beta cut; #139 tracked as a known-open discrepancy.
+
+### Why
+Roll the two merged FEATURE-POLL features — default-route monitoring (ADR-020, CR-260907-route-monitoring, #136) and WireGuard peer sensors (ADR-021, CR-260907-wireguard-peers, #137) — into a `-beta.1` pre-release off `dev` for HACS opt-in testing. Neither is hardware-gated to absent hardware, so this is a normal beta cadence (not a beta-first hardware gate).
+
+### Verification
+- CI green on `dev` (Python 3.13 + 3.14); full suite 758 passed.
+- **Live validation PASS** on the deployed `dev` code (`origin/dev` @ 74787f8) on the four-router fleet, 2026-09-08: route (policy routing + ECMP + blackhole-inactive) and WireGuard (2 peers, rx/tx within tolerance, capability gate correct) both correct; core-class regression spot-check exact. Per `docs/release-validation.md`.
+- Known-open: [#139](https://github.com/jnctech/homeassistant-mikrotik_router/issues/139) blackhole attribute reads False (low impact; `active` correct) — documented, ships in the beta.
+
 ## CR-260907-wireguard-peers — implement WireGuard peer sensors (B2)
 
 **Date:** 2026-09-07

--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -2,6 +2,8 @@
 
 ## In-flight
 
+> **Updated 2026-09-08 (route + WireGuard beta session).** Merged **B4 route monitoring** ([#136](https://github.com/jnctech/homeassistant-mikrotik_router/pull/136), ADR-020) and **B2 WireGuard peers** ([#137](https://github.com/jnctech/homeassistant-mikrotik_router/pull/137), ADR-021) to `dev`; live-validated the deployed `dev` code on the four-router fleet (**PASS**, `docs/release-validation.md`); cut **v2.3.22-beta.1** as a pre-release off `dev` (CR-260908). Known-open: [#139](https://github.com/jnctech/homeassistant-mikrotik_router/issues/139) blackhole attribute reads False (low impact; `active` signal correct) — ships documented in the beta. Promote to stable **v2.3.22** after beta soak (`dev→master` PR + back-merge).
+>
 > **Updated 2026-09-07 (v2.3.21 release session).** **Cut stable [v2.3.21](https://github.com/jnctech/homeassistant-mikrotik_router/releases/tag/v2.3.21)** — the v2.3.21 beta cycle (beta.1 LTE, beta.2 self-recovery) rolled up to stable via a `dev→master` PR + back-merge (`master ⊆ dev` restored, branch-sync-guard green). CR-260907-release-v2321.
 >
 > **v2.3.21 rolls up:** LTE modem sensors (ADR-019, #116, @zvldz) · self-recovery reconnect-on-poll after a transient API outage (#123/#127, @sappsys) · `unknown`-not-stale base-class fix (#120) · leak-gate governance-token extension (#125) · CONTRIBUTING/ADR-index docs (#119).
@@ -11,8 +13,8 @@
 > **Release validated.** Fresh `/validate-live-sensors` on the deployed beta.2 (2026-09-07): **501 integration entities**, every sensor class cross-checked against router ground-truth within tolerance, **0 phantom LTE entities**; bad-state set benign (documented orphans + by-design `unknown`). Stable == beta.2 code + version bump only. Internal report in gitignored config docs.
 >
 > **NEXT SESSION (lead):**
-> 1. **Route monitoring (`ENH-260907-route-monitoring`, FEATURE-POLL B4)** — 🟠 **implemented** on `feature/route-monitoring` (ADR-020, CR-260907-route-monitoring), PR to `dev`; 20 tests green. Remaining: live validation on RB4011/CRS310/single-table at release time.
-> 2. **WireGuard peer sensors (`ENH-260703-wireguard-sensors`, FEATURE-POLL B2)** — 🟠 **implemented** on `feature/wireguard-peers` (ADR-021, CR-260907-wireguard-peers), PR to `dev`; 24 tests green. Remaining: live validation on RB4011 (2 peers) + non-WG device + diagnostics redaction at release time.
+> 1. **Route monitoring (`ENH-260907-route-monitoring`, FEATURE-POLL B4)** — 🟢 **merged to `dev`** (#136, ADR-020, CR-260907-route-monitoring); live-validated PASS on the four-router fleet 2026-09-08; shipping in **v2.3.22-beta.1**.
+> 2. **WireGuard peer sensors (`ENH-260703-wireguard-sensors`, FEATURE-POLL B2)** — 🟢 **merged to `dev`** (#137, ADR-021, CR-260907-wireguard-peers); live-validated PASS on rb4011 (2 peers) + zero phantom entities on non-WG routers 2026-09-08; shipping in **v2.3.22-beta.1**.
 > 3. **librouteros cap-lift** — `ENH-260512-librouteros-test-matrix`: 3.4.1 / latest-3.x / expected-fail-4.x CI matrix, then lift `manifest` to `>=4.0,<5` (the floor-bump is the **v2.4.0** trigger).
 > 4. **Gold/Platinum** — `reconfiguration-flow` (Gold) may be decoupled from the deferred coordinator decomposition; `strict-typing` (Platinum) stays gated on it (would-be ADR-016). Author a `quality_scale.yaml` to make the remaining gaps auditable.
 > 5. **Stale-debt sweep** — write the deferred `ISS-260512-librouteros-concurrency-adr` (Open, doc-only); reconcile stale statuses. **Operator-open:** `ISS-260712` history-scrub decision + `dev` branch-protection requiring the leak gate.

--- a/info.md
+++ b/info.md
@@ -10,6 +10,12 @@ Monitor and control your MikroTik router from Home Assistant.
 
 ![Mikrotik Logo](https://raw.githubusercontent.com/tomaae/homeassistant-mikrotik_router/master/docs/assets/images/ui/header.png)
 
+### What's new in v2.3.22-beta.1
+Pre-release adding two opt-in monitoring features (off by default), live-validated on a four-router fleet.
+- **Default-route monitoring** — per-default-route `active` binary_sensor + per-table active-default count, for multi-WAN failover awareness. Correct under policy routing + ECMP; blackhole kill-switch routes read inactive. Enable **Default route monitoring sensors**. FEATURE-POLL B4. See ADR-020.
+- **WireGuard peer sensors** — per-peer `connected` (from handshake recency), a stable last-handshake timestamp, and RX/TX totals. Only on routers with WireGuard; peer keys redacted, public-key sensor disabled by default. Enable **WireGuard peer sensors**. FEATURE-POLL B2. See ADR-021.
+- Known issue: blackhole route `blackhole` attribute reads False (#139) — low impact; `active` signal correct.
+
 ### What's new in v2.3.21
 Stable release rolling up the v2.3.21 beta cycle (beta.1–beta.2). Two contributor-driven additions + an integration-wide reliability fix, live-validated on a four-controller deployment; the LTE sensors confirmed on real modem hardware by the contributor.
 - **LTE modem sensors** — signal (RSSI/RSRP/RSRQ/SINR/CQI), operator, connection, session uptime, and modem firmware for routers with an `/interface/lte`. Conditional on LTE hardware. IMEI/IMSI/ICCID collected but disabled by default + redacted. Thanks @zvldz for the implementation + live validation on a MikroTik Chateau. Implements tomaae #249. See ADR-019.


### PR DESCRIPTION
## Summary
- Version bump `2.3.21` -> `2.3.22-beta.1` to cut a pre-release off `dev`.
- Rolls up the two merged FEATURE-POLL features: default-route monitoring (ADR-020, #136) and WireGuard peer sensors (ADR-021, #137). Both opt-in, off by default.
- README/info.md "What's New — v2.3.22-beta.1"; `CR-260908-release-v2.3.22-beta.1`; ISSUES.md In-flight refreshed.

## Post-Deploy Actions
- After merge, create the `v2.3.22-beta.1` **pre-release** off `dev` (triggers the release workflow: zip + SBOM). No `dev->master` for a beta.
- Promote to stable `v2.3.22` after beta soak via a `dev->master` PR + back-merge.

## Test Plan
- CI green on `dev` (Python 3.13 + 3.14); full suite 758 passed.
- Live-validated the deployed `dev` code on the four-router fleet 2026-09-08 (PASS) per `docs/release-validation.md`: route monitoring (policy routing + ECMP + blackhole-inactive) and WireGuard peers (2 peers, rx/tx within tolerance, capability gate) both correct; core-class regression spot-check exact.
- Known-open: #139 blackhole attribute reads False (low impact; `active` failover signal correct) — ships documented in the beta.